### PR TITLE
ISS-12 define provider source registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The first bootstrap slice provides:
   - `GET /capabilities`
   - `POST /v1/secrets`
   - `POST /v1/resolve`
+  - `GET /v1/sources/status`
 - CLI-style commands:
   - `secretsbroker serve`
   - `secretsbroker status`
@@ -53,7 +54,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. OS wrapper enrollment, policy, provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`. OS wrapper enrollment, policy, concrete provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -214,6 +214,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /capabilities",
 			"POST /v1/secrets",
 			"POST /v1/resolve",
+			"GET /v1/sources/status",
 		},
 		Features: []string{
 			"liveness",
@@ -225,10 +226,10 @@ func defaultCapabilities() CapabilitiesResponse {
 			"batched-resolve",
 			"typed-errors",
 			"audit-redaction",
+			"source-status",
 		},
 		FutureFeatures: []string{
 			"write-back",
-			"source-status",
 		},
 		Outcomes: append([]string(nil), typedOutcomes...),
 	}
@@ -317,6 +318,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 	})
 	if backend != nil {
 		registerLocalStoreHandlers(mux, backend, security)
+		registerSourceRegistryHandlers(mux, backend)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -1,0 +1,60 @@
+package main
+
+import "net/http"
+
+type SourceRegistry struct {
+	Sources []SourceStatus `json:"sources"`
+}
+
+type SourceStatus struct {
+	SourceID         string   `json:"sourceId"`
+	Kind             string   `json:"kind"`
+	DisplayName      string   `json:"displayName"`
+	Enabled          bool     `json:"enabled"`
+	Critical         bool     `json:"critical"`
+	Priority         int      `json:"priority"`
+	Capabilities     []string `json:"capabilities"`
+	Namespaces       []string `json:"namespaces"`
+	State            string   `json:"state"`
+	AffectedRefs     []string `json:"affectedRefs"`
+	AffectedServices []string `json:"affectedServices"`
+}
+
+type sourceStatusResponse struct {
+	ServiceID  string         `json:"serviceId"`
+	APIVersion string         `json:"apiVersion"`
+	Sources    []SourceStatus `json:"sources"`
+}
+
+func defaultSourceRegistry(backend *localBackend) SourceRegistry {
+	state := "locked"
+	if backend != nil && !backend.locked() {
+		state = "ready"
+	}
+	return SourceRegistry{Sources: []SourceStatus{
+		{
+			SourceID:         "local",
+			Kind:             "local-encrypted-store",
+			DisplayName:      "Local encrypted store",
+			Enabled:          true,
+			Critical:         true,
+			Priority:         0,
+			Capabilities:     []string{"read", "write", "health"},
+			Namespaces:       []string{"*"},
+			State:            state,
+			AffectedRefs:     []string{},
+			AffectedServices: []string{},
+		},
+	}}
+}
+
+func registerSourceRegistryHandlers(mux *http.ServeMux, backend *localBackend) {
+	mux.HandleFunc("/v1/sources/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/sources/status.", "invalid_ref", "")
+			return
+		}
+		registry := defaultSourceRegistry(backend)
+		writeJSON(w, http.StatusOK, sourceStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Sources: registry.Sources})
+	})
+}

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDefaultSourceRegistryReflectsLocalKeyState(t *testing.T) {
+	locked := defaultSourceRegistry(newLocalBackend("store.json", "audit.jsonl", ""))
+	if len(locked.Sources) != 1 {
+		t.Fatalf("sources = %d", len(locked.Sources))
+	}
+	if locked.Sources[0].SourceID != "local" || locked.Sources[0].State != "locked" {
+		t.Fatalf("locked source = %#v", locked.Sources[0])
+	}
+	assertContains(t, locked.Sources[0].Capabilities, "read")
+	assertContains(t, locked.Sources[0].Namespaces, "*")
+
+	ready := defaultSourceRegistry(newLocalBackend("store.json", "audit.jsonl", "master-key"))
+	if ready.Sources[0].State != "ready" {
+		t.Fatalf("ready source = %#v", ready.Sources[0])
+	}
+}
+
+func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {
+	backend := newLocalBackend("store.json", "audit.jsonl", "master-key")
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{}))
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/v1/sources/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	var body sourceStatusResponse
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sources) != 1 || body.Sources[0].SourceID != "local" || body.Sources[0].State != "ready" {
+		t.Fatalf("body = %#v", body)
+	}
+}

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -161,7 +161,8 @@ Example response:
     "GET /state",
     "GET /capabilities",
     "POST /v1/secrets",
-    "POST /v1/resolve"
+    "POST /v1/resolve",
+    "GET /v1/sources/status"
   ],
   "features": [
     "liveness",
@@ -172,11 +173,11 @@ Example response:
     "local-encrypted-store",
     "batched-resolve",
     "typed-errors",
-    "audit-redaction"
+    "audit-redaction",
+    "source-status"
   ],
   "futureFeatures": [
-    "write-back",
-    "source-status"
+    "write-back"
   ],
   "outcomes": [
     "setup_needed",
@@ -299,7 +300,7 @@ Planned write-back operations:
 - `invalidate`
 - `reconnect`
 
-## Planned source status contract
+## Source status contract
 
 Endpoint:
 

--- a/docs/provider-source-registry.md
+++ b/docs/provider-source-registry.md
@@ -1,0 +1,166 @@
+# Provider Connection and Source Registry Model
+
+Status: initial model  
+Issue: #12
+
+## Purpose
+
+`@secretsbroker` needs one consistent source model for local encrypted storage and future backends such as Vault/OpenBao, AWS Secrets Manager, 1Password, Bitwarden/BWS, env, file, and exec.
+
+The model separates:
+
+- visible source/connection metadata
+- encrypted secret material
+- source health/state
+- audit events
+- namespace/ref mapping
+
+## Core entities
+
+### Source registry entry
+
+A source registry entry describes a configured backend/source without revealing secret values.
+
+```json
+{
+  "sourceId": "local",
+  "kind": "local-encrypted-store",
+  "displayName": "Local encrypted store",
+  "enabled": true,
+  "critical": true,
+  "priority": 0,
+  "capabilities": ["read", "write", "health"],
+  "namespaces": ["*"],
+  "state": "ready",
+  "affectedRefs": [],
+  "affectedServices": []
+}
+```
+
+### Provider connection metadata
+
+Provider connection metadata is visible and listable. It should be safe for UI/status surfaces.
+
+```json
+{
+  "connectionId": "openai-primary",
+  "sourceId": "local",
+  "provider": "openai",
+  "workspaceId": "workspace-local",
+  "displayName": "OpenAI primary",
+  "state": "ready",
+  "createdAt": "2026-05-07T00:00:00Z",
+  "updatedAt": "2026-05-07T00:00:00Z"
+}
+```
+
+### Provider connection secrets
+
+Secret payloads are encrypted and stored separately from visible metadata.
+
+```json
+{
+  "connectionId": "openai-primary",
+  "ref": "openclaw/openai/api_key",
+  "sourceId": "local",
+  "payload": {
+    "alg": "AES-256-GCM",
+    "keyId": "mk-0123456789abcdef",
+    "keyVersion": "v1",
+    "nonce": "base64...",
+    "ciphertext": "base64..."
+  }
+}
+```
+
+### Provider connection audit
+
+Audit records never include secret values.
+
+```json
+{
+  "ts": "2026-05-07T00:00:00Z",
+  "actor": "service:openclaw",
+  "sourceId": "local",
+  "ref": "openclaw/openai/api_key",
+  "action": "resolve",
+  "outcome": "ready"
+}
+```
+
+## Capabilities
+
+Canonical capability names:
+
+- `read`
+- `write`
+- `write-back`
+- `health`
+- `lease`
+- `renew`
+- `revoke`
+- `reconnect`
+- `auth-required`
+
+## Source states
+
+Canonical source states align with broker outcomes:
+
+- `ready`
+- `setup_needed`
+- `locked`
+- `source_auth_required`
+- `degraded`
+- `source_unavailable`
+- `identity_expired`
+- `policy_denied`
+
+## Namespace mapping
+
+A source can claim namespaces:
+
+```json
+{
+  "sourceId": "vault-prod",
+  "namespaces": ["prod/*", "billing/*"]
+}
+```
+
+Resolution should choose the highest-priority enabled source whose namespace mapping matches the ref.
+
+The local store can act as default fallback with namespace `*`.
+
+## Reconnect/source-auth transitions
+
+- missing or expired auth should become `source_auth_required` or `identity_expired`
+- optional source outage should become `degraded` or `source_unavailable`
+- affected refs/services should be reported by identifier only
+- unrelated refs/services should continue when possible
+
+## Current implemented MVP
+
+This slice adds an in-process registry with the default local source:
+
+- `sourceId`: `local`
+- `kind`: `local-encrypted-store`
+- `capabilities`: `read`, `write`, `health`
+- `namespaces`: `*`
+- state follows broker store/key state:
+  - no master key => `locked`
+  - master key available => `ready`
+
+Endpoint:
+
+```text
+GET /v1/sources/status
+```
+
+Secret values are not returned.
+
+## Out of scope
+
+- env/file/exec adapters
+- Vault/OpenBao adapter
+- AWS/1Password/Bitwarden/BWS adapters
+- persistent registry config UI
+- policy engine


### PR DESCRIPTION
## Issue
Closes #12

## Summary
- adds `docs/provider-source-registry.md`
- defines source registry, provider connection metadata, encrypted connection secret, and audit model
- adds default local source registry entry
- exposes `GET /v1/sources/status`
- advertises source-status capability

## Scope
In scope:
- metadata/source registry model
- default local source status
- source status endpoint and tests

Out of scope:
- concrete env/file/exec adapters (#5)
- Vault/OpenBao adapter (#6)
- AWS/1Password/Bitwarden/BWS adapters
- policy engine
- persistent registry UI/config

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`