### PR TITLE
ISS-10 define lifecycle state contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back implementations are intentionally future issues. The initial local API and bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`.
+Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -22,6 +22,15 @@ const (
 	serviceID  = "@secretsbroker"
 )
 
+var lifecycleStates = []string{
+	"setup_needed",
+	"locked",
+	"ready",
+	"source_auth_required",
+	"degraded",
+	"policy_denied",
+}
+
 var typedOutcomes = []string{
 	"setup_needed",
 	"locked",
@@ -60,6 +69,8 @@ type StateResponse struct {
 	State            string   `json:"state"`
 	Ready            bool     `json:"ready"`
 	Outcome          string   `json:"outcome"`
+	KeyState         string   `json:"keyState"`
+	NextAction       string   `json:"nextAction"`
 	AffectedRefs     []string `json:"affectedRefs"`
 	AffectedServices []string `json:"affectedServices"`
 }
@@ -132,7 +143,12 @@ func normalizeState(state string) string {
 	if state == "" {
 		return "setup_needed"
 	}
-	return state
+	for _, allowed := range lifecycleStates {
+		if state == allowed {
+			return state
+		}
+	}
+	return "degraded"
 }
 
 func isReadyState(state string) bool {
@@ -160,6 +176,10 @@ func defaultHealth(state string) HealthResponse {
 }
 
 func defaultState(state string) StateResponse {
+	return stateResponse(state, nil, nil)
+}
+
+func stateResponse(state string, affectedRefs []string, affectedServices []string) StateResponse {
 	state = normalizeState(state)
 	return StateResponse{
 		ServiceID:        serviceID,
@@ -167,8 +187,10 @@ func defaultState(state string) StateResponse {
 		State:            state,
 		Ready:            isReadyState(state),
 		Outcome:          state,
-		AffectedRefs:     []string{},
-		AffectedServices: []string{},
+		KeyState:         keyStateFor(state),
+		NextAction:       nextActionFor(state),
+		AffectedRefs:     safeList(affectedRefs),
+		AffectedServices: safeList(affectedServices),
 	}
 }
 
@@ -218,16 +240,24 @@ func serve(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	listen := fs.String("listen", getenvDefault("SECRETSBROKER_LISTEN", "127.0.0.1:17890"), "listen address")
 	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
+	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
+	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
+	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
+	fs.Var(&affectedServices, "affected-service", "affected service id to report for non-ready states; repeatable")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+
+	refs := []string(affectedRefs)
+	services := []string(affectedServices)
+	stateView := runtimeState{state: state, affectedRefs: &refs, affectedServices: &services}
 
 	ln, err := net.Listen("tcp", *listen)
 	if err != nil {
 		return err
 	}
 
-	server := &http.Server{Handler: newHandler(state), ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{Handler: newHandler(stateView), ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -244,13 +274,13 @@ func serve(args []string) error {
 	return server.Shutdown(shutdownCtx)
 }
 
-func newHandler(state *string) http.Handler {
+func newHandler(state runtimeState) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, defaultHealth(*state))
+		writeJSON(w, http.StatusOK, defaultHealth(state.current()))
 	})
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		body := defaultState(*state)
+		body := state.response()
 		code := http.StatusOK
 		if !body.Ready {
 			code = http.StatusServiceUnavailable
@@ -258,15 +288,99 @@ func newHandler(state *string) http.Handler {
 		writeJSON(w, code, body)
 	})
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, defaultStatus(*state))
+		writeJSON(w, http.StatusOK, defaultStatus(state.current()))
 	})
 	mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, defaultState(*state))
+		writeJSON(w, http.StatusOK, state.response())
 	})
 	mux.HandleFunc("/capabilities", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, defaultCapabilities())
 	})
 	return mux
+}
+
+type runtimeState struct {
+	state            *string
+	affectedRefs     *[]string
+	affectedServices *[]string
+}
+
+func (s runtimeState) current() string {
+	if s.state == nil {
+		return "setup_needed"
+	}
+	return *s.state
+}
+
+func (s runtimeState) response() StateResponse {
+	var refs []string
+	if s.affectedRefs != nil {
+		refs = *s.affectedRefs
+	}
+	var services []string
+	if s.affectedServices != nil {
+		services = *s.affectedServices
+	}
+	return stateResponse(s.current(), refs, services)
+}
+
+type multiFlag []string
+
+func (m *multiFlag) String() string { return strings.Join(*m, ",") }
+
+func (m *multiFlag) Set(value string) error {
+	*m = append(*m, splitCSV(value)...)
+	return nil
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	return safeList(parts)
+}
+
+func safeList(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	clean := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			clean = append(clean, value)
+		}
+	}
+	return clean
+}
+
+func keyStateFor(state string) string {
+	switch normalizeState(state) {
+	case "setup_needed":
+		return "not_initialized"
+	case "locked":
+		return "locked"
+	default:
+		return "available"
+	}
+}
+
+func nextActionFor(state string) string {
+	switch normalizeState(state) {
+	case "setup_needed":
+		return "run_setup"
+	case "locked":
+		return "unlock_broker"
+	case "source_auth_required":
+		return "reconnect_source"
+	case "degraded":
+		return "inspect_sources"
+	case "policy_denied":
+		return "review_policy"
+	default:
+		return ""
+	}
 }
 
 func writeJSON(w http.ResponseWriter, code int, value any) {

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -46,7 +46,9 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 
 func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
 	state := "locked"
-	server := httptest.NewServer(newHandler(&state))
+	affectedRefs := []string{"openclaw/anthropic/api_key"}
+	affectedServices := []string{"openclaw"}
+	server := httptest.NewServer(newHandler(runtimeState{state: &state, affectedRefs: &affectedRefs, affectedServices: &affectedServices}))
 	defer server.Close()
 
 	res, err := http.Get(server.URL + "/ready")
@@ -67,6 +69,14 @@ func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
 	if body.Outcome != "locked" {
 		t.Fatalf("outcome = %q", body.Outcome)
 	}
+	if body.KeyState != "locked" {
+		t.Fatalf("keyState = %q", body.KeyState)
+	}
+	if body.NextAction != "unlock_broker" {
+		t.Fatalf("nextAction = %q", body.NextAction)
+	}
+	assertContains(t, body.AffectedRefs, "openclaw/anthropic/api_key")
+	assertContains(t, body.AffectedServices, "openclaw")
 
 	state = "ready"
 	res, err = http.Get(server.URL + "/ready")
@@ -76,6 +86,50 @@ func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("ready status code = %d", res.StatusCode)
+	}
+}
+
+func TestLifecycleStateOutcomesAndActions(t *testing.T) {
+	tests := []struct {
+		state      string
+		ready      bool
+		keyState   string
+		nextAction string
+	}{
+		{state: "setup_needed", ready: false, keyState: "not_initialized", nextAction: "run_setup"},
+		{state: "ready", ready: true, keyState: "available", nextAction: ""},
+		{state: "locked", ready: false, keyState: "locked", nextAction: "unlock_broker"},
+		{state: "source_auth_required", ready: false, keyState: "available", nextAction: "reconnect_source"},
+		{state: "degraded", ready: false, keyState: "available", nextAction: "inspect_sources"},
+		{state: "policy_denied", ready: false, keyState: "available", nextAction: "review_policy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			got := defaultState(tt.state)
+			if got.Outcome != tt.state {
+				t.Fatalf("outcome = %q", got.Outcome)
+			}
+			if got.Ready != tt.ready {
+				t.Fatalf("ready = %v", got.Ready)
+			}
+			if got.KeyState != tt.keyState {
+				t.Fatalf("keyState = %q", got.KeyState)
+			}
+			if got.NextAction != tt.nextAction {
+				t.Fatalf("nextAction = %q", got.NextAction)
+			}
+		})
+	}
+}
+
+func TestUnknownStateNormalizesToDegraded(t *testing.T) {
+	got := defaultState("surprise")
+	if got.State != "degraded" {
+		t.Fatalf("state = %q", got.State)
+	}
+	if got.NextAction != "inspect_sources" {
+		t.Fatalf("nextAction = %q", got.NextAction)
 	}
 }
 

--- a/docs/lifecycle-states.md
+++ b/docs/lifecycle-states.md
@@ -1,0 +1,138 @@
+# Secrets Broker Lifecycle States
+
+Status: initial contract  
+Issue: #10  
+Service id: `@secretsbroker`
+
+## Purpose
+
+`@secretsbroker` must distinguish process liveness from secret usability.
+
+A running process can still be unusable for a dependent service when the broker has not been set up, the portable master key is locked, a required source identity expired, or policy denies access.
+
+Service Lasso should use these states to block only the affected service/ref where possible rather than treating every broker problem as a global startup failure.
+
+## Lifecycle states
+
+### `setup_needed`
+
+Blank install. No local encrypted store/master-key enrollment exists yet.
+
+Operator experience:
+
+- show setup wizard
+- create/import portable master key
+- initialize local encrypted store
+- enroll this machine's OS wrapper when available
+
+Startup behavior:
+
+- broker process can start
+- `/health` is OK
+- `/ready` is not ready
+- dependent secret resolution is blocked until setup completes
+
+### `locked`
+
+Encrypted vault/store exists, but this machine cannot currently unwrap/access the portable master key.
+
+Common causes:
+
+- encrypted vault copied to a new machine
+- OS wrapper not enrolled
+- portable master key not imported
+- local wrapper/keychain/DPAPI entry unavailable
+
+Operator next action:
+
+- import/unlock portable master key
+- re-wrap/enroll this machine
+
+### `ready`
+
+Broker can service allowed local requests.
+
+This does not mean every external source is healthy; optional source outages can still produce per-ref `degraded` or `source_auth_required` outcomes.
+
+### `source_auth_required`
+
+A configured source/backend identity is missing, expired, or needs reconnect.
+
+Startup behavior:
+
+- do not prompt for every optional source at broker startup
+- prompt/block only when a startup-critical source/ref is needed
+- report affected refs/services safely
+
+### `degraded`
+
+Broker is partially usable, but one or more optional sources/backends are unavailable.
+
+Startup behavior:
+
+- unrelated services may continue
+- affected refs/services should be reported
+- dependent services should block only when they require the degraded source/ref
+
+### `policy_denied`
+
+The broker intentionally denied a request or service/ref relation by policy.
+
+Startup behavior:
+
+- do not report this as a missing secret
+- report precise denied ref/service relation where safe
+- record audit event when policy/audit implementation exists
+
+## State response shape
+
+`GET /state` and `GET /ready` expose safe machine-readable lifecycle detail:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "state": "source_auth_required",
+  "ready": false,
+  "outcome": "source_auth_required",
+  "keyState": "available",
+  "nextAction": "reconnect_source",
+  "affectedRefs": ["openclaw/telegram/bot_token"],
+  "affectedServices": ["openclaw"]
+}
+```
+
+Rules:
+
+- state/outcome is stable and machine-readable
+- affected refs/services are safe identifiers only, never secret values
+- `/ready` returns HTTP `200` only for `ready`
+- `/ready` returns HTTP `503` for setup/locked/auth/degraded/policy states
+- `/health` remains HTTP `200` while the process is alive
+
+## CLI/dev state simulation
+
+The bootstrap daemon supports state simulation for early Service Lasso integration work:
+
+```powershell
+secretsbroker serve --state locked --affected-ref openclaw/anthropic/api_key --affected-service openclaw
+secretsbroker status --state source_auth_required
+```
+
+Environment equivalents:
+
+```text
+SECRETSBROKER_STATE=source_auth_required
+SECRETSBROKER_AFFECTED_REFS=openclaw/telegram/bot_token,billing/stripe/api_key
+SECRETSBROKER_AFFECTED_SERVICES=openclaw,billing
+```
+
+These simulation flags are not a substitute for the real encrypted store/source adapter implementations. They let Service Lasso core and Service Admin build against stable typed outcomes before storage and source adapters land.
+
+## Out of scope for this slice
+
+- encrypted local store
+- portable master-key import/unwrap implementation
+- source adapter auth flows
+- audit persistence
+- policy engine

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -134,6 +134,8 @@ Example response:
   "state": "setup_needed",
   "ready": false,
   "outcome": "setup_needed",
+  "keyState": "not_initialized",
+  "nextAction": "run_setup",
   "affectedRefs": [],
   "affectedServices": []
 }


### PR DESCRIPTION
## Issue
Closes #10

## Summary
- adds `docs/lifecycle-states.md` covering setup_needed, locked, ready, source_auth_required, degraded, and policy_denied behavior
- extends `/state` and `/ready` with safe `keyState`, `nextAction`, `affectedRefs`, and `affectedServices`
- adds daemon flags/env simulation for affected refs/services during bootstrap integration work
- normalizes unknown lifecycle state values to `degraded`
- updates the local API contract and README to reference lifecycle behavior
- adds tests for lifecycle outcomes/actions and readiness behavior

## Scope
In scope:
- lifecycle/source-auth state contract
- safe state reporting fields
- CLI/dev state simulation for early Service Lasso integration

Out of scope:
- encrypted local store
- actual portable master-key unwrap/import
- source adapter auth flows
- audit persistence
- policy engine

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`

## Notes
No secret values are exposed by state/readiness endpoints; affected refs/services are identifier-only diagnostics.