### PR TITLE
ISS-3 add local encrypted store resolve MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ The first bootstrap slice provides:
   - `GET /status`
   - `GET /state`
   - `GET /capabilities`
+  - `POST /v1/secrets`
+  - `POST /v1/resolve`
 - CLI-style commands:
   - `secretsbroker serve`
   - `secretsbroker status`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-Secret storage, unlock, policy, audit, provider/source adapters, and resolve/write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key unlock, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 
@@ -66,6 +68,7 @@ pwsh -NoLogo -NoProfile -File .\scripts\package.ps1
 Run the daemon directly:
 
 ```powershell
+$env:SECRETSBROKER_MASTER_KEY = "local-dev-key"
 go run .\cmd\secretsbroker serve --listen 127.0.0.1:17890
 ```
 

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	localStoreVersion = 1
+	localStoreSource  = "local"
+)
+
+var (
+	errLocked     = errors.New("secrets broker store is locked")
+	errMissingRef = errors.New("secret ref was not found")
+	errInvalidRef = errors.New("invalid secret ref")
+)
+
+type localBackend struct {
+	storePath string
+	auditPath string
+	masterKey string
+	now       func() time.Time
+}
+
+type localStoreFile struct {
+	Version   int                    `json:"version"`
+	ServiceID string                 `json:"serviceId"`
+	CreatedAt time.Time              `json:"createdAt"`
+	UpdatedAt time.Time              `json:"updatedAt"`
+	Secrets   map[string]secretEntry `json:"secrets"`
+}
+
+type secretEntry struct {
+	Ref      string         `json:"ref"`
+	Metadata SecretMetadata `json:"metadata"`
+	Payload  secretPayload  `json:"payload"`
+}
+
+type SecretMetadata struct {
+	SourceID  string    `json:"sourceId"`
+	Version   string    `json:"version"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type secretPayload struct {
+	Alg        string `json:"alg"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type writeSecretRequest struct {
+	Ref      string            `json:"ref"`
+	Value    string            `json:"value"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+type writeSecretResponse struct {
+	ServiceID  string         `json:"serviceId"`
+	APIVersion string         `json:"apiVersion"`
+	Ref        string         `json:"ref"`
+	Outcome    string         `json:"outcome"`
+	Metadata   SecretMetadata `json:"metadata"`
+}
+
+type resolveRequest struct {
+	RequestID   string   `json:"requestId"`
+	WorkspaceID string   `json:"workspaceId"`
+	ServiceID   string   `json:"serviceId"`
+	Purpose     string   `json:"purpose"`
+	Refs        []string `json:"refs"`
+}
+
+type resolveResponse struct {
+	ServiceID  string          `json:"serviceId"`
+	APIVersion string          `json:"apiVersion"`
+	RequestID  string          `json:"requestId,omitempty"`
+	Results    []resolveResult `json:"results"`
+}
+
+type resolveResult struct {
+	Ref      string          `json:"ref"`
+	Outcome  string          `json:"outcome"`
+	Value    string          `json:"value,omitempty"`
+	Metadata *SecretMetadata `json:"metadata,omitempty"`
+	Message  string          `json:"message,omitempty"`
+}
+
+type auditEvent struct {
+	TS        time.Time `json:"ts"`
+	Operation string    `json:"operation"`
+	Ref       string    `json:"ref,omitempty"`
+	Outcome   string    `json:"outcome"`
+	ServiceID string    `json:"serviceId,omitempty"`
+	RequestID string    `json:"requestId,omitempty"`
+}
+
+func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
+	return &localBackend{storePath: storePath, auditPath: auditPath, masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func defaultStorePath() string { return filepath.Join("data", "secretsbroker-store.json") }
+func defaultAuditPath() string { return filepath.Join("data", "secretsbroker-audit.jsonl") }
+
+func (b *localBackend) locked() bool { return strings.TrimSpace(b.masterKey) == "" }
+
+func validSecretRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") || strings.Contains(ref, "..") {
+		return false
+	}
+	if strings.ContainsAny(ref, " \t\r\n") {
+		return false
+	}
+	parts := strings.Split(ref, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *localBackend) writeSecret(req writeSecretRequest) (writeSecretResponse, error) {
+	ref := strings.TrimSpace(req.Ref)
+	if !validSecretRef(ref) {
+		_ = b.audit("write", ref, "invalid_ref", "", "")
+		return writeSecretResponse{}, errInvalidRef
+	}
+	if b.locked() {
+		_ = b.audit("write", ref, "locked", "", "")
+		return writeSecretResponse{}, errLocked
+	}
+
+	store, err := b.loadStore()
+	if err != nil {
+		return writeSecretResponse{}, err
+	}
+	now := b.now()
+	version := now.Format(time.RFC3339Nano)
+	metadata := SecretMetadata{
+		SourceID:  firstNonEmpty(req.Metadata["sourceId"], localStoreSource),
+		Version:   version,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if existing, ok := store.Secrets[ref]; ok {
+		metadata.CreatedAt = existing.Metadata.CreatedAt
+	}
+	payload, err := b.encrypt(req.Value)
+	if err != nil {
+		return writeSecretResponse{}, err
+	}
+	store.Secrets[ref] = secretEntry{Ref: ref, Metadata: metadata, Payload: payload}
+	store.UpdatedAt = now
+	if err := b.saveStore(store); err != nil {
+		return writeSecretResponse{}, err
+	}
+	_ = b.audit("write", ref, "ready", "", "")
+	return writeSecretResponse{ServiceID: serviceID, APIVersion: apiVersion, Ref: ref, Outcome: "ready", Metadata: metadata}, nil
+}
+
+func (b *localBackend) resolve(req resolveRequest) resolveResponse {
+	results := make([]resolveResult, 0, len(req.Refs))
+	if len(req.Refs) == 0 {
+		return resolveResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, Results: []resolveResult{}}
+	}
+
+	var store localStoreFile
+	var storeErr error
+	if !b.locked() {
+		store, storeErr = b.loadStore()
+	}
+
+	for _, rawRef := range req.Refs {
+		ref := strings.TrimSpace(rawRef)
+		result := resolveResult{Ref: ref}
+		switch {
+		case !validSecretRef(ref):
+			result.Outcome = "invalid_ref"
+			result.Message = "Secret ref is invalid."
+		case b.locked():
+			result.Outcome = "locked"
+			result.Message = "Secrets Broker local store is locked."
+		case storeErr != nil:
+			result.Outcome = "degraded"
+			result.Message = "Local store could not be read."
+		default:
+			entry, ok := store.Secrets[ref]
+			if !ok {
+				result.Outcome = "missing_ref"
+				result.Message = "Secret ref was not found."
+			} else if value, err := b.decrypt(entry.Payload); err != nil {
+				result.Outcome = "degraded"
+				result.Message = "Secret payload could not be decrypted."
+			} else {
+				metadata := entry.Metadata
+				result.Outcome = "ready"
+				result.Value = value
+				result.Metadata = &metadata
+			}
+		}
+		_ = b.audit("resolve", ref, result.Outcome, req.ServiceID, req.RequestID)
+		results = append(results, result)
+	}
+	return resolveResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, Results: results}
+}
+
+func (b *localBackend) loadStore() (localStoreFile, error) {
+	now := b.now()
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}}
+	bytes, err := os.ReadFile(b.storePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return store, nil
+	}
+	if err != nil {
+		return store, err
+	}
+	if len(bytes) == 0 {
+		return store, nil
+	}
+	if err := json.Unmarshal(bytes, &store); err != nil {
+		return store, err
+	}
+	if store.Secrets == nil {
+		store.Secrets = map[string]secretEntry{}
+	}
+	return store, nil
+}
+
+func (b *localBackend) saveStore(store localStoreFile) error {
+	if err := os.MkdirAll(filepath.Dir(b.storePath), 0o700); err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(b.storePath, bytes, 0o600)
+}
+
+func (b *localBackend) audit(operation, ref, outcome, requestServiceID, requestID string) error {
+	if strings.TrimSpace(b.auditPath) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(b.auditPath), 0o700); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(b.auditPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return json.NewEncoder(file).Encode(auditEvent{TS: b.now(), Operation: operation, Ref: ref, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID})
+}
+
+func (b *localBackend) encrypt(value string) (secretPayload, error) {
+	block, err := aes.NewCipher(b.key())
+	if err != nil {
+		return secretPayload{}, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return secretPayload{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return secretPayload{}, err
+	}
+	ciphertext := gcm.Seal(nil, nonce, []byte(value), nil)
+	return secretPayload{Alg: "AES-256-GCM", Nonce: base64.StdEncoding.EncodeToString(nonce), Ciphertext: base64.StdEncoding.EncodeToString(ciphertext)}, nil
+}
+
+func (b *localBackend) decrypt(payload secretPayload) (string, error) {
+	if payload.Alg != "AES-256-GCM" {
+		return "", fmt.Errorf("unsupported payload algorithm %q", payload.Alg)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(payload.Nonce)
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(payload.Ciphertext)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(b.key())
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}
+
+func (b *localBackend) key() []byte {
+	sum := sha256.Sum256([]byte(b.masterKey))
+	return sum[:]
+}
+
+func firstNonEmpty(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend) {
+	mux.HandleFunc("/v1/secrets", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/secrets.", "invalid_ref", "")
+			return
+		}
+		var req writeSecretRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+			return
+		}
+		res, err := backend.writeSecret(req)
+		switch {
+		case err == nil:
+			writeJSON(w, http.StatusOK, res)
+		case errors.Is(err, errInvalidRef):
+			writeAPIError(w, http.StatusBadRequest, "invalid_ref", "Secret ref is invalid.", "invalid_ref", "")
+		case errors.Is(err, errLocked):
+			writeAPIError(w, http.StatusServiceUnavailable, "locked", "Secrets Broker local store is locked.", "locked", "unlock_broker")
+		default:
+			writeAPIError(w, http.StatusInternalServerError, "store_error", "Local store write failed.", "degraded", "inspect_sources")
+		}
+	})
+
+	mux.HandleFunc("/v1/resolve", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/resolve.", "invalid_ref", "")
+			return
+		}
+		var req resolveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, backend.resolve(req))
+	})
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, message, outcome, nextAction string) {
+	writeJSON(w, status, ErrorEnvelope{Error: APIError{Code: code, Message: message, Outcome: outcome, NextAction: nextAction, AffectedRefs: []string{}, AffectedServices: []string{}}})
+}

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLocalStoreHTTPWriteAndResolve(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend))
+	defer server.Close()
+
+	writeBody := []byte(`{"ref":"openclaw/anthropic/api_key","value":"secret-value","metadata":{"sourceId":"local-test"}}`)
+	writeRes, err := http.Post(server.URL+"/v1/secrets", "application/json", bytes.NewReader(writeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writeRes.Body.Close()
+	if writeRes.StatusCode != http.StatusOK {
+		t.Fatalf("write status = %d", writeRes.StatusCode)
+	}
+	var written writeSecretResponse
+	if err := json.NewDecoder(writeRes.Body).Decode(&written); err != nil {
+		t.Fatal(err)
+	}
+	if written.Outcome != "ready" || written.Ref != "openclaw/anthropic/api_key" {
+		t.Fatalf("write response = %#v", written)
+	}
+
+	resolveBody := []byte(`{"requestId":"req-1","serviceId":"openclaw","refs":["openclaw/anthropic/api_key"]}`)
+	resolveRes, err := http.Post(server.URL+"/v1/resolve", "application/json", bytes.NewReader(resolveBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resolveRes.Body.Close()
+	if resolveRes.StatusCode != http.StatusOK {
+		t.Fatalf("resolve status = %d", resolveRes.StatusCode)
+	}
+	var resolved resolveResponse
+	if err := json.NewDecoder(resolveRes.Body).Decode(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "secret-value" {
+		t.Fatalf("resolve response = %#v", resolved)
+	}
+}

--- a/cmd/secretsbroker/local_store_test.go
+++ b/cmd/secretsbroker/local_store_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalBackendWriteSeparatesMetadataAndEncryptedPayload(t *testing.T) {
+	backend := testBackend(t)
+	res, err := backend.writeSecret(writeSecretRequest{Ref: "openclaw/anthropic/api_key", Value: "secret-value", Metadata: map[string]string{"sourceId": "local-test"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "ready" {
+		t.Fatalf("outcome = %q", res.Outcome)
+	}
+	bytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(bytes), "secret-value") {
+		t.Fatalf("store contains plaintext secret: %s", string(bytes))
+	}
+	var store localStoreFile
+	if err := json.Unmarshal(bytes, &store); err != nil {
+		t.Fatal(err)
+	}
+	entry := store.Secrets["openclaw/anthropic/api_key"]
+	if entry.Metadata.SourceID != "local-test" {
+		t.Fatalf("sourceId = %q", entry.Metadata.SourceID)
+	}
+	if entry.Payload.Ciphertext == "" || entry.Payload.Nonce == "" {
+		t.Fatalf("encrypted payload missing: %#v", entry.Payload)
+	}
+}
+
+func TestLocalBackendResolveBatchOutcomes(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "openclaw/anthropic/api_key", Value: "secret-value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := backend.resolve(resolveRequest{RequestID: "req-1", ServiceID: "openclaw", Refs: []string{"openclaw/anthropic/api_key", "openclaw/missing", "bad ref"}})
+	if len(res.Results) != 3 {
+		t.Fatalf("results = %d", len(res.Results))
+	}
+	if res.Results[0].Outcome != "ready" || res.Results[0].Value != "secret-value" {
+		t.Fatalf("ready result = %#v", res.Results[0])
+	}
+	if res.Results[1].Outcome != "missing_ref" || res.Results[1].Value != "" {
+		t.Fatalf("missing result = %#v", res.Results[1])
+	}
+	if res.Results[2].Outcome != "invalid_ref" || res.Results[2].Value != "" {
+		t.Fatalf("invalid result = %#v", res.Results[2])
+	}
+
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(auditBytes), "secret-value") {
+		t.Fatalf("audit contains plaintext secret: %s", string(auditBytes))
+	}
+	for _, want := range []string{"ready", "missing_ref", "invalid_ref"} {
+		if !strings.Contains(string(auditBytes), want) {
+			t.Fatalf("audit missing %q: %s", want, string(auditBytes))
+		}
+	}
+}
+
+func TestLockedBackendResolveDoesNotRevealValues(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "openclaw/anthropic/api_key", Value: "secret-value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	locked := newLocalBackend(backend.storePath, backend.auditPath, "")
+	res := locked.resolve(resolveRequest{Refs: []string{"openclaw/anthropic/api_key"}})
+	if res.Results[0].Outcome != "locked" {
+		t.Fatalf("outcome = %#v", res.Results[0])
+	}
+	if res.Results[0].Value != "" {
+		t.Fatalf("locked result leaked value")
+	}
+}
+
+func TestValidSecretRef(t *testing.T) {
+	valid := []string{"openclaw/anthropic/api_key", "workspace-local/github/token"}
+	invalid := []string{"", "/leading", "trailing/", "has space/ref", "a//b", "a/../b"}
+	for _, ref := range valid {
+		if !validSecretRef(ref) {
+			t.Fatalf("expected valid ref %q", ref)
+		}
+	}
+	for _, ref := range invalid {
+		if validSecretRef(ref) {
+			t.Fatalf("expected invalid ref %q", ref)
+		}
+	}
+}
+
+func testBackend(t *testing.T) *localBackend {
+	t.Helper()
+	dir := t.TempDir()
+	backend := newLocalBackend(filepath.Join(dir, "store.json"), filepath.Join(dir, "audit.jsonl"), "test-master-key")
+	fixed := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	backend.now = func() time.Time { return fixed }
+	return backend
+}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -206,6 +206,8 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /status",
 			"GET /state",
 			"GET /capabilities",
+			"POST /v1/secrets",
+			"POST /v1/resolve",
 		},
 		Features: []string{
 			"liveness",
@@ -213,13 +215,14 @@ func defaultCapabilities() CapabilitiesResponse {
 			"status",
 			"state",
 			"capabilities",
-		},
-		FutureFeatures: []string{
+			"local-encrypted-store",
 			"batched-resolve",
-			"write-back",
-			"source-status",
 			"typed-errors",
 			"audit-redaction",
+		},
+		FutureFeatures: []string{
+			"write-back",
+			"source-status",
 		},
 		Outcomes: append([]string(nil), typedOutcomes...),
 	}
@@ -240,6 +243,9 @@ func serve(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	listen := fs.String("listen", getenvDefault("SECRETSBROKER_LISTEN", "127.0.0.1:17890"), "listen address")
 	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key; empty means locked")
 	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
 	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
 	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
@@ -251,13 +257,14 @@ func serve(args []string) error {
 	refs := []string(affectedRefs)
 	services := []string(affectedServices)
 	stateView := runtimeState{state: state, affectedRefs: &refs, affectedServices: &services}
+	backend := newLocalBackend(*storePath, *auditPath, *masterKey)
 
 	ln, err := net.Listen("tcp", *listen)
 	if err != nil {
 		return err
 	}
 
-	server := &http.Server{Handler: newHandler(stateView), ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{Handler: newHandler(stateView, backend), ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -274,7 +281,7 @@ func serve(args []string) error {
 	return server.Shutdown(shutdownCtx)
 }
 
-func newHandler(state runtimeState) http.Handler {
+func newHandler(state runtimeState, backend *localBackend) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, defaultHealth(state.current()))
@@ -296,6 +303,9 @@ func newHandler(state runtimeState) http.Handler {
 	mux.HandleFunc("/capabilities", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, defaultCapabilities())
 	})
+	if backend != nil {
+		registerLocalStoreHandlers(mux, backend)
+	}
 	return mux
 }
 

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -39,7 +39,7 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	assertContains(t, caps.Endpoints, "GET /capabilities")
 	assertContains(t, caps.Endpoints, "GET /ready")
 	assertContains(t, caps.Features, "readiness")
-	assertContains(t, caps.FutureFeatures, "batched-resolve")
+	assertContains(t, caps.Features, "batched-resolve")
 	assertContains(t, caps.Outcomes, "source_auth_required")
 	assertContains(t, caps.Outcomes, "policy_denied")
 }
@@ -48,7 +48,7 @@ func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
 	state := "locked"
 	affectedRefs := []string{"openclaw/anthropic/api_key"}
 	affectedServices := []string{"openclaw"}
-	server := httptest.NewServer(newHandler(runtimeState{state: &state, affectedRefs: &affectedRefs, affectedServices: &affectedServices}))
+	server := httptest.NewServer(newHandler(runtimeState{state: &state, affectedRefs: &affectedRefs, affectedServices: &affectedServices}, nil))
 	defer server.Close()
 
 	res, err := http.Get(server.URL + "/ready")

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -158,21 +158,24 @@ Example response:
     "GET /ready",
     "GET /status",
     "GET /state",
-    "GET /capabilities"
+    "GET /capabilities",
+    "POST /v1/secrets",
+    "POST /v1/resolve"
   ],
   "features": [
     "liveness",
     "readiness",
     "status",
     "state",
-    "capabilities"
-  ],
-  "futureFeatures": [
+    "capabilities",
+    "local-encrypted-store",
     "batched-resolve",
-    "write-back",
-    "source-status",
     "typed-errors",
     "audit-redaction"
+  ],
+  "futureFeatures": [
+    "write-back",
+    "source-status"
   ],
   "outcomes": [
     "setup_needed",
@@ -189,7 +192,7 @@ Example response:
 }
 ```
 
-## Planned resolve contract
+## Batched resolve contract
 
 Endpoint:
 

--- a/docs/local-store-resolve.md
+++ b/docs/local-store-resolve.md
@@ -1,0 +1,220 @@
+# Local Encrypted Store and Resolve API
+
+Status: MVP contract  
+Issue: #3  
+API version: `secretsbroker.local/v1`
+
+## Purpose
+
+This document defines the first local backend for `@secretsbroker`:
+
+```text
+Service Lasso -> @secretsbroker -> local encrypted store
+```
+
+The MVP is intentionally small but establishes the important invariants:
+
+- secret metadata is stored separately from encrypted payload values
+- plaintext values do not appear in normal logs, diagnostics, status, or audit records
+- secret refs are namespace-aware strings such as `openclaw/anthropic/api_key`
+- runtime clients resolve refs through a batched API
+- missing/locked/invalid outcomes are typed per ref where possible
+
+## Local store file
+
+Default path:
+
+```text
+./data/secretsbroker-store.json
+```
+
+Override:
+
+```text
+SECRETSBROKER_STORE_PATH=C:\path\to\secretsbroker-store.json
+```
+
+The store is JSON so early development remains inspectable, but secret values are encrypted with AES-GCM.
+
+Illustrative shape:
+
+```json
+{
+  "version": 1,
+  "serviceId": "@secretsbroker",
+  "createdAt": "2026-05-07T00:00:00Z",
+  "updatedAt": "2026-05-07T00:00:00Z",
+  "secrets": {
+    "openclaw/anthropic/api_key": {
+      "ref": "openclaw/anthropic/api_key",
+      "metadata": {
+        "sourceId": "local",
+        "version": "2026-05-07T00:00:00Z",
+        "createdAt": "2026-05-07T00:00:00Z",
+        "updatedAt": "2026-05-07T00:00:00Z"
+      },
+      "payload": {
+        "alg": "AES-256-GCM",
+        "nonce": "base64...",
+        "ciphertext": "base64..."
+      }
+    }
+  }
+}
+```
+
+## Key material
+
+MVP key source:
+
+```text
+SECRETSBROKER_MASTER_KEY=<development/local key material>
+```
+
+No master key means the local store is `locked` for secret read/write/resolve operations.
+
+This is a bootstrap implementation only. Issue #4 will replace/extend this with the portable master-key and OS wrapper unlock foundation.
+
+## Audit log
+
+Default path:
+
+```text
+./data/secretsbroker-audit.jsonl
+```
+
+Override:
+
+```text
+SECRETSBROKER_AUDIT_PATH=C:\path\to\secretsbroker-audit.jsonl
+```
+
+Audit events are JSON Lines and must not include plaintext secret values.
+
+Example:
+
+```json
+{"ts":"2026-05-07T00:00:00Z","operation":"resolve","ref":"openclaw/anthropic/api_key","outcome":"ready","serviceId":"openclaw"}
+```
+
+## Write endpoint
+
+MVP local write endpoint:
+
+```text
+POST /v1/secrets
+```
+
+Request:
+
+```json
+{
+  "ref": "openclaw/anthropic/api_key",
+  "value": "plaintext accepted only by this write endpoint",
+  "metadata": {
+    "sourceId": "local"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "ref": "openclaw/anthropic/api_key",
+  "outcome": "ready",
+  "metadata": {
+    "sourceId": "local",
+    "version": "2026-05-07T00:00:00Z"
+  }
+}
+```
+
+The response never echoes the plaintext value.
+
+## Batched resolve endpoint
+
+Endpoint:
+
+```text
+POST /v1/resolve
+```
+
+Request:
+
+```json
+{
+  "requestId": "01HV...",
+  "workspaceId": "workspace-local",
+  "serviceId": "openclaw",
+  "purpose": "service-start",
+  "refs": [
+    "openclaw/anthropic/api_key",
+    "openclaw/telegram/bot_token"
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "01HV...",
+  "results": [
+    {
+      "ref": "openclaw/anthropic/api_key",
+      "outcome": "ready",
+      "value": "plaintext only on successful resolve result",
+      "metadata": {
+        "sourceId": "local",
+        "version": "2026-05-07T00:00:00Z"
+      }
+    },
+    {
+      "ref": "openclaw/telegram/bot_token",
+      "outcome": "missing_ref",
+      "message": "Secret ref was not found."
+    }
+  ]
+}
+```
+
+Rules:
+
+- Batch response reports per-ref outcomes.
+- Missing refs use `missing_ref`, not generic failure.
+- Invalid refs use `invalid_ref`.
+- Locked store uses `locked` per requested ref.
+- `value` is present only when outcome is `ready`.
+- Audit logs redact values.
+
+## Ref validation
+
+MVP refs must:
+
+- be non-empty
+- contain only path-like segments separated by `/`
+- not start or end with `/`
+- not include `..`
+- not include whitespace
+
+This intentionally supports namespace-aware refs like:
+
+```text
+openclaw/anthropic/api_key
+billing/stripe/api_key
+workspace-local/github/token
+```
+
+## Out of scope
+
+- portable master-key import/unwrap
+- OS wrapper storage
+- policy engine
+- source adapters
+- Service Admin UI
+- Service Lasso manifest resolver integration


### PR DESCRIPTION
## Issue
Closes #3

## Summary
- adds `docs/local-store-resolve.md` for the local encrypted store and resolve MVP
- adds AES-GCM encrypted JSON local store with metadata/ciphertext separation
- adds redacted JSONL audit events for write/resolve attempts
- adds `POST /v1/secrets` for local/dev bootstrap writes
- adds batched `POST /v1/resolve` with per-ref typed outcomes
- advertises local encrypted store and batched resolve capabilities
- updates README and local API contract docs

## Scope
In scope:
- first local encrypted backend MVP
- namespace-aware secret refs
- batched resolve endpoint
- typed outcomes for ready, missing_ref, invalid_ref, locked, degraded
- no plaintext in store/audit/status diagnostics

Out of scope:
- portable master-key unlock foundation (#4)
- policy engine
- external source adapters
- Service Admin UI
- Service Lasso manifest resolver integration

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`

## Notes
The MVP uses `SECRETSBROKER_MASTER_KEY` / `--master-key` as local development key material. A missing key reports `locked`. The portable master-key/OS-wrapper design remains issue #4.