### PR TITLE
ISS-7 add local API token security

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ The first bootstrap slice provides:
   - `secretsbroker status`
   - `secretsbroker key status`
   - `secretsbroker key generate`
+  - `secretsbroker session status`
+  - `secretsbroker session generate`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. OS wrapper enrollment, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. OS wrapper enrollment, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 
@@ -71,6 +73,7 @@ Run the daemon directly:
 
 ```powershell
 $env:SECRETSBROKER_MASTER_KEY = "local-dev-key"
+$env:SECRETSBROKER_API_TOKEN = "local-api-token"
 go run .\cmd\secretsbroker serve --listen 127.0.0.1:17890
 ```
 

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -325,10 +325,13 @@ func firstNonEmpty(value, fallback string) string {
 	return fallback
 }
 
-func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend) {
+func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
 	mux.HandleFunc("/v1/secrets", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/secrets.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
 			return
 		}
 		var req writeSecretRequest
@@ -352,6 +355,9 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend) {
 	mux.HandleFunc("/v1/resolve", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/resolve.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
 			return
 		}
 		var req resolveRequest

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -11,11 +11,17 @@ import (
 func TestLocalStoreHTTPWriteAndResolve(t *testing.T) {
 	backend := testBackend(t)
 	state := "ready"
-	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend))
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
 	defer server.Close()
 
 	writeBody := []byte(`{"ref":"openclaw/anthropic/api_key","value":"secret-value","metadata":{"sourceId":"local-test"}}`)
-	writeRes, err := http.Post(server.URL+"/v1/secrets", "application/json", bytes.NewReader(writeBody))
+	writeReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/secrets", bytes.NewReader(writeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeReq.Header.Set("Content-Type", "application/json")
+	writeReq.Header.Set("Authorization", "Bearer test-token")
+	writeRes, err := http.DefaultClient.Do(writeReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +38,13 @@ func TestLocalStoreHTTPWriteAndResolve(t *testing.T) {
 	}
 
 	resolveBody := []byte(`{"requestId":"req-1","serviceId":"openclaw","refs":["openclaw/anthropic/api_key"]}`)
-	resolveRes, err := http.Post(server.URL+"/v1/resolve", "application/json", bytes.NewReader(resolveBody))
+	resolveReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/resolve", bytes.NewReader(resolveBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveReq.Header.Set("Content-Type", "application/json")
+	resolveReq.Header.Set("X-SecretsBroker-Token", "test-token")
+	resolveRes, err := http.DefaultClient.Do(resolveReq)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -119,6 +119,8 @@ func run(args []string) error {
 		return printStatus(args[1:])
 	case "key":
 		return runKey(args[1:])
+	case "session":
+		return runSession(args[1:])
 	case "version":
 		fmt.Println(version)
 		return nil
@@ -132,12 +134,13 @@ func run(args []string) error {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|version>")
+	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|session|version>")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
 	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
 	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key foundation")
+	fmt.Fprintln(os.Stderr, "  session Manage local API session/token foundation")
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
 }
 
@@ -250,6 +253,7 @@ func serve(args []string) error {
 	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
 	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key; empty means locked")
 	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	apiToken := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "local API token for secret-bearing endpoints")
 	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
 	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
 	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
@@ -272,7 +276,7 @@ func serve(args []string) error {
 		return err
 	}
 
-	server := &http.Server{Handler: newHandler(stateView, backend), ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{Handler: newHandler(stateView, backend, localAPISecurity{token: *apiToken}), ReadHeaderTimeout: 5 * time.Second}
 	go func() {
 		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -289,7 +293,7 @@ func serve(args []string) error {
 	return server.Shutdown(shutdownCtx)
 }
 
-func newHandler(state runtimeState, backend *localBackend) http.Handler {
+func newHandler(state runtimeState, backend *localBackend, security localAPISecurity) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, defaultHealth(state.current()))
@@ -312,7 +316,7 @@ func newHandler(state runtimeState, backend *localBackend) http.Handler {
 		writeJSON(w, http.StatusOK, defaultCapabilities())
 	})
 	if backend != nil {
-		registerLocalStoreHandlers(mux, backend)
+		registerLocalStoreHandlers(mux, backend, security)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -48,7 +48,7 @@ func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {
 	state := "locked"
 	affectedRefs := []string{"openclaw/anthropic/api_key"}
 	affectedServices := []string{"openclaw"}
-	server := httptest.NewServer(newHandler(runtimeState{state: &state, affectedRefs: &affectedRefs, affectedServices: &affectedServices}, nil))
+	server := httptest.NewServer(newHandler(runtimeState{state: &state, affectedRefs: &affectedRefs, affectedServices: &affectedServices}, nil, localAPISecurity{}))
 	defer server.Close()
 
 	res, err := http.Get(server.URL + "/ready")

--- a/cmd/secretsbroker/session.go
+++ b/cmd/secretsbroker/session.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type sessionStatusResponse struct {
+	ServiceID  string `json:"serviceId"`
+	APIVersion string `json:"apiVersion"`
+	Configured bool   `json:"configured"`
+	Source     string `json:"source"`
+	State      string `json:"state"`
+}
+
+type sessionGenerateResponse struct {
+	ServiceID  string `json:"serviceId"`
+	APIVersion string `json:"apiVersion"`
+	Token      string `json:"token"`
+	Warning    string `json:"warning"`
+}
+
+func runSession(args []string) error {
+	if len(args) == 0 {
+		return printSessionStatus(args)
+	}
+	switch args[0] {
+	case "status":
+		return printSessionStatus(args[1:])
+	case "generate":
+		return printGeneratedSessionToken()
+	default:
+		return fmt.Errorf("unknown session command %q", args[0])
+	}
+}
+
+func printSessionStatus(args []string) error {
+	fs := flag.NewFlagSet("session status", flag.ContinueOnError)
+	apiToken := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "local API token")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(sessionStatus(*apiToken))
+}
+
+func printGeneratedSessionToken() error {
+	token, err := generateSessionToken()
+	if err != nil {
+		return err
+	}
+	res := sessionGenerateResponse{ServiceID: serviceID, APIVersion: apiVersion, Token: token, Warning: "Store this local API token securely. Secret-bearing endpoints require it."}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(res)
+}
+
+func sessionStatus(token string) sessionStatusResponse {
+	configured := strings.TrimSpace(token) != ""
+	state := "locked"
+	source := "none"
+	if configured {
+		state = "ready"
+		source = "flag/env"
+	}
+	return sessionStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Configured: configured, Source: source, State: state}
+}
+
+func generateSessionToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return "sbk_" + base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+type localAPISecurity struct{ token string }
+
+func (s localAPISecurity) require(w http.ResponseWriter, r *http.Request) bool {
+	expected := strings.TrimSpace(s.token)
+	if expected == "" {
+		writeAPIError(w, http.StatusServiceUnavailable, "security_not_configured", "Secret-bearing endpoints require SECRETSBROKER_API_TOKEN or --api-token.", "policy_denied", "configure_api_token")
+		return false
+	}
+	got := bearerToken(r.Header.Get("Authorization"))
+	if got == "" {
+		got = strings.TrimSpace(r.Header.Get("X-SecretsBroker-Token"))
+	}
+	if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized", "A valid local API token is required.", "policy_denied", "authenticate_local_session")
+		return false
+	}
+	return true
+}
+
+func bearerToken(header string) string {
+	parts := strings.SplitN(strings.TrimSpace(header), " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/cmd/secretsbroker/session_test.go
+++ b/cmd/secretsbroker/session_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSessionStatusAndGenerate(t *testing.T) {
+	locked := sessionStatus("")
+	if locked.Configured || locked.State != "locked" {
+		t.Fatalf("locked session = %#v", locked)
+	}
+	ready := sessionStatus("token")
+	if !ready.Configured || ready.State != "ready" {
+		t.Fatalf("ready session = %#v", ready)
+	}
+	token, err := generateSessionToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(token, "sbk_") {
+		t.Fatalf("token = %q", token)
+	}
+}
+
+func TestLocalAPISecurityRequiresConfiguredToken(t *testing.T) {
+	sec := localAPISecurity{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+	res := httptest.NewRecorder()
+	if sec.require(res, req) {
+		t.Fatalf("unconfigured security should reject")
+	}
+	if res.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d", res.Code)
+	}
+}
+
+func TestLocalAPISecurityAcceptsBearerAndRejectsWrongToken(t *testing.T) {
+	sec := localAPISecurity{token: "secret-token"}
+	badReq := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+	badReq.Header.Set("Authorization", "Bearer wrong")
+	badRes := httptest.NewRecorder()
+	if sec.require(badRes, badReq) {
+		t.Fatalf("wrong token should reject")
+	}
+	if badRes.Code != http.StatusUnauthorized {
+		t.Fatalf("bad status = %d", badRes.Code)
+	}
+
+	goodReq := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+	goodReq.Header.Set("Authorization", "Bearer secret-token")
+	goodRes := httptest.NewRecorder()
+	if !sec.require(goodRes, goodReq) {
+		t.Fatalf("good bearer token should pass")
+	}
+}

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -37,6 +37,7 @@ The initial daemon exposes loopback HTTP. Named pipe/Unix socket transports shou
 
 - API version is visible in `status` and `capabilities` responses.
 - Secret values are never returned by status/capabilities/state/source-status endpoints.
+- Secret-bearing endpoints require local API token authentication for the loopback HTTP transport.
 - Resolve responses may include secret material only for requested refs allowed by policy.
 - Error responses use the typed error envelope below.
 - Batch APIs must report per-ref outcomes rather than failing the whole batch whenever practical.

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -1,0 +1,123 @@
+# Local API Security and Session Model
+
+Status: foundation slice  
+Issue: #7
+
+## Purpose
+
+Secret-bearing APIs must not be broad plaintext dump surfaces.
+
+This slice establishes the first local access boundary for the loopback HTTP development transport while documenting the intended Vault-like local IPC/session model.
+
+## Current implemented model
+
+Secret-bearing endpoints require a local API token:
+
+- `POST /v1/secrets`
+- `POST /v1/resolve`
+
+Safe bootstrap/status endpoints remain unauthenticated:
+
+- `GET /health`
+- `GET /ready`
+- `GET /status`
+- `GET /state`
+- `GET /capabilities`
+
+## Token configuration
+
+Provide the token to the daemon with:
+
+```text
+SECRETSBROKER_API_TOKEN=<token>
+```
+
+or:
+
+```powershell
+secretsbroker serve --api-token <token>
+```
+
+Requests may authenticate with either:
+
+```http
+Authorization: Bearer <token>
+```
+
+or:
+
+```http
+X-SecretsBroker-Token: <token>
+```
+
+If no token is configured, secret-bearing endpoints return `503 security_not_configured` rather than accepting unauthenticated access.
+
+## CLI helpers
+
+Generate a local development token:
+
+```powershell
+secretsbroker session generate
+```
+
+Check whether token configuration is present without revealing it:
+
+```powershell
+secretsbroker session status
+```
+
+## Error behavior
+
+Missing/invalid token:
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "A valid local API token is required.",
+    "outcome": "policy_denied",
+    "nextAction": "authenticate_local_session",
+    "affectedRefs": [],
+    "affectedServices": []
+  }
+}
+```
+
+No server token configured:
+
+```json
+{
+  "error": {
+    "code": "security_not_configured",
+    "message": "Secret-bearing endpoints require SECRETSBROKER_API_TOKEN or --api-token.",
+    "outcome": "policy_denied",
+    "nextAction": "configure_api_token",
+    "affectedRefs": [],
+    "affectedServices": []
+  }
+}
+```
+
+## Planned production model
+
+Preferred transports:
+
+- Windows named pipe with OS-authenticated local client identity
+- Unix socket with filesystem permissions and peer credential checks where available
+- loopback HTTP only for development/bootstrap compatibility
+
+Planned session model:
+
+- short-lived scoped sessions/tokens
+- service identity authentication for launched services
+- per-service/ref policy checks before resolve/write-back
+- lease/renew/revoke for runtime identities where applicable
+- audit events for allow/deny/resolve/write-back without plaintext values
+
+## Non-goals for this slice
+
+- full policy engine
+- named pipe/Unix socket implementation
+- service identity leases
+- user-facing unlock/setup wizard
+- broad plaintext dump command


### PR DESCRIPTION
## Issue
Closes #7

## Summary
- adds `docs/local-api-security.md`
- adds `secretsbroker session status` and `secretsbroker session generate`
- adds local API token authentication for secret-bearing endpoints
- requires a valid token for `POST /v1/secrets` and `POST /v1/resolve`
- keeps health/status/state/capabilities unauthenticated for bootstrap diagnostics
- documents planned named-pipe/Unix-socket/session/lease model

## Scope
In scope:
- local loopback HTTP token gate
- session token CLI primitives
- safe unauthorized/security-not-configured typed errors
- tests for accepted/rejected token behavior

Out of scope:
- Windows named pipe / Unix socket implementation
- full policy engine
- service identity leases
- audit view CLI
- setup/unlock/source-test UX commands

## Validation
- PASS `go test ./...`
- PASS `go run .\cmd\secretsbroker session status`
- PASS `go run .\cmd\secretsbroker session generate`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`

## Notes
This deliberately does not create a broad plaintext dump command. Secret material remains limited to authenticated targeted resolve responses.