### PR TITLE
ISS-11 define local API bootstrap contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .harness/
+.tmp/
 dist/
 output/
 verify/service-harness.ci.json

--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ The first bootstrap slice provides:
 - minimal Go daemon
 - local HTTP endpoints:
   - `GET /health`
+  - `GET /ready`
   - `GET /status`
   - `GET /state`
+  - `GET /capabilities`
 - CLI-style commands:
   - `secretsbroker serve`
   - `secretsbroker status`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back APIs are intentionally future issues.
+Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back implementations are intentionally future issues. The initial local API and bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -16,18 +16,77 @@ import (
 	"time"
 )
 
-const version = "0.1.0"
+const (
+	version    = "0.1.0"
+	apiVersion = "secretsbroker.local/v1"
+	serviceID  = "@secretsbroker"
+)
+
+var typedOutcomes = []string{
+	"setup_needed",
+	"locked",
+	"ready",
+	"source_auth_required",
+	"degraded",
+	"policy_denied",
+	"missing_ref",
+	"invalid_ref",
+	"source_unavailable",
+	"identity_expired",
+}
 
 type Status struct {
 	ServiceID   string    `json:"serviceId"`
 	Name        string    `json:"name"`
 	Version     string    `json:"version"`
+	APIVersion  string    `json:"apiVersion"`
 	State       string    `json:"state"`
 	Ready       bool      `json:"ready"`
 	LocalFirst  bool      `json:"localFirst"`
 	Backend     string    `json:"backend"`
 	Description string    `json:"description"`
 	CheckedAt   time.Time `json:"checkedAt"`
+}
+
+type HealthResponse struct {
+	OK        bool   `json:"ok"`
+	ServiceID string `json:"serviceId"`
+	State     string `json:"state"`
+}
+
+type StateResponse struct {
+	ServiceID        string   `json:"serviceId"`
+	APIVersion       string   `json:"apiVersion"`
+	State            string   `json:"state"`
+	Ready            bool     `json:"ready"`
+	Outcome          string   `json:"outcome"`
+	AffectedRefs     []string `json:"affectedRefs"`
+	AffectedServices []string `json:"affectedServices"`
+}
+
+type CapabilitiesResponse struct {
+	ServiceID      string   `json:"serviceId"`
+	APIVersion     string   `json:"apiVersion"`
+	Version        string   `json:"version"`
+	Transports     []string `json:"transports"`
+	Endpoints      []string `json:"endpoints"`
+	Features       []string `json:"features"`
+	FutureFeatures []string `json:"futureFeatures"`
+	Outcomes       []string `json:"outcomes"`
+}
+
+type ErrorEnvelope struct {
+	Error APIError `json:"error"`
+}
+
+type APIError struct {
+	Code             string   `json:"code"`
+	Message          string   `json:"message"`
+	Outcome          string   `json:"outcome"`
+	RequestID        string   `json:"requestId,omitempty"`
+	NextAction       string   `json:"nextAction,omitempty"`
+	AffectedRefs     []string `json:"affectedRefs"`
+	AffectedServices []string `json:"affectedServices"`
 }
 
 func main() {
@@ -68,21 +127,79 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
 }
 
