### PR TITLE
ISS-4 add portable master-key foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The first bootstrap slice provides:
 - CLI-style commands:
   - `secretsbroker serve`
   - `secretsbroker status`
+  - `secretsbroker key status`
+  - `secretsbroker key generate`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key unlock, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. OS wrapper enrollment, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/key_material.go
+++ b/cmd/secretsbroker/key_material.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const masterKeyVersion = "v1"
+
+type keyMaterial struct {
+	Value  string
+	Source string
+}
+
+type keyStatusResponse struct {
+	ServiceID  string `json:"serviceId"`
+	APIVersion string `json:"apiVersion"`
+	Available  bool   `json:"available"`
+	KeyID      string `json:"keyId"`
+	KeyVersion string `json:"keyVersion"`
+	Source     string `json:"source"`
+	State      string `json:"state"`
+}
+
+type keyGenerateResponse struct {
+	ServiceID  string `json:"serviceId"`
+	APIVersion string `json:"apiVersion"`
+	KeyID      string `json:"keyId"`
+	KeyVersion string `json:"keyVersion"`
+	MasterKey  string `json:"masterKey"`
+	Warning    string `json:"warning"`
+}
+
+func runKey(args []string) error {
+	if len(args) == 0 {
+		return printKeyStatus(args)
+	}
+	switch args[0] {
+	case "status":
+		return printKeyStatus(args[1:])
+	case "generate":
+		return printGeneratedKey()
+	default:
+		return fmt.Errorf("unknown key command %q", args[0])
+	}
+}
+
+func printKeyStatus(args []string) error {
+	fs := flag.NewFlagSet("key status", flag.ContinueOnError)
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(keyStatus(material))
+}
+
+func printGeneratedKey() error {
+	key, err := generatePortableMasterKey()
+	if err != nil {
+		return err
+	}
+	res := keyGenerateResponse{
+		ServiceID:  serviceID,
+		APIVersion: apiVersion,
+		KeyID:      masterKeyID(key),
+		KeyVersion: masterKeyVersion,
+		MasterKey:  key,
+		Warning:    "Store this portable master key securely. It can decrypt local vault payloads.",
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(res)
+}
+
+func loadKeyMaterial(flagValue, filePath string) (keyMaterial, error) {
+	if strings.TrimSpace(flagValue) != "" {
+		return keyMaterial{Value: strings.TrimSpace(flagValue), Source: "flag/env"}, nil
+	}
+	if strings.TrimSpace(filePath) != "" {
+		bytes, err := os.ReadFile(filePath)
+		if err != nil {
+			return keyMaterial{}, err
+		}
+		value := strings.TrimSpace(string(bytes))
+		if value != "" {
+			return keyMaterial{Value: value, Source: "file"}, nil
+		}
+	}
+	return keyMaterial{Source: "none"}, errLocked
+}
+
+func keyStatus(material keyMaterial) keyStatusResponse {
+	available := strings.TrimSpace(material.Value) != ""
+	state := "locked"
+	keyID := ""
+	keyVersion := ""
+	if available {
+		state = "ready"
+		keyID = masterKeyID(material.Value)
+		keyVersion = masterKeyVersion
+	}
+	source := material.Source
+	if source == "" {
+		source = "none"
+	}
+	return keyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Available: available, KeyID: keyID, KeyVersion: keyVersion, Source: source, State: state}
+}
+
+func generatePortableMasterKey() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+func masterKeyID(masterKey string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(masterKey)))
+	return "mk-" + hex.EncodeToString(sum[:])[:16]
+}

