### PR TITLE
ISS-1 bootstrap secrets broker daemon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,17 @@ jobs:
         include:
           - os: windows-latest
             platform: win32
-            artifact: dist/echo-service-win32.zip
+            artifact: dist/secretsbroker-win32.zip
             archive_name: service-lasso-harness-windows-amd64.zip
             binary_name: service-lasso-harness.exe
           - os: ubuntu-latest
             platform: linux
-            artifact: dist/echo-service-linux.tar.gz
+            artifact: dist/secretsbroker-linux.tar.gz
             archive_name: service-lasso-harness-linux-amd64.tar.gz
             binary_name: service-lasso-harness
           - os: macos-14
             platform: darwin
-            artifact: dist/echo-service-darwin.tar.gz
+            artifact: dist/secretsbroker-darwin.tar.gz
             archive_name: service-lasso-harness-darwin-arm64.tar.gz
             binary_name: service-lasso-harness
 
@@ -40,6 +40,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
 
       - name: Download released service-lasso-harness binary
         env:
@@ -82,12 +88,12 @@ jobs:
           echo "$BIN_DIR" >> "$GITHUB_PATH"
           echo "SERVICE_LASSO_HARNESS_BIN=$BIN_PATH" >> "$GITHUB_ENV"
 
-      - name: Validate template (Windows)
+      - name: Validate Secrets Broker (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\scripts\test.ps1
 
-      - name: Validate template (POSIX)
+      - name: Validate Secrets Broker (POSIX)
         if: runner.os != 'Windows'
         shell: bash
         run: bash ./scripts/test.sh
@@ -115,7 +121,7 @@ jobs:
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v4
         with:
-          name: echo-service-${{ matrix.platform }}
+          name: secretsbroker-${{ matrix.platform }}
           path: ${{ matrix.artifact }}
 
       - name: Upload verify artifacts
@@ -135,11 +141,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-assets
-          pattern: echo-service-*
+          pattern: secretsbroker-*
           merge-multiple: true
 
       - name: Copy service manifest into release assets
@@ -163,8 +175,8 @@ jobs:
           name: ${{ steps.version.outputs.version }}
           target_commitish: ${{ github.sha }}
           files: |
-            release-assets/echo-service-win32.zip
-            release-assets/echo-service-linux.tar.gz
-            release-assets/echo-service-darwin.tar.gz
+            release-assets/secretsbroker-win32.zip
+            release-assets/secretsbroker-linux.tar.gz
+            release-assets/secretsbroker-darwin.tar.gz
             release-assets/service.json
           generate_release_notes: true

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - name: Download released service-lasso-harness binary
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -82,22 +87,22 @@ jobs:
           echo "$BIN_DIR" >> "$GITHUB_PATH"
           echo "SERVICE_LASSO_HARNESS_BIN=$BIN_PATH" >> "$GITHUB_ENV"
 
-      - name: Package starter artifact (Windows)
+      - name: Package Secrets Broker artifact (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\scripts\package.ps1
 
-      - name: Package starter artifact (POSIX)
+      - name: Package Secrets Broker artifact (POSIX)
         if: runner.os != 'Windows'
         shell: bash
         run: bash ./scripts/package.sh
 
-      - name: Run starter tests (Windows)
+      - name: Run Secrets Broker tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\scripts\test.ps1
 
-      - name: Run starter tests (POSIX)
+      - name: Run Secrets Broker tests (POSIX)
         if: runner.os != 'Windows'
         shell: bash
         run: bash ./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -1,134 +1,85 @@
-# service-template
+# lasso-secretsbroker
 
-_Status: starter template repo_
+_Status: bootstrap skeleton_
 
-`service-template` is the canonical starting point for new Service Lasso service repos.
+`lasso-secretsbroker` is the Service Lasso-native Secrets Broker service repo.
 
-Use this repo when you want to create a new service repo that already has:
-- the expected service repo layout
-- a starter `service.json`
-- a starter `services/` inventory example for app/reference repos that embed Service Lasso
-- starter packaging scripts
-- starter verify scripts and harness contract shape
-- starter docs for service contract, packaging, and validation
-- starter CI scaffolding
+Service identity:
 
-## Use this template
-
-Recommended flow:
-
-1. Create a new repo from this GitHub template.
-2. Rename the sample service files/content for the real service.
-3. Replace the sample runtime payload with the real service payload.
-4. Update `service.json`, `verify/service-harness.json`, and the docs for the new service.
-5. Run the local package + test flow.
-6. Wire the repo into the real released `service-lasso-harness` binary once that integration path is enabled.
-
-## Quick start
-
-### Local package
-
-```powershell
-pwsh -NoLogo -NoProfile -File .\scripts\package.ps1
+```text
+@secretsbroker
 ```
 
-### Local tests
+The broker is intended to be a lean, local-first, Vault-like process managed by Service Lasso during an early bootstrap phase. Service Lasso core keeps only the tiny bootstrap client/state machine; this repo owns the actual broker daemon, CLI/API contract, storage, policy, audit, source adapters, and resolve/write-back behavior.
+
+## Architecture stance
+
+Default/local mode:
+
+```text
+Service Lasso -> @secretsbroker -> local encrypted store
+```
+
+Cluster/enterprise mode:
+
+```text
+Service Lasso -> @secretsbroker -> Vault/OpenBao cluster
+```
+
+`@secretsbroker` is the stable Service Lasso-facing contract. HashiCorp Vault, OpenBao, AWS Secrets Manager, 1Password, Bitwarden/BWS, `env`, `file`, and `exec` are backends/sources behind the broker rather than replacements for the Service Lasso broker contract.
+
+## Current skeleton
+
+The first bootstrap slice provides:
+
+- Service Lasso template repo structure
+- root `service.json` with id `@secretsbroker`
+- minimal Go daemon
+- local HTTP endpoints:
+  - `GET /health`
+  - `GET /status`
+  - `GET /state`
+- CLI-style commands:
+  - `secretsbroker serve`
+  - `secretsbroker status`
+  - `secretsbroker version`
+- package/test/verify scripts following the service-template contract
+
+Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back APIs are intentionally future issues.
+
+## Local development
+
+Run tests:
 
 ```powershell
 pwsh -NoLogo -NoProfile -File .\scripts\test.ps1
 ```
 
-## Start here for deeper design context
+Package Windows artifact:
 
-Read in this order if you need the underlying design/spec context:
+```powershell
+pwsh -NoLogo -NoProfile -File .\scripts\package.ps1
+```
 
-1. `docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md`
-2. `docs/openspec-drafts/OPENSPEC-TRACKER.md`
-3. `docs/service-contract.md`
-4. `docs/service-json-reference.md`
-5. `docs/packaging.md`
-6. `docs/validation.md`
-7. `docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md`
+Run the daemon directly:
 
-## What is here
+```powershell
+go run .\cmd\secretsbroker serve --listen 127.0.0.1:17890
+```
 
-### OpenSpec drafts
-- `docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md`
-- `docs/openspec-drafts/OPENSPEC-TRACKER.md`
+Check status:
 
-### Supporting reference/planning docs
-- `docs/service-contract.md`
-- `docs/service-json-reference.md`
-- `docs/packaging.md`
-- `docs/validation.md`
-- `docs/reference/SERVICE-TEMPLATE-REPO.md`
-- `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
-- `docs/reference/PROPOSED-CODEBASE-STRUCTURE.md`
-- `docs/reference/DECISION-CONTEXT.md`
-- `docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md`
-- `docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md`
-- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
-- `docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md`
-- `docs/reference/EXAMPLE-REPO-TREE.md`
-- `docs/reference/EXAMPLE-service.json`
-- `docs/reference/EXAMPLE-service-harness.json`
-- `docs/reference/EXAMPLE-verify.ps1`
-- `docs/reference/EXAMPLE-verify.sh`
+```powershell
+go run .\cmd\secretsbroker status
+```
 
-## Purpose
+## Service Lasso integration boundary
 
-This repo is the canonical starting point for Service Lasso service repos.
+`service-lasso` should own only:
 
-Its role is to define:
-- one-service-per-repo expectations
-- service repo layout
-- service author documentation expectations
-- sample service expectations
-- packaging/release expectations
-- validation-harness integration expectations
+- locating/starting the `@secretsbroker` process in bootstrap phase
+- checking `/health`, `/status`, and `/state`
+- mapping typed broker states into startup/materialization diagnostics
+- using the broker during env/config materialization once resolve APIs exist
 
-## Current status
-
-This repo is usable now as a starter template.
-
-It currently includes:
-- actual starter repo files (`service.json`, `verify/`, `scripts/`, `runtime/`, `config/`, `.github/workflows/`)
-- a tracked example `services/` inventory for downstream app/reference repos
-- a packaged first-pass sample artifact at `dist/echo-service-win32.zip`
-- a starter multi-OS GitHub Actions workflow that packages release archives and runs basic tests
-- starter harness-contract files and thin verify wrappers
-- supporting reference/spec docs for deeper design work
-
-Important current validation note:
-- the pipeline now downloads and invokes the released `service-lasso-harness` binary in CI
-- it still keeps the starter local package/test flow alongside harness verification
-- the current harness version is pinned in workflow config and can be advanced intentionally over time
-
-Important current manifest note:
-- the bounded first-pass core runtime now expects service release/install metadata to live directly in `service.json`
-- the current template example uses a bounded `artifact.kind`, `artifact.source`, and `artifact.platforms` shape to show that direction explicitly
-- bundled app artifacts mean the app package step has already acquired service archives into `services/<service-id>/.state/artifacts/<tag>/<assetName>` so first run can install without downloading those archives
-
-## Baseline app inventory rule
-
-This repo still models the canonical one-service-per-repo contract through the root `service.json`.
-
-In addition, it now carries a tracked example `services/` inventory to show what app/reference repos should own when they embed Service Lasso.
-
-Current baseline inventory:
-- `services/echo-service/service.json`
-- `services/@serviceadmin/service.json`
-- `services/@node/service.json`
-- `services/@localcert/service.json`
-- `services/@nginx/service.json`
-- `services/@traefik/service.json`
-
-Optional provider inventory:
-- `services/@python/service.json` disabled release-backed Python 3.11.5 provider; Windows artifact only
-- `services/@java/service.json` disabled release-backed Java 17 provider
-
-Important rule:
-- app/reference repos should own the exact `services/` manifests for the services they intend to manage
-- if an app repo includes `@serviceadmin`, it should also include the manifests needed to satisfy Service Admin's declared service dependencies
-- core Service Lasso services use the `@` prefix: `@node`, `@python`, `@java`, `@localcert`, `@nginx`, `@traefik`, and `@serviceadmin`; `echo-service` stays unprefixed because it is the sample/test managed service
-- environment settings like `VITE_SERVICE_LASSO_API_BASE_URL` still belong in app/runtime config, not as extra service manifests
+`lasso-serviceadmin` should remain an optional UI client over Service Lasso and Secrets Broker APIs. The broker must work headless through CLI/API.

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const version = "0.1.0"
+
+type Status struct {
+	ServiceID   string    `json:"serviceId"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	State       string    `json:"state"`
+	Ready       bool      `json:"ready"`
+	LocalFirst  bool      `json:"localFirst"`
+	Backend     string    `json:"backend"`
+	Description string    `json:"description"`
+	CheckedAt   time.Time `json:"checkedAt"`
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		args = []string{"serve"}
+	}
+
+	switch args[0] {
+	case "serve":
+		return serve(args[1:])
+	case "status":
+		return printStatus(args[1:])
+	case "version":
+		fmt.Println(version)
+		return nil
+	case "help", "-h", "--help":
+		usage()
+		return nil
+	default:
+		usage()
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|version>")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
+	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
+	fmt.Fprintln(os.Stderr, "  version Print broker version")
+}
+
+func defaultStatus(state string) Status {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		state = "setup_needed"
+	}
+	return Status{
+		ServiceID:   "@secretsbroker",
+		Name:        "Service Lasso Secrets Broker",
+		Version:     version,
+		State:       state,
+		Ready:       state == "ready",
+		LocalFirst:  true,
+		Backend:     "local",
+		Description: "Lean local-first Vault-like broker bootstrap skeleton. Secrets storage/resolution is intentionally not implemented yet.",
+		CheckedAt:   time.Now().UTC(),
+	}
+}
+
+func printStatus(args []string) error {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(defaultStatus(*state))
+}
+
+func serve(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	listen := fs.String("listen", getenvDefault("SECRETSBROKER_LISTEN", "127.0.0.1:17890"), "listen address")
+	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "serviceId": "@secretsbroker", "state": *state})
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, defaultStatus(*state))
+	})
+	mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"serviceId": "@secretsbroker", "state": defaultStatus(*state).State, "ready": defaultStatus(*state).Ready})
+	})
+
+	ln, err := net.Listen("tcp", *listen)
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
+		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("server failed", "error", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return server.Shutdown(shutdownCtx)
+}
+
+func writeJSON(w http.ResponseWriter, code int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func getenvDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestDefaultStatus(t *testing.T) {
+	status := defaultStatus("")
+	if status.ServiceID != "@secretsbroker" {
+		t.Fatalf("service id = %q", status.ServiceID)
+	}
+	if status.State != "setup_needed" {
+		t.Fatalf("state = %q", status.State)
+	}
+	if status.Ready {
+		t.Fatalf("setup_needed should not be ready")
+	}
+
+	ready := defaultStatus("ready")
+	if !ready.Ready {
+		t.Fatalf("ready state should report Ready")
+	}
+}

--- a/config/example.env
+++ b/config/example.env
@@ -1,1 +1,2 @@
-ECHO_MESSAGE=hello from service-template
+SECRETSBROKER_STATE=setup_needed
+SECRETSBROKER_LISTEN=127.0.0.1:17890

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/service-lasso/lasso-secretsbroker
+
+go 1.24

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -2,16 +2,27 @@ $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
 $dist = Join-Path $root 'dist'
-$runtime = Join-Path $root 'runtime'
-$staging = Join-Path $dist 'echo-service-win32'
-$zipPath = Join-Path $dist 'echo-service-win32.zip'
+$staging = Join-Path $dist 'secretsbroker-win32'
+$zipPath = Join-Path $dist 'secretsbroker-win32.zip'
 
 New-Item -ItemType Directory -Force -Path $dist | Out-Null
 if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
 New-Item -ItemType Directory -Force -Path $staging | Out-Null
 
-Copy-Item -Recurse -Force (Join-Path $runtime 'win32') (Join-Path $staging 'runtime')
+Push-Location $root
+try {
+  $env:GOOS = 'windows'
+  $env:GOARCH = 'amd64'
+  go build -o (Join-Path $staging 'secretsbroker.exe') ./cmd/secretsbroker
+}
+finally {
+  Pop-Location
+  Remove-Item Env:\GOOS -ErrorAction SilentlyContinue
+  Remove-Item Env:\GOARCH -ErrorAction SilentlyContinue
+}
+
 Copy-Item -Recurse -Force (Join-Path $root 'config') (Join-Path $staging 'config')
+Copy-Item -Force (Join-Path $root 'service.json') (Join-Path $staging 'service.json')
 
 if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
 Compress-Archive -Path (Join-Path $staging '*') -DestinationPath $zipPath

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,21 +5,25 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/dist"
 OS_NAME=$(uname -s)
 case "$OS_NAME" in
-  Linux*) PLATFORM="linux" ;;
-  Darwin*) PLATFORM="darwin" ;;
+  Linux*) PLATFORM="linux"; GOOS_VALUE="linux" ;;
+  Darwin*) PLATFORM="darwin"; GOOS_VALUE="darwin" ;;
   *) echo "Unsupported OS for package.sh: $OS_NAME" >&2; exit 1 ;;
 esac
-STAGING="$DIST/echo-service-$PLATFORM"
-TAR_PATH="$DIST/echo-service-$PLATFORM.tar.gz"
+STAGING="$DIST/secretsbroker-$PLATFORM"
+TAR_PATH="$DIST/secretsbroker-$PLATFORM.tar.gz"
 
 mkdir -p "$DIST"
 rm -rf "$STAGING"
 mkdir -p "$STAGING"
 
-cp -R "$ROOT/runtime/$PLATFORM" "$STAGING/runtime"
-cp -R "$ROOT/config" "$STAGING/config"
+(
+  cd "$ROOT"
+  GOOS="$GOOS_VALUE" GOARCH=amd64 go build -o "$STAGING/secretsbroker" ./cmd/secretsbroker
+)
 
-chmod +x "$STAGING/runtime/echo-service.sh" 2>/dev/null || true
+cp -R "$ROOT/config" "$STAGING/config"
+cp "$ROOT/service.json" "$STAGING/service.json"
+chmod +x "$STAGING/secretsbroker"
 
 rm -f "$TAR_PATH"
 tar -czf "$TAR_PATH" -C "$STAGING" .

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,33 +1,62 @@
 $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
-
-$required = @(
-  (Join-Path $root 'service.json'),
-  (Join-Path $root 'verify\service-harness.json'),
-  (Join-Path $root 'runtime\win32\echo-service.ps1')
-)
-
-foreach ($path in $required) {
-  if (-not (Test-Path $path)) {
-    throw "Missing required file: $path"
+Push-Location $root
+try {
+  foreach ($path in @('service.json', 'verify\service-harness.json', 'cmd\secretsbroker\main.go', 'go.mod')) {
+    if (-not (Test-Path (Join-Path $root $path))) {
+      throw "Missing required file: $path"
+    }
   }
-}
 
-$service = Get-Content (Join-Path $root 'service.json') -Raw | ConvertFrom-Json
-if ($service.id -ne 'echo-service') {
-  throw 'service.json id mismatch'
-}
+  $service = Get-Content (Join-Path $root 'service.json') -Raw | ConvertFrom-Json
+  if ($service.id -ne '@secretsbroker') {
+    throw 'service.json id mismatch'
+  }
 
-$contract = Get-Content (Join-Path $root 'verify\service-harness.json') -Raw | ConvertFrom-Json
-if ($contract.serviceId -ne 'echo-service') {
-  throw 'service-harness.json serviceId mismatch'
-}
+  $contract = Get-Content (Join-Path $root 'verify\service-harness.json') -Raw | ConvertFrom-Json
+  if ($contract.serviceId -ne '@secretsbroker') {
+    throw 'service-harness.json serviceId mismatch'
+  }
 
-$env:ECHO_MESSAGE = 'pipeline test message'
-$output = & (Join-Path $root 'runtime\win32\echo-service.ps1') | Out-String
-if ($output -notmatch 'pipeline test message') {
-  throw 'Echo runtime output mismatch'
-}
+  go test ./...
 
-Write-Host 'Template tests passed (Windows)'
+  $tmp = Join-Path $root '.tmp\test'
+  New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+  $exe = Join-Path $tmp 'secretsbroker.exe'
+  go build -o $exe ./cmd/secretsbroker
+
+  $status = & $exe status | ConvertFrom-Json
+  if ($status.serviceId -ne '@secretsbroker') {
+    throw 'status serviceId mismatch'
+  }
+  if ($status.state -ne 'setup_needed') {
+    throw 'default status state mismatch'
+  }
+
+  $port = 17891
+  $proc = Start-Process -FilePath $exe -ArgumentList @('serve', '--listen', "127.0.0.1:$port") -PassThru -WindowStyle Hidden
+  try {
+    $ok = $false
+    for ($i = 0; $i -lt 20; $i++) {
+      try {
+        $health = Invoke-RestMethod -Uri "http://127.0.0.1:$port/health" -TimeoutSec 1
+        if ($health.ok -and $health.serviceId -eq '@secretsbroker') { $ok = $true; break }
+      } catch {
+        Start-Sleep -Milliseconds 250
+      }
+    }
+    if (-not $ok) { throw 'health endpoint did not become ready' }
+  }
+  finally {
+    if (-not $proc.HasExited) {
+      Stop-Process -Id $proc.Id -Force
+      $proc.WaitForExit()
+    }
+  }
+
+  Write-Host 'Secrets Broker tests passed (Windows)'
+}
+finally {
+  Pop-Location
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,11 +2,10 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OS_NAME="$(uname -s)"
 cd "$ROOT"
 
-for path in \
-  "$ROOT/service.json" \
-  "$ROOT/verify/service-harness.json"; do
+for path in service.json verify/service-harness.json cmd/secretsbroker/main.go go.mod; do
   if [[ ! -f "$path" ]]; then
     echo "Missing required file: $path" >&2
     exit 1
@@ -15,38 +14,59 @@ done
 
 SERVICE_ID=$(python3 - <<'PY'
 import json, pathlib
-path = pathlib.Path('service.json')
-print(json.loads(path.read_text())['id'])
+print(json.loads(pathlib.Path('service.json').read_text())['id'])
 PY
 )
-if [[ "$SERVICE_ID" != "echo-service" ]]; then
+if [[ "$SERVICE_ID" != "@secretsbroker" ]]; then
   echo "service.json id mismatch" >&2
   exit 1
 fi
 
 CONTRACT_ID=$(python3 - <<'PY'
 import json, pathlib
-path = pathlib.Path('verify/service-harness.json')
-print(json.loads(path.read_text())['serviceId'])
+print(json.loads(pathlib.Path('verify/service-harness.json').read_text())['serviceId'])
 PY
 )
-if [[ "$CONTRACT_ID" != "echo-service" ]]; then
+if [[ "$CONTRACT_ID" != "@secretsbroker" ]]; then
   echo "service-harness.json serviceId mismatch" >&2
   exit 1
 fi
 
-OS_NAME=$(uname -s)
-case "$OS_NAME" in
-  Linux*) RUNTIME="$ROOT/runtime/linux/echo-service.sh" ;;
-  Darwin*) RUNTIME="$ROOT/runtime/darwin/echo-service.sh" ;;
-  *) echo "Unsupported OS for test.sh: $OS_NAME" >&2; exit 1 ;;
-esac
+go test ./...
 
-chmod +x "$RUNTIME"
-OUTPUT=$(ECHO_MESSAGE='pipeline test message' "$RUNTIME")
-if [[ "$OUTPUT" != *"pipeline test message"* ]]; then
-  echo "Echo runtime output mismatch" >&2
-  exit 1
-fi
+TMP="$ROOT/.tmp/test"
+mkdir -p "$TMP"
+go build -o "$TMP/secretsbroker" ./cmd/secretsbroker
 
-echo "Template tests passed ($OS_NAME)"
+STATUS_JSON="$($TMP/secretsbroker status)"
+STATUS_JSON="$STATUS_JSON" python3 - <<'PY'
+import json, os
+payload = json.loads(os.environ['STATUS_JSON'])
+assert payload['serviceId'] == '@secretsbroker'
+assert payload['state'] == 'setup_needed'
+PY
+
+PORT=17891
+"$TMP/secretsbroker" serve --listen "127.0.0.1:$PORT" >"$TMP/server.log" 2>&1 &
+PID=$!
+cleanup() { kill "$PID" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+for _ in $(seq 1 20); do
+  if python3 - <<PY
+import json, urllib.request
+try:
+    payload=json.load(urllib.request.urlopen('http://127.0.0.1:$PORT/health', timeout=1))
+    raise SystemExit(0 if payload.get('ok') and payload.get('serviceId') == '@secretsbroker' else 1)
+except Exception:
+    raise SystemExit(1)
+PY
+  then
+    echo "Secrets Broker tests passed ($OS_NAME)"
+    exit 0
+  fi
+  sleep 0.25
+done
+
+echo "health endpoint did not become ready" >&2
+cat "$TMP/server.log" >&2 || true
+exit 1

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -34,7 +34,7 @@ $resolvedContractPath = Join-Path $root 'verify\service-harness.ci.json'
 $runOutputDir = Join-Path $outputPath 'harness-run'
 
 $doc = Get-Content $contractPath -Raw | ConvertFrom-Json
-$doc.artifact.path = '..\dist\echo-service-win32.zip'
+$doc.artifact.path = '..\dist\secretsbroker-win32.zip'
 $doc | ConvertTo-Json -Depth 10 | Set-Content $resolvedContractPath
 
 $harness = Resolve-HarnessBinary

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -36,9 +36,9 @@ resolved_path = pathlib.Path(sys.argv[2]).resolve()
 resolved_path.parent.mkdir(parents=True, exist_ok=True)
 
 doc = json.loads(contract_path.read_text())
-doc['artifact']['path'] = '../dist/echo-service-linux.tar.gz'
+doc['artifact']['path'] = '../dist/secretsbroker-linux.tar.gz'
 if sys.platform == 'darwin':
-    doc['artifact']['path'] = '../dist/echo-service-darwin.tar.gz'
+    doc['artifact']['path'] = '../dist/secretsbroker-darwin.tar.gz'
 resolved_path.write_text(json.dumps(doc, indent=2) + '\n')
 PY
 

--- a/service.json
+++ b/service.json
@@ -1,14 +1,14 @@
 {
-  "id": "echo-service",
-  "name": "Echo Service",
-  "description": "Minimal sample service used to prove the service-template contract.",
+  "id": "@secretsbroker",
+  "name": "Service Lasso Secrets Broker",
+  "description": "Lean local-first Vault-like secrets broker for Service Lasso bootstrap, service identities, policy, audit, and secret resolution.",
   "enabled": true,
   "version": "0.1.0",
   "logoutput": true,
   "icon": [
     {
       "provider": "lucide",
-      "name": "terminal"
+      "name": "key-round"
     }
   ],
   "servicetype": 50,
@@ -16,7 +16,7 @@
   "logo": [],
   "logs": {
     "default": {
-      "path": "logs/echo-service.log"
+      "path": "logs/secretsbroker.log"
     }
   },
   "meta": {
@@ -28,107 +28,123 @@
     "license": "Apache-2.0",
     "repository": {
       "type": "git",
-      "url": "https://github.com/service-lasso/service-template.git"
+      "url": "https://github.com/service-lasso/lasso-secretsbroker.git"
     },
-    "websiteUrl": "https://github.com/service-lasso/service-template",
-    "documentationUrl": "https://github.com/service-lasso/service-template/blob/main/README.md",
-    "issuesUrl": "https://github.com/service-lasso/service-template/issues",
+    "websiteUrl": "https://github.com/service-lasso/lasso-secretsbroker",
+    "documentationUrl": "https://github.com/service-lasso/lasso-secretsbroker/blob/main/README.md",
+    "issuesUrl": "https://github.com/service-lasso/lasso-secretsbroker/issues",
     "support": {
-      "issuesUrl": "https://github.com/service-lasso/service-template/issues"
+      "issuesUrl": "https://github.com/service-lasso/lasso-secretsbroker/issues"
     },
     "links": {
-      "repository": "https://github.com/service-lasso/service-template",
-      "issues": "https://github.com/service-lasso/service-template/issues",
-      "documentation": "https://github.com/service-lasso/service-template/blob/main/README.md"
+      "repository": "https://github.com/service-lasso/lasso-secretsbroker",
+      "issues": "https://github.com/service-lasso/lasso-secretsbroker/issues",
+      "documentation": "https://github.com/service-lasso/lasso-secretsbroker/blob/main/README.md"
     },
     "tags": [
       "service-lasso",
-      "template",
-      "example-service"
+      "secrets",
+      "broker",
+      "local-first",
+      "vault-like"
     ]
   },
   "artifact": {
     "kind": "archive",
     "source": {
       "type": "github-release",
-      "repo": "service-lasso/service-template",
+      "repo": "service-lasso/lasso-secretsbroker",
       "channel": "latest"
     },
     "platforms": {
       "win32": {
-        "assetName": "echo-service-win32.zip",
+        "assetName": "secretsbroker-win32.zip",
         "archiveType": "zip",
-        "command": "./echo-service.exe",
-        "args": []
+        "command": "./secretsbroker.exe",
+        "args": [
+          "serve"
+        ]
       },
       "darwin": {
-        "assetName": "echo-service-darwin.tar.gz",
+        "assetName": "secretsbroker-darwin.tar.gz",
         "archiveType": "tar.gz",
-        "command": "./echo-service",
-        "args": []
+        "command": "./secretsbroker",
+        "args": [
+          "serve"
+        ]
       },
       "linux": {
-        "assetName": "echo-service-linux.tar.gz",
+        "assetName": "secretsbroker-linux.tar.gz",
         "archiveType": "tar.gz",
-        "command": "./echo-service",
-        "args": []
+        "command": "./secretsbroker",
+        "args": [
+          "serve"
+        ]
       },
       "default": {
-        "assetName": "echo-service-win32.zip",
+        "assetName": "secretsbroker-win32.zip",
         "archiveType": "zip",
-        "command": "./echo-service.exe",
-        "args": []
+        "command": "./secretsbroker.exe",
+        "args": [
+          "serve"
+        ]
       }
     }
   },
   "actions": {
     "install": {
-      "description": "Acquire or unpack the packaged echo-service runtime artifact.",
+      "description": "Acquire or unpack the packaged @secretsbroker runtime artifact.",
       "mode": "converge-install",
       "idempotent": true
     },
     "config": {
-      "description": "Materialize deployment-local echo-service config and env values.",
+      "description": "Materialize deployment-local @secretsbroker config and env values.",
       "mode": "converge-config",
       "idempotent": true
     },
     "update": {
-      "description": "Apply a newer release artifact and reconcile update-time changes before restart.",
+      "description": "Apply a newer @secretsbroker release artifact and reconcile update-time changes before restart.",
       "mode": "converge-update",
       "idempotent": true
     },
     "start": {
-      "description": "Start the sample echo service.",
+      "description": "Start the @secretsbroker daemon.",
       "mode": "runtime-start",
       "idempotent": true
     },
     "stop": {
-      "description": "Stop the sample echo service gracefully.",
+      "description": "Stop the @secretsbroker daemon gracefully.",
       "mode": "runtime-stop",
       "idempotent": true
     },
     "restart": {
-      "description": "Restart the sample echo service after config or update changes.",
+      "description": "Restart @secretsbroker after config or update changes.",
       "mode": "runtime-restart",
       "idempotent": false
     },
     "rollback": {
-      "description": "Restore the previously deployed artifact if an update fails validation.",
+      "description": "Restore the previously deployed @secretsbroker artifact if an update fails validation.",
       "mode": "state-rollback",
       "idempotent": false
     }
   },
   "execconfig": {
-    "serviceorder": 100,
-    "serviceport": 0,
-    "execcwd": "runtime",
-    "executable": "echo-service",
+    "serviceorder": 5,
+    "serviceport": 17890,
+    "execcwd": ".",
+    "executable": "secretsbroker",
+    "args": [
+      "serve"
+    ],
     "env": {
-      "ECHO_MESSAGE": "hello from service-template"
+      "SECRETSBROKER_STATE": "setup_needed",
+      "SECRETSBROKER_LISTEN": "127.0.0.1:17890"
     },
     "depend_on": [],
     "healthcheck": {
-      "type": "process"
+      "type": "http",
+      "url": "http://127.0.0.1:17890/health",
+      "timeoutSeconds": 5
     }
   }
 }

--- a/verify/service-harness.json
+++ b/verify/service-harness.json
@@ -1,7 +1,7 @@
 {
-  "serviceId": "echo-service",
+  "serviceId": "@secretsbroker",
   "artifact": {
-    "path": "dist/echo-service-win32.zip",
+    "path": "dist/secretsbroker-win32.zip",
     "kind": "archive"
   },
   "dependencies": [],


### PR DESCRIPTION
## Summary
- bootstraps `lasso-secretsbroker` from the GitHub `service-template` repo
- sets service identity to `@secretsbroker`
- adds minimal Go daemon with `serve`, `status`, and `version`
- adds `/health`, `/status`, and `/state` endpoints
- updates package/test/verify scripts and release workflow artifact names
- documents the local-first lean Vault stance and Vault/OpenBao clustered backend path

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`

Closes #1