-func defaultStatus(state string) Status {
+func normalizeState(state string) string {
 	state = strings.TrimSpace(state)
 	if state == "" {
-		state = "setup_needed"
+		return "setup_needed"
 	}
+	return state
+}
+
+func isReadyState(state string) bool {
+	return normalizeState(state) == "ready"
+}
+
+func defaultStatus(state string) Status {
+	state = normalizeState(state)
 	return Status{
-		ServiceID:   "@secretsbroker",
+		ServiceID:   serviceID,
 		Name:        "Service Lasso Secrets Broker",
 		Version:     version,
+		APIVersion:  apiVersion,
 		State:       state,
-		Ready:       state == "ready",
+		Ready:       isReadyState(state),
 		LocalFirst:  true,
 		Backend:     "local",
 		Description: "Lean local-first Vault-like broker bootstrap skeleton. Secrets storage/resolution is intentionally not implemented yet.",
 		CheckedAt:   time.Now().UTC(),
+	}
+}
+
+func defaultHealth(state string) HealthResponse {
+	return HealthResponse{OK: true, ServiceID: serviceID, State: normalizeState(state)}
+}
+
+func defaultState(state string) StateResponse {
+	state = normalizeState(state)
+	return StateResponse{
+		ServiceID:        serviceID,
+		APIVersion:       apiVersion,
+		State:            state,
+		Ready:            isReadyState(state),
+		Outcome:          state,
+		AffectedRefs:     []string{},
+		AffectedServices: []string{},
+	}
+}
+
+func defaultCapabilities() CapabilitiesResponse {
+	return CapabilitiesResponse{
+		ServiceID:  serviceID,
+		APIVersion: apiVersion,
+		Version:    version,
+		Transports: []string{"loopback-http"},
+		Endpoints: []string{
+			"GET /health",
+			"GET /ready",
+			"GET /status",
+			"GET /state",
+			"GET /capabilities",
+		},
+		Features: []string{
+			"liveness",
+			"readiness",
+			"status",
+			"state",
+			"capabilities",
+		},
+		FutureFeatures: []string{
+			"batched-resolve",
+			"write-back",
+			"source-status",
+			"typed-errors",
+			"audit-redaction",
+		},
+		Outcomes: append([]string(nil), typedOutcomes...),
 	}
 }
 
@@ -105,23 +222,12 @@ func serve(args []string) error {
 		return err
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "serviceId": "@secretsbroker", "state": *state})
-	})
-	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, defaultStatus(*state))
-	})
-	mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{"serviceId": "@secretsbroker", "state": defaultStatus(*state).State, "ready": defaultStatus(*state).Ready})
-	})
-
 	ln, err := net.Listen("tcp", *listen)
 	if err != nil {
 		return err
 	}
 
-	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{Handler: newHandler(state), ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -136,6 +242,31 @@ func serve(args []string) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return server.Shutdown(shutdownCtx)
+}
+
+func newHandler(state *string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, defaultHealth(*state))
+	})
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		body := defaultState(*state)
+		code := http.StatusOK
+		if !body.Ready {
+			code = http.StatusServiceUnavailable
+		}
+		writeJSON(w, code, body)
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, defaultStatus(*state))
+	})
+	mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, defaultState(*state))
+	})
+	mux.HandleFunc("/capabilities", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, defaultCapabilities())
+	})
+	return mux
 }
 
 func writeJSON(w http.ResponseWriter, code int, value any) {

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -1,11 +1,19 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestDefaultStatus(t *testing.T) {
 	status := defaultStatus("")
 	if status.ServiceID != "@secretsbroker" {
 		t.Fatalf("service id = %q", status.ServiceID)
+	}
+	if status.APIVersion != apiVersion {
+		t.Fatalf("api version = %q", status.APIVersion)
 	}
 	if status.State != "setup_needed" {
 		t.Fatalf("state = %q", status.State)
@@ -18,4 +26,65 @@ func TestDefaultStatus(t *testing.T) {
 	if !ready.Ready {
 		t.Fatalf("ready state should report Ready")
 	}
+}
+
+func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
+	caps := defaultCapabilities()
+	if caps.ServiceID != "@secretsbroker" {
+		t.Fatalf("service id = %q", caps.ServiceID)
+	}
+	if caps.APIVersion != apiVersion {
+		t.Fatalf("api version = %q", caps.APIVersion)
+	}
+	assertContains(t, caps.Endpoints, "GET /capabilities")
+	assertContains(t, caps.Endpoints, "GET /ready")
+	assertContains(t, caps.Features, "readiness")
+	assertContains(t, caps.FutureFeatures, "batched-resolve")
+	assertContains(t, caps.Outcomes, "source_auth_required")
+	assertContains(t, caps.Outcomes, "policy_denied")
+}
+
+func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
+	state := "locked"
+	server := httptest.NewServer(newHandler(&state))
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d", res.StatusCode)
+	}
+	var body StateResponse
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Ready {
+		t.Fatalf("locked state should not be ready")
+	}
+	if body.Outcome != "locked" {
+		t.Fatalf("outcome = %q", body.Outcome)
+	}
+
+	state = "ready"
+	res, err = http.Get(server.URL + "/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("ready status code = %d", res.StatusCode)
+	}
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("%q not found in %#v", want, values)
 }

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -1,0 +1,370 @@
+# Secrets Broker Local API and Bootstrap Contract
+
+Status: initial contract  
+Issue: #11  
+Service id: `@secretsbroker`  
+API version: `secretsbroker.local/v1`
+
+## Purpose
+
+This contract defines the stable local process boundary between Service Lasso core, Service Admin, `secretsbroker-resolve`, and the `@secretsbroker` daemon.
+
+Service Lasso core should keep only a tiny bootstrap client/state machine:
+
+1. locate/start `@secretsbroker`
+2. check process liveness
+3. check API capabilities/version
+4. check readiness/state
+5. call resolve/write-back APIs when materializing dependent services
+6. map typed broker outcomes into startup diagnostics
+
+The daemon in this repo owns storage, unlock, policy, audit, source adapters, resolve/write-back behavior, and external provider/source state.
+
+## Transport shape
+
+Preferred production transports:
+
+- Windows: named pipe
+- macOS/Linux: Unix domain socket
+
+Development/bootstrap compatibility transport:
+
+- loopback HTTP bound to `127.0.0.1`
+
+The initial daemon exposes loopback HTTP. Named pipe/Unix socket transports should preserve the same request/response schema.
+
+## Cross-cutting response rules
+
+- API version is visible in `status` and `capabilities` responses.
+- Secret values are never returned by status/capabilities/state/source-status endpoints.
+- Resolve responses may include secret material only for requested refs allowed by policy.
+- Error responses use the typed error envelope below.
+- Batch APIs must report per-ref outcomes rather than failing the whole batch whenever practical.
+
+## Typed outcomes
+
+Canonical outcome strings:
+
+- `setup_needed`
+- `locked`
+- `ready`
+- `source_auth_required`
+- `degraded`
+- `policy_denied`
+- `missing_ref`
+- `invalid_ref`
+- `source_unavailable`
+- `identity_expired`
+
+## Endpoints
+
+### `GET /health`
+
+Liveness only. This answers whether the broker process is reachable, not whether secrets are usable.
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "serviceId": "@secretsbroker",
+  "state": "setup_needed"
+}
+```
+
+### `GET /ready`
+
+Readiness for secret resolution. This should be true only when the current lifecycle state is `ready`.
+
+Example ready response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "ready": true,
+  "state": "ready",
+  "outcome": "ready"
+}
+```
+
+Example not-ready response:
+
+HTTP status: `503`
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "ready": false,
+  "state": "locked",
+  "outcome": "locked"
+}
+```
+
+### `GET /status`
+
+Human/operator-friendly status summary. Safe for logs and UI diagnostics.
+
+Example response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "name": "Service Lasso Secrets Broker",
+  "version": "0.1.0",
+  "apiVersion": "secretsbroker.local/v1",
+  "state": "setup_needed",
+  "ready": false,
+  "localFirst": true,
+  "backend": "local",
+  "description": "Lean local-first Vault-like broker bootstrap skeleton. Secrets storage/resolution is intentionally not implemented yet.",
+  "checkedAt": "2026-05-07T00:00:00Z"
+}
+```
+
+### `GET /state`
+
+Machine-oriented lifecycle state used by bootstrap clients.
+
+Example response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "state": "setup_needed",
+  "ready": false,
+  "outcome": "setup_needed",
+  "affectedRefs": [],
+  "affectedServices": []
+}
+```
+
+### `GET /capabilities`
+
+Version and feature discovery.
+
+Example response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "version": "0.1.0",
+  "transports": ["loopback-http"],
+  "endpoints": [
+    "GET /health",
+    "GET /ready",
+    "GET /status",
+    "GET /state",
+    "GET /capabilities"
+  ],
+  "features": [
+    "liveness",
+    "readiness",
+    "status",
+    "state",
+    "capabilities"
+  ],
+  "futureFeatures": [
+    "batched-resolve",
+    "write-back",
+    "source-status",
+    "typed-errors",
+    "audit-redaction"
+  ],
+  "outcomes": [
+    "setup_needed",
+    "locked",
+    "ready",
+    "source_auth_required",
+    "degraded",
+    "policy_denied",
+    "missing_ref",
+    "invalid_ref",
+    "source_unavailable",
+    "identity_expired"
+  ]
+}
+```
+
+## Planned resolve contract
+
+Endpoint:
+
+```text
+POST /v1/resolve
+```
+
+Request:
+
+```json
+{
+  "requestId": "01HV...",
+  "workspaceId": "workspace-local",
+  "serviceId": "openclaw",
+  "purpose": "service-start",
+  "refs": [
+    "openclaw/anthropic/api_key",
+    "openclaw/telegram/bot_token"
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "01HV...",
+  "results": [
+    {
+      "ref": "openclaw/anthropic/api_key",
+      "outcome": "ready",
+      "value": "<plaintext only for allowed resolve calls>",
+      "metadata": {
+        "sourceId": "local",
+        "version": "current"
+      }
+    },
+    {
+      "ref": "openclaw/telegram/bot_token",
+      "outcome": "source_auth_required",
+      "message": "Telegram source needs reconnect before this ref can be resolved.",
+      "nextAction": "reconnect_source"
+    }
+  ]
+}
+```
+
+Rules:
+
+- Values are present only for refs allowed by policy and only on resolve endpoints.
+- Missing/denied/invalid/auth-required entries use per-result outcomes.
+- Audit records must redact secret values.
+
+## Planned write-back contract
+
+Endpoint:
+
+```text
+POST /v1/write-back
+```
+
+Request:
+
+```json
+{
+  "requestId": "01HW...",
+  "workspaceId": "workspace-local",
+  "serviceId": "openclaw",
+  "operation": "generated_secret_capture",
+  "items": [
+    {
+      "ref": "openclaw/webhook/signing_secret",
+      "value": "<plaintext accepted by write-back endpoint only>",
+      "policy": "rotate-on-next-deploy"
+    }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "01HW...",
+  "results": [
+    {
+      "ref": "openclaw/webhook/signing_secret",
+      "outcome": "ready",
+      "version": "2026-05-07T00:00:00Z"
+    }
+  ]
+}
+```
+
+Planned write-back operations:
+
+- `generated_secret_capture`
+- `refresh`
+- `invalidate`
+- `reconnect`
+
+## Planned source status contract
+
+Endpoint:
+
+```text
+GET /v1/sources/status
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "sources": [
+    {
+      "sourceId": "local",
+      "kind": "local-encrypted-store",
+      "outcome": "ready",
+      "critical": true
+    },
+    {
+      "sourceId": "vault-prod",
+      "kind": "vault",
+      "outcome": "identity_expired",
+      "critical": false,
+      "affectedRefs": ["billing/stripe/api_key"],
+      "affectedServices": ["billing"]
+    }
+  ]
+}
+```
+
+## Error envelope
+
+All endpoint-level errors should use this safe envelope:
+
+```json
+{
+  "error": {
+    "code": "locked",
+    "message": "Secrets Broker is locked. Import or unwrap the portable master key before resolving refs.",
+    "outcome": "locked",
+    "requestId": "01HX...",
+    "nextAction": "unlock_broker",
+    "affectedRefs": [],
+    "affectedServices": []
+  }
+}
+```
+
+Rules:
+
+- `code` is stable and machine-readable.
+- `message` is safe for logs/UI.
+- `outcome` should be one of the typed outcomes when applicable.
+- Secret values must never appear in errors.
+
+## Bootstrap client minimum
+
+A Service Lasso bootstrap client can implement against this contract without knowing broker internals:
+
+1. start process from `service.json`
+2. wait for `GET /health`
+3. read `GET /capabilities` and confirm compatible `apiVersion`
+4. read `GET /state` or `GET /ready`
+5. block only dependent refs/services when state/outcome is not globally ready
+6. call resolve/write-back endpoints once those features are advertised
+
+## Versioning
+
+- Current API version: `secretsbroker.local/v1`
+- Compatible additions may add fields/endpoints/features.
+- Breaking schema changes require a new API version string.
+- Clients should ignore unknown fields and check feature names before calling optional endpoints.


### PR DESCRIPTION
## Issue
Closes #11

## Summary
- adds `docs/local-api-bootstrap-contract.md` for the versioned local API/bootstrap contract
- exposes API version in status/state/capabilities responses
- adds `GET /ready` to distinguish liveness from readiness
- adds `GET /capabilities` with current endpoints/features and planned future features
- introduces shared response/error structs and canonical typed outcomes
- updates README endpoint list and contract pointer
- ignores `.tmp/` test output generated by the local test script

## Scope
In scope:
- bootstrap/local API contract documentation
- daemon bootstrap endpoints and shared structs
- tests for readiness/capability behavior

Out of scope:
- encrypted local store
- resolve/write-back implementation
- named pipe/Unix socket transports
- provider/source adapters

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`

## Notes
Secret-bearing resolve/write-back APIs are documented as planned contracts only; no endpoint returns broad plaintext dumps by default.