--- a/cmd/secretsbroker/key_material_test.go
+++ b/cmd/secretsbroker/key_material_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeyStatusLockedAndReady(t *testing.T) {
+	locked := keyStatus(keyMaterial{})
+	if locked.Available || locked.State != "locked" || locked.KeyID != "" {
+		t.Fatalf("locked status = %#v", locked)
+	}
+
+	ready := keyStatus(keyMaterial{Value: "portable-key", Source: "env"})
+	if !ready.Available || ready.State != "ready" || ready.KeyVersion != masterKeyVersion || ready.KeyID == "" {
+		t.Fatalf("ready status = %#v", ready)
+	}
+}
+
+func TestLoadKeyMaterialFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "master-key.txt")
+	if err := os.WriteFile(path, []byte("file-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	material, err := loadKeyMaterial("", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if material.Value != "file-key" || material.Source != "file" {
+		t.Fatalf("material = %#v", material)
+	}
+}
+
+func TestGeneratePortableMasterKey(t *testing.T) {
+	key, err := generatePortableMasterKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == "" {
+		t.Fatalf("empty key")
+	}
+	if masterKeyID(key) == "" {
+		t.Fatalf("empty key id")
+	}
+}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -58,6 +58,8 @@ type SecretMetadata struct {
 
 type secretPayload struct {
 	Alg        string `json:"alg"`
+	KeyID      string `json:"keyId"`
+	KeyVersion string `json:"keyVersion"`
 	Nonce      string `json:"nonce"`
 	Ciphertext string `json:"ciphertext"`
 }
@@ -281,7 +283,7 @@ func (b *localBackend) encrypt(value string) (secretPayload, error) {
 		return secretPayload{}, err
 	}
 	ciphertext := gcm.Seal(nil, nonce, []byte(value), nil)
-	return secretPayload{Alg: "AES-256-GCM", Nonce: base64.StdEncoding.EncodeToString(nonce), Ciphertext: base64.StdEncoding.EncodeToString(ciphertext)}, nil
+	return secretPayload{Alg: "AES-256-GCM", KeyID: masterKeyID(b.masterKey), KeyVersion: masterKeyVersion, Nonce: base64.StdEncoding.EncodeToString(nonce), Ciphertext: base64.StdEncoding.EncodeToString(ciphertext)}, nil
 }
 
 func (b *localBackend) decrypt(payload secretPayload) (string, error) {

--- a/cmd/secretsbroker/local_store_test.go
+++ b/cmd/secretsbroker/local_store_test.go
@@ -36,6 +36,9 @@ func TestLocalBackendWriteSeparatesMetadataAndEncryptedPayload(t *testing.T) {
 	if entry.Payload.Ciphertext == "" || entry.Payload.Nonce == "" {
 		t.Fatalf("encrypted payload missing: %#v", entry.Payload)
 	}
+	if entry.Payload.KeyID != masterKeyID("test-master-key") || entry.Payload.KeyVersion != masterKeyVersion {
+		t.Fatalf("key metadata missing: %#v", entry.Payload)
+	}
 }
 
 func TestLocalBackendResolveBatchOutcomes(t *testing.T) {

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -117,6 +117,8 @@ func run(args []string) error {
 		return serve(args[1:])
 	case "status":
 		return printStatus(args[1:])
+	case "key":
+		return runKey(args[1:])
 	case "version":
 		fmt.Println(version)
 		return nil
@@ -130,11 +132,12 @@ func run(args []string) error {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|version>")
+	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|version>")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
 	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
+	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key foundation")
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
 }
 
@@ -246,6 +249,7 @@ func serve(args []string) error {
 	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
 	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
 	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key; empty means locked")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
 	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
 	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
 	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
@@ -257,7 +261,11 @@ func serve(args []string) error {
 	refs := []string(affectedRefs)
 	services := []string(affectedServices)
 	stateView := runtimeState{state: state, affectedRefs: &refs, affectedServices: &services}
-	backend := newLocalBackend(*storePath, *auditPath, *masterKey)
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, material.Value)
 
 	ln, err := net.Listen("tcp", *listen)
 	if err != nil {

--- a/docs/local-store-resolve.md
+++ b/docs/local-store-resolve.md
@@ -55,6 +55,8 @@ Illustrative shape:
       },
       "payload": {
         "alg": "AES-256-GCM",
+        "keyId": "mk-0123456789abcdef",
+        "keyVersion": "v1",
         "nonce": "base64...",
         "ciphertext": "base64..."
       }
@@ -65,15 +67,16 @@ Illustrative shape:
 
 ## Key material
 
-MVP key source:
+MVP key sources:
 
 ```text
 SECRETSBROKER_MASTER_KEY=<development/local key material>
+SECRETSBROKER_MASTER_KEY_FILE=./data/master-key.txt
 ```
 
 No master key means the local store is `locked` for secret read/write/resolve operations.
 
-This is a bootstrap implementation only. Issue #4 will replace/extend this with the portable master-key and OS wrapper unlock foundation.
+Portable master-key identity and key metadata are documented in `docs/portable-master-key.md`. OS wrapper unlock/enrollment remains future scope.
 
 ## Audit log
 

--- a/docs/portable-master-key.md
+++ b/docs/portable-master-key.md
@@ -1,0 +1,135 @@
+# Portable Master Key and Unlock Foundation
+
+Status: foundation slice  
+Issue: #4
+
+## Purpose
+
+The local encrypted store must be portable across operating systems while still allowing each machine to protect its local unlock material.
+
+Canonical model:
+
+```text
+portable master key -> encrypts vault payloads
+local machine wrapper -> protects/unlocks local copy of portable master key
+```
+
+The encrypted vault/store should be movable between Windows, macOS, and Linux. A copied vault on a new machine should enter `locked` until the operator imports the portable master key and enrolls/re-wraps it for that machine.
+
+## MVP implemented in this slice
+
+This slice establishes the platform-independent key identity and payload metadata foundation:
+
+- master key material can be supplied from:
+  - `SECRETSBROKER_MASTER_KEY`
+  - `SECRETSBROKER_MASTER_KEY_FILE`
+  - `--master-key`
+  - `--master-key-file`
+- `secretsbroker key generate` creates a portable random 256-bit master key and stable key id
+- `secretsbroker key status` reports whether key material is available without revealing it
+- encrypted payload records include:
+  - `keyId`
+  - `keyVersion`
+  - `alg`
+  - `nonce`
+  - `ciphertext`
+- key id is a stable `mk-<sha256-prefix>` fingerprint of the portable master key
+- missing key material leaves the broker in locked behavior for local store read/write/resolve
+
+## Key status examples
+
+No key:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "available": false,
+  "keyId": "",
+  "keyVersion": "",
+  "source": "none",
+  "state": "locked"
+}
+```
+
+Key from env/file/flag:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "available": true,
+  "keyId": "mk-0123456789abcdef",
+  "keyVersion": "v1",
+  "source": "env",
+  "state": "ready"
+}
+```
+
+## Generate portable key
+
+```powershell
+secretsbroker key generate
+```
+
+Output:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "keyId": "mk-0123456789abcdef",
+  "keyVersion": "v1",
+  "masterKey": "base64url-random-key-material",
+  "warning": "Store this portable master key securely. It can decrypt local vault payloads."
+}
+```
+
+This command intentionally prints the generated key once. Operators should store it in a secure out-of-band location until OS-wrapper enrollment exists.
+
+## Planned local wrapper enrollment
+
+Future implementation should add OS-backed local wrapper commands:
+
+```text
+secretsbroker key import --master-key-file <file>
+secretsbroker key enroll-local
+secretsbroker key rewrap-local
+secretsbroker key lock
+secretsbroker key unlock
+```
+
+Recommended wrappers:
+
+- Windows: DPAPI user/machine scope, with explicit scope metadata
+- macOS: Keychain item scoped to the service identity
+- Linux: protected file or secret-service/libsecret integration, with strict permissions
+
+The OS wrapper stores/protects a local copy of the same portable master key. The ciphertext format remains platform-independent.
+
+## Copied vault flow
+
+1. Copy encrypted store file to new machine.
+2. Start broker without local wrapper/key.
+3. Broker reports `locked`.
+4. Operator imports portable master key.
+5. Broker verifies key id against existing payload metadata.
+6. Operator enrolls/re-wraps local machine wrapper.
+7. Broker reports `ready`.
+
+## Recovery shares
+
+Shamir/recovery shares are a future design topic. This slice does not implement recovery shares.
+
+Design note:
+
+- recovery shares should reconstruct/import the same portable master key
+- shares must not be stored beside the encrypted vault
+- recovery events should be audited
+
+## Security notes
+
+- Secret values are never stored in plaintext.
+- The portable master key must be treated as sensitive secret material.
+- Key ids are fingerprints only; they are safe for diagnostics.
+- A wrong master key produces decrypt failures and `degraded` resolve outcomes, not plaintext output.


### PR DESCRIPTION
## Issue
Closes #4

## Summary
- adds `docs/portable-master-key.md`
- adds `secretsbroker key status`
- adds `secretsbroker key generate`
- supports master-key loading from env, flag, or file
- adds stable `keyId` and `keyVersion` metadata to encrypted payload records
- updates local store docs and README

## Scope
In scope:
- portable master-key identity/fingerprint foundation
- platform-independent ciphertext key metadata
- locked/ready key status reporting
- import-by-file/env/flag foundation for copied vault workflows

Out of scope:
- DPAPI/Keychain/Linux secret-store wrapper implementation
- Shamir/recovery shares
- key rotation/rewrap commands
- policy engine

## Validation
- PASS `go test ./...`
- PASS `go run .\cmd\secretsbroker key status` with env key
- PASS `go run .\cmd\secretsbroker key generate`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`

## Notes
This does not fake OS wrapper security. It establishes portable key identity + payload metadata first, and documents DPAPI/Keychain/Linux wrapper enrollment as follow-up implementation.