### PR TITLE
ISS-5 add env file exec source adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`. OS wrapper enrollment, policy, concrete provider/source adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`. OS wrapper enrollment, policy, Vault/OpenBao adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -32,6 +32,7 @@ type localBackend struct {
 	storePath string
 	auditPath string
 	masterKey string
+	sources   sourceConfigFile
 	now       func() time.Time
 }
 
@@ -203,8 +204,18 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 		default:
 			entry, ok := store.Secrets[ref]
 			if !ok {
-				result.Outcome = "missing_ref"
-				result.Message = "Secret ref was not found."
+				sourceResult := b.sources.resolve(ref)
+				if sourceResult.Found {
+					result.Outcome = sourceResult.Outcome
+					result.Message = sourceResult.Message
+					if sourceResult.Outcome == "ready" {
+						result.Value = sourceResult.Value
+						result.Metadata = &SecretMetadata{SourceID: sourceResult.SourceID, Version: "source"}
+					}
+				} else {
+					result.Outcome = "missing_ref"
+					result.Message = "Secret ref was not found."
+				}
 			} else if value, err := b.decrypt(entry.Payload); err != nil {
 				result.Outcome = "degraded"
 				result.Message = "Secret payload could not be decrypted."

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -227,6 +227,9 @@ func defaultCapabilities() CapabilitiesResponse {
 			"typed-errors",
 			"audit-redaction",
 			"source-status",
+			"env-source",
+			"file-source",
+			"exec-source",
 		},
 		FutureFeatures: []string{
 			"write-back",
@@ -255,6 +258,7 @@ func serve(args []string) error {
 	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key; empty means locked")
 	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
 	apiToken := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "local API token for secret-bearing endpoints")
+	sourcesPath := fs.String("sources", getenvDefault("SECRETSBROKER_SOURCES_PATH", ""), "source adapter config path")
 	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
 	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
 	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
@@ -271,6 +275,11 @@ func serve(args []string) error {
 		return err
 	}
 	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	sources, err := loadSourceConfig(*sourcesPath)
+	if err != nil {
+		return err
+	}
+	backend.sources = sources
 
 	ln, err := net.Listen("tcp", *listen)
 	if err != nil {

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+type sourceConfigFile struct {
+	Sources []sourceConfig `json:"sources"`
+}
+
+type sourceConfig struct {
+	SourceID            string                     `json:"sourceId"`
+	Kind                string                     `json:"kind"`
+	DisplayName         string                     `json:"displayName"`
+	Enabled             bool                       `json:"enabled"`
+	Critical            bool                       `json:"critical"`
+	Priority            int                        `json:"priority"`
+	Namespaces          []string                   `json:"namespaces"`
+	TrustedDirs         []string                   `json:"trustedDirs"`
+	AllowSymlinkCommand bool                       `json:"allowSymlinkCommand"`
+	Refs                map[string]sourceRefConfig `json:"refs"`
+}
+
+type sourceRefConfig struct {
+	Env            string   `json:"env"`
+	Path           string   `json:"path"`
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	TimeoutMs      int      `json:"timeoutMs"`
+	MaxStdoutBytes int      `json:"maxStdoutBytes"`
+	UnsafeStdout   bool     `json:"unsafeStdout"`
+}
+
+type sourceResolveResult struct {
+	Found    bool
+	Value    string
+	SourceID string
+	Outcome  string
+	Message  string
+}
+
+func loadSourceConfig(path string) (sourceConfigFile, error) {
+	if strings.TrimSpace(path) == "" {
+		return sourceConfigFile{}, nil
+	}
+	bytes, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return sourceConfigFile{}, nil
+	}
+	if err != nil {
+		return sourceConfigFile{}, err
+	}
+	var cfg sourceConfigFile
+	if err := json.Unmarshal(bytes, &cfg); err != nil {
+		return sourceConfigFile{}, err
+	}
+	return cfg, nil
+}
+
+func (cfg sourceConfigFile) enabledSources() []sourceConfig {
+	sources := make([]sourceConfig, 0, len(cfg.Sources))
+	for _, source := range cfg.Sources {
+		if source.Enabled {
+			sources = append(sources, source)
+		}
+	}
+	sort.SliceStable(sources, func(i, j int) bool { return sources[i].Priority < sources[j].Priority })
+	return sources
+}
+
+func (cfg sourceConfigFile) resolve(ref string) sourceResolveResult {
+	for _, source := range cfg.enabledSources() {
+		refCfg, ok := source.Refs[ref]
+		if !ok {
+			continue
+		}
+		result := source.resolve(ref, refCfg)
+		result.Found = true
+		result.SourceID = source.SourceID
+		return result
+	}
+	return sourceResolveResult{Found: false, Outcome: "missing_ref", Message: "Secret ref was not found."}
+}
+
+func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveResult {
+	switch strings.ToLower(strings.TrimSpace(s.Kind)) {
+	case "env":
+		return resolveEnv(refCfg)
+	case "file":
+		return resolveFile(refCfg)
+	case "exec":
+		return s.resolveExec(refCfg)
+	default:
+		return sourceResolveResult{Outcome: "invalid_ref", Message: fmt.Sprintf("Unsupported source kind %q.", s.Kind)}
+	}
+}
+
+func resolveEnv(refCfg sourceRefConfig) sourceResolveResult {
+	if strings.TrimSpace(refCfg.Env) == "" {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Env source mapping is missing env name."}
+	}
+	value := os.Getenv(refCfg.Env)
+	if strings.TrimSpace(value) == "" {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped environment variable is empty or missing."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+func resolveFile(refCfg sourceRefConfig) sourceResolveResult {
+	if strings.TrimSpace(refCfg.Path) == "" {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "File source mapping is missing path."}
+	}
+	bytes, err := os.ReadFile(refCfg.Path)
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file could not be read."}
+	}
+	value := strings.TrimSpace(string(bytes))
+	if value == "" {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file is empty."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+func (s sourceConfig) resolveExec(refCfg sourceRefConfig) sourceResolveResult {
+	if err := validateExecConfig(s, refCfg); err != nil {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: err.Error()}
+	}
+	timeout := time.Duration(firstPositive(refCfg.TimeoutMs, 2000)) * time.Millisecond
+	maxStdout := firstPositive(refCfg.MaxStdoutBytes, 4096)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, refCfg.Command, refCfg.Args...)
+	cmd.Env = []string{}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source timed out."}
+	}
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source failed."}
+	}
+	if len(out) > maxStdout {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source stdout exceeded limit."}
+	}
+	value := ""
+	if refCfg.UnsafeStdout {
+		value = strings.TrimSpace(string(out))
+	} else {
+		var payload struct {
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(out, &payload); err != nil {
+			return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source did not return JSON value protocol."}
+		}
+		value = strings.TrimSpace(payload.Value)
+	}
+	if value == "" {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source returned empty value."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+func validateExecConfig(source sourceConfig, refCfg sourceRefConfig) error {
+	command := strings.TrimSpace(refCfg.Command)
+	if command == "" {
+		return errors.New("exec source mapping is missing command")
+	}
+	if !filepath.IsAbs(command) && runtime.GOOS != "windows" {
+		return errors.New("exec command must be absolute")
+	}
+	if len(source.TrustedDirs) > 0 {
+		cleanCommand, err := filepath.Abs(command)
+		if err != nil {
+			return err
+		}
+		allowed := false
+		for _, dir := range source.TrustedDirs {
+			cleanDir, err := filepath.Abs(dir)
+			if err != nil {
+				continue
+			}
+			rel, err := filepath.Rel(cleanDir, cleanCommand)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return errors.New("exec command is outside trustedDirs")
+		}
+	}
+	if !source.AllowSymlinkCommand {
+		if info, err := os.Lstat(command); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("exec command symlink is not allowed")
+		}
+	}
+	return nil
+}
+
+func firstPositive(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}

--- a/cmd/secretsbroker/source_adapters_test.go
+++ b/cmd/secretsbroker/source_adapters_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnvSourceAdapter(t *testing.T) {
+	t.Setenv("TEST_SECRET", "env-secret")
+	cfg := sourceConfigFile{Sources: []sourceConfig{{SourceID: "env-local", Kind: "env", Enabled: true, Refs: map[string]sourceRefConfig{"openclaw/env": {Env: "TEST_SECRET"}}}}}
+	res := cfg.resolve("openclaw/env")
+	if res.Outcome != "ready" || res.Value != "env-secret" || res.SourceID != "env-local" {
+		t.Fatalf("env result = %#v", res)
+	}
+}
+
+func TestFileSourceAdapter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("file-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := sourceConfigFile{Sources: []sourceConfig{{SourceID: "file-local", Kind: "file", Enabled: true, Refs: map[string]sourceRefConfig{"openclaw/file": {Path: path}}}}}
+	res := cfg.resolve("openclaw/file")
+	if res.Outcome != "ready" || res.Value != "file-secret" {
+		t.Fatalf("file result = %#v", res)
+	}
+}
+
+func TestSourcePriorityAndMissing(t *testing.T) {
+	t.Setenv("LOW", "low")
+	t.Setenv("HIGH", "high")
+	cfg := sourceConfigFile{Sources: []sourceConfig{
+		{SourceID: "low", Kind: "env", Enabled: true, Priority: 20, Refs: map[string]sourceRefConfig{"ref": {Env: "LOW"}}},
+		{SourceID: "high", Kind: "env", Enabled: true, Priority: 10, Refs: map[string]sourceRefConfig{"ref": {Env: "HIGH"}}},
+	}}
+	res := cfg.resolve("ref")
+	if res.SourceID != "high" || res.Value != "high" {
+		t.Fatalf("priority result = %#v", res)
+	}
+	missing := cfg.resolve("missing")
+	if missing.Outcome != "missing_ref" {
+		t.Fatalf("missing result = %#v", missing)
+	}
+}
+
+func TestExecSourceRejectsUntrustedCommand(t *testing.T) {
+	cfg := sourceConfig{SourceID: "exec", Kind: "exec", Enabled: true, TrustedDirs: []string{filepath.Join(t.TempDir(), "trusted")}}
+	res := cfg.resolve("ref", sourceRefConfig{Command: filepath.Join(t.TempDir(), "tool"), UnsafeStdout: true})
+	if res.Outcome != "invalid_ref" {
+		t.Fatalf("exec result = %#v", res)
+	}
+}

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -31,7 +31,7 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 	if backend != nil && !backend.locked() {
 		state = "ready"
 	}
-	return SourceRegistry{Sources: []SourceStatus{
+	sources := []SourceStatus{
 		{
 			SourceID:         "local",
 			Kind:             "local-encrypted-store",
@@ -45,7 +45,38 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 			AffectedRefs:     []string{},
 			AffectedServices: []string{},
 		},
-	}}
+	}
+	if backend != nil {
+		for _, source := range backend.sources.enabledSources() {
+			status := SourceStatus{
+				SourceID:         source.SourceID,
+				Kind:             source.Kind,
+				DisplayName:      firstNonEmpty(source.DisplayName, source.SourceID),
+				Enabled:          source.Enabled,
+				Critical:         source.Critical,
+				Priority:         source.Priority,
+				Capabilities:     capabilitiesForSourceKind(source.Kind),
+				Namespaces:       safeList(source.Namespaces),
+				State:            "ready",
+				AffectedRefs:     []string{},
+				AffectedServices: []string{},
+			}
+			if len(status.Namespaces) == 0 {
+				status.Namespaces = []string{"*"}
+			}
+			sources = append(sources, status)
+		}
+	}
+	return SourceRegistry{Sources: sources}
+}
+
+func capabilitiesForSourceKind(kind string) []string {
+	switch kind {
+	case "env", "file", "exec":
+		return []string{"read", "health"}
+	default:
+		return []string{"health"}
+	}
 }
 
 func registerSourceRegistryHandlers(mux *http.ServeMux, backend *localBackend) {

--- a/docs/env-file-exec-sources.md
+++ b/docs/env-file-exec-sources.md
@@ -1,0 +1,134 @@
+# Env, File, and Exec Source Adapters
+
+Status: MVP  
+Issue: #5
+
+## Purpose
+
+`@secretsbroker` can resolve refs from the local encrypted store and, when configured, from simple external local sources:
+
+- `env`
+- `file`
+- `exec`
+
+These are sources behind the stable broker contract, not replacements for `@secretsbroker`.
+
+## Source config
+
+Default: no external sources configured.
+
+Configure with:
+
+```text
+SECRETSBROKER_SOURCES_PATH=./config/sources.json
+```
+
+or:
+
+```powershell
+secretsbroker serve --sources ./config/sources.json
+```
+
+Example:
+
+```json
+{
+  "sources": [
+    {
+      "sourceId": "env-local",
+      "kind": "env",
+      "displayName": "Local env",
+      "enabled": true,
+      "critical": false,
+      "priority": 10,
+      "namespaces": ["openclaw/*"],
+      "refs": {
+        "openclaw/anthropic/api_key": { "env": "ANTHROPIC_API_KEY" }
+      }
+    },
+    {
+      "sourceId": "file-local",
+      "kind": "file",
+      "enabled": true,
+      "priority": 20,
+      "refs": {
+        "openclaw/telegram/bot_token": { "path": "./secrets/telegram-token.txt" }
+      }
+    },
+    {
+      "sourceId": "exec-local",
+      "kind": "exec",
+      "enabled": true,
+      "priority": 30,
+      "trustedDirs": ["C:/tools/secrets"],
+      "refs": {
+        "openclaw/github/token": {
+          "command": "C:/tools/secrets/read-secret.exe",
+          "args": ["openclaw/github/token"],
+          "timeoutMs": 2000,
+          "maxStdoutBytes": 4096
+        }
+      }
+    }
+  ]
+}
+```
+
+## Resolution order
+
+1. local encrypted store
+2. enabled configured sources by priority
+3. missing ref
+
+Each ref in a batched resolve response gets an independent outcome.
+
+## Env adapter
+
+Reads an exact environment variable name from the source config.
+
+Outcomes:
+
+- `ready` when env var exists and is non-empty
+- `missing_ref` when the ref is not mapped
+- `source_unavailable` when mapped env var is empty/missing
+
+## File adapter
+
+Reads a file path from the source config.
+
+Rules:
+
+- file value is trimmed of surrounding whitespace
+- empty file is `source_unavailable`
+- missing file is `source_unavailable`
+- value is returned only through authenticated resolve
+
+## Exec adapter hardening
+
+The exec adapter is intentionally strict:
+
+- no shell execution
+- command must be configured exactly
+- command must be absolute when the OS/path format can determine that
+- command must live under one configured `trustedDirs` entry when `trustedDirs` is set
+- symlink commands are rejected unless `allowSymlinkCommand` is true
+- args are fixed in config
+- timeout defaults to 2000ms
+- max stdout defaults to 4096 bytes
+- stderr is never treated as secret
+- JSON protocol mode is default: stdout must be `{ "value": "..." }`
+- simple stdout mode requires `unsafeStdout: true`
+
+Outcomes:
+
+- `ready` when command succeeds and returns a non-empty value
+- `source_unavailable` for command failures/timeouts/empty output
+- `invalid_ref` for invalid source config
+
+## Source status
+
+`GET /v1/sources/status` includes configured env/file/exec sources without exposing values.
+
+## Audit
+
+Each source resolve attempt is audited by ref/source/outcome without secret values.


### PR DESCRIPTION
## Issue
Closes #5

## Summary
- adds `docs/env-file-exec-sources.md`
- adds source config loading via `SECRETSBROKER_SOURCES_PATH` / `--sources`
- implements env, file, and hardened exec source adapters
- resolves missing local-store refs through enabled sources by priority
- reports configured sources through `GET /v1/sources/status`
- advertises env/file/exec capabilities

## Scope
In scope:
- source config model for env/file/exec
- per-ref source outcomes in batched resolve
- source status visibility without secret values
- exec hardening: no shell, trustedDirs, no symlink by default, fixed args, timeout, stdout limit, JSON protocol default

Out of scope:
- Vault/OpenBao adapter (#6)
- policy engine
- Service Lasso manifest integration
- UI

## Validation
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS `git diff --check`