### PR TITLE
ISS-6 add Vault/OpenBao source adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`. OS wrapper enrollment, policy, Vault/OpenBao adapters, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. OS wrapper enrollment, policy, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +31,9 @@ type sourceConfig struct {
 	Namespaces          []string                   `json:"namespaces"`
 	TrustedDirs         []string                   `json:"trustedDirs"`
 	AllowSymlinkCommand bool                       `json:"allowSymlinkCommand"`
+	Address             string                     `json:"address"`
+	Token               string                     `json:"token"`
+	TokenEnv            string                     `json:"tokenEnv"`
 	Refs                map[string]sourceRefConfig `json:"refs"`
 }
 
@@ -40,6 +45,7 @@ type sourceRefConfig struct {
 	TimeoutMs      int      `json:"timeoutMs"`
 	MaxStdoutBytes int      `json:"maxStdoutBytes"`
 	UnsafeStdout   bool     `json:"unsafeStdout"`
+	Field          string   `json:"field"`
 }
 
 type sourceResolveResult struct {
@@ -101,6 +107,8 @@ func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveR
 		return resolveFile(refCfg)
 	case "exec":
 		return s.resolveExec(refCfg)
+	case "vault", "openbao":
+		return s.resolveVault(refCfg)
 	default:
 		return sourceResolveResult{Outcome: "invalid_ref", Message: fmt.Sprintf("Unsupported source kind %q.", s.Kind)}
 	}
@@ -170,6 +178,86 @@ func (s sourceConfig) resolveExec(refCfg sourceRefConfig) sourceResolveResult {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source returned empty value."}
 	}
 	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+func (s sourceConfig) resolveVault(refCfg sourceRefConfig) sourceResolveResult {
+	if strings.TrimSpace(s.Address) == "" || strings.TrimSpace(refCfg.Path) == "" || strings.TrimSpace(refCfg.Field) == "" {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Vault/OpenBao source mapping requires address, path, and field."}
+	}
+	token := firstNonEmpty(s.Token, os.Getenv(s.TokenEnv))
+	if strings.TrimSpace(token) == "" {
+		return sourceResolveResult{Outcome: "source_auth_required", Message: "Vault/OpenBao token is missing."}
+	}
+	url := strings.TrimRight(s.Address, "/") + "/v1/" + strings.TrimLeft(refCfg.Path, "/")
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Vault/OpenBao URL is invalid."}
+	}
+	req.Header.Set("X-Vault-Token", token)
+	client := http.Client{Timeout: time.Duration(firstPositive(refCfg.TimeoutMs, 3000)) * time.Millisecond}
+	res, err := client.Do(req)
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao source is unavailable."}
+	}
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		return sourceResolveResult{Outcome: "source_auth_required", Message: "Vault/OpenBao token is unauthorized or expired."}
+	case http.StatusForbidden:
+		return sourceResolveResult{Outcome: "policy_denied", Message: "Vault/OpenBao policy denied access."}
+	case http.StatusNotFound:
+		return sourceResolveResult{Outcome: "missing_ref", Message: "Vault/OpenBao path or field was not found."}
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		if vaultResponseSealed(res.Body, firstPositive(refCfg.MaxStdoutBytes, 65536)) {
+			return sourceResolveResult{Outcome: "locked", Message: "Vault/OpenBao source is sealed."}
+		}
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao source returned a non-success status."}
+	}
+	limit := int64(firstPositive(refCfg.MaxStdoutBytes, 65536))
+	body, err := io.ReadAll(io.LimitReader(res.Body, limit+1))
+	if err != nil || int64(len(body)) > limit {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao response could not be read safely."}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao response was not JSON."}
+	}
+	value, ok := vaultField(payload, refCfg.Field)
+	if !ok || strings.TrimSpace(value) == "" {
+		return sourceResolveResult{Outcome: "missing_ref", Message: "Vault/OpenBao field was not found."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+func vaultResponseSealed(body io.Reader, maxBytes int) bool {
+	limit := int64(firstPositive(maxBytes, 65536))
+	bytes, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil || int64(len(bytes)) > limit {
+		return false
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return false
+	}
+	sealed, _ := payload["sealed"].(bool)
+	return sealed
+}
+
+func vaultField(payload map[string]any, field string) (string, bool) {
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	if nested, ok := data["data"].(map[string]any); ok {
+		data = nested
+	}
+	value, ok := data[field]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	return text, ok
 }
 
 func validateExecConfig(source sourceConfig, refCfg sourceRefConfig) error {

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -1,6 +1,10 @@
 package main
 
-import "net/http"
+import (
+	"net/http"
+	"os"
+	"strings"
+)
 
 type SourceRegistry struct {
 	Sources []SourceStatus `json:"sources"`
@@ -57,7 +61,7 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 				Priority:         source.Priority,
 				Capabilities:     capabilitiesForSourceKind(source.Kind),
 				Namespaces:       safeList(source.Namespaces),
-				State:            "ready",
+				State:            sourceRegistryState(source),
 				AffectedRefs:     []string{},
 				AffectedServices: []string{},
 			}
@@ -70,9 +74,22 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 	return SourceRegistry{Sources: sources}
 }
 
+func sourceRegistryState(source sourceConfig) string {
+	switch source.Kind {
+	case "vault", "openbao":
+		if strings.TrimSpace(source.Address) == "" {
+			return "invalid_ref"
+		}
+		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
+			return "source_auth_required"
+		}
+	}
+	return "ready"
+}
+
 func capabilitiesForSourceKind(kind string) []string {
 	switch kind {
-	case "env", "file", "exec":
+	case "env", "file", "exec", "vault", "openbao":
 		return []string{"read", "health"}
 	default:
 		return []string{"health"}

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -24,6 +24,24 @@ func TestDefaultSourceRegistryReflectsLocalKeyState(t *testing.T) {
 	}
 }
 
+func TestSourceRegistryMapsVaultAuthStateWithoutTokenLeak(t *testing.T) {
+	backend := newLocalBackend("store.json", "audit.jsonl", "master-key")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{
+		{SourceID: "vault-prod", Kind: "vault", DisplayName: "Vault prod", Enabled: true, Address: "https://vault.example.com", TokenEnv: "MISSING_VAULT_TOKEN", Namespaces: []string{"prod/*"}},
+	}}
+
+	registry := defaultSourceRegistry(backend)
+	if len(registry.Sources) != 2 {
+		t.Fatalf("sources = %#v", registry.Sources)
+	}
+	vault := registry.Sources[1]
+	if vault.SourceID != "vault-prod" || vault.State != "source_auth_required" {
+		t.Fatalf("vault source = %#v", vault)
+	}
+	assertContains(t, vault.Capabilities, "read")
+	assertContains(t, vault.Namespaces, "prod/*")
+}
+
 func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {
 	backend := newLocalBackend("store.json", "audit.jsonl", "master-key")
 	state := "ready"

--- a/cmd/secretsbroker/vault_source_test.go
+++ b/cmd/secretsbroker/vault_source_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVaultSourceAdapterKVv2(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"data":{"api_key":"vault-secret"}}}`)
+	}))
+	defer server.Close()
+
+	cfg := sourceConfigFile{Sources: []sourceConfig{{SourceID: "vault-prod", Kind: "vault", Enabled: true, Address: server.URL, Token: "test-token", Refs: map[string]sourceRefConfig{"prod/openclaw/api_key": {Path: "secret/data/openclaw", Field: "api_key"}}}}}
+	res := cfg.resolve("prod/openclaw/api_key")
+	if res.Outcome != "ready" || res.Value != "vault-secret" || res.SourceID != "vault-prod" {
+		t.Fatalf("vault result = %#v", res)
+	}
+}
+
+func TestVaultSourceAdapterStatusMapping(t *testing.T) {
+	tests := []struct {
+		status  int
+		body    string
+		outcome string
+	}{
+		{status: http.StatusUnauthorized, outcome: "source_auth_required"},
+		{status: http.StatusForbidden, outcome: "policy_denied"},
+		{status: http.StatusNotFound, outcome: "missing_ref"},
+		{status: http.StatusServiceUnavailable, body: `{"sealed":true}`, outcome: "locked"},
+		{status: http.StatusInternalServerError, outcome: "source_unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+			source := sourceConfig{SourceID: "vault", Kind: "openbao", Enabled: true, Address: server.URL, Token: "token"}
+			res := source.resolve("ref", sourceRefConfig{Path: "secret/data/ref", Field: "value"})
+			if res.Outcome != tt.outcome {
+				t.Fatalf("outcome = %#v", res)
+			}
+		})
+	}
+}
+
+func TestVaultSourceMissingTokenRequiresAuth(t *testing.T) {
+	source := sourceConfig{SourceID: "vault", Kind: "vault", Address: "https://vault.invalid"}
+	res := source.resolve("ref", sourceRefConfig{Path: "secret/data/ref", Field: "value"})
+	if res.Outcome != "source_auth_required" {
+		t.Fatalf("outcome = %#v", res)
+	}
+}
+
+func TestVaultSourceUsesTokenEnv(t *testing.T) {
+	t.Setenv("VAULT_TEST_TOKEN", "env-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "env-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"api_key":"flat-secret"}}`)
+	}))
+	defer server.Close()
+
+	source := sourceConfig{SourceID: "vault", Kind: "vault", Address: server.URL, TokenEnv: "VAULT_TEST_TOKEN"}
+	res := source.resolve("ref", sourceRefConfig{Path: "secret/data/ref", Field: "api_key"})
+	if res.Outcome != "ready" || res.Value != "flat-secret" {
+		t.Fatalf("result = %#v", res)
+	}
+}

--- a/docs/vault-openbao-source.md
+++ b/docs/vault-openbao-source.md
@@ -1,0 +1,100 @@
+# Vault and OpenBao Source Adapter
+
+Status: read-only MVP  
+Issue: #6
+
+## Purpose
+
+Clustered/enterprise deployments may keep secret material in HashiCorp Vault or OpenBao while preserving the stable Service Lasso-facing broker contract:
+
+```text
+Service Lasso -> @secretsbroker -> Vault/OpenBao cluster
+```
+
+## Source config
+
+Vault/OpenBao sources use the same `SECRETSBROKER_SOURCES_PATH` config as env/file/exec sources.
+
+Example:
+
+```json
+{
+  "sources": [
+    {
+      "sourceId": "vault-prod",
+      "kind": "vault",
+      "displayName": "Vault prod",
+      "enabled": true,
+      "critical": false,
+      "priority": 50,
+      "namespaces": ["prod/*"],
+      "address": "https://vault.example.com",
+      "tokenEnv": "VAULT_TOKEN",
+      "refs": {
+        "prod/openclaw/anthropic_api_key": {
+          "path": "secret/data/openclaw/anthropic",
+          "field": "api_key"
+        }
+      }
+    }
+  ]
+}
+```
+
+OpenBao uses the same API shape for this MVP:
+
+```json
+{ "kind": "openbao" }
+```
+
+## Auth and backend state mapping
+
+- no token/token env missing -> `source_auth_required`
+- configured source without an address -> `invalid_ref` in source status
+- HTTP 401/403 -> `source_auth_required` or `policy_denied`
+- HTTP 404 -> `missing_ref`
+- sealed response body (`{"sealed":true}` on a non-2xx response) -> `locked`
+- unreachable/5xx without sealed evidence -> `source_unavailable`
+- successful value -> `ready`
+
+`GET /v1/sources/status` reports configured Vault/OpenBao sources without returning tokens. It performs local config/auth-state classification only; it does not poll external clusters on every status request.
+
+## KV response shape
+
+The MVP supports common KV v2 response shape:
+
+```json
+{
+  "data": {
+    "data": {
+      "api_key": "value"
+    }
+  }
+}
+```
+
+It also accepts a flat `data` object for lightweight OpenBao/Vault-compatible test doubles:
+
+```json
+{
+  "data": {
+    "api_key": "value"
+  }
+}
+```
+
+## Security notes
+
+- tokens are read from env or explicit source token only
+- tokens are not returned by status/capabilities/source status
+- resolved secret values are returned only through authenticated `POST /v1/resolve`
+- audit records include ref/source/outcome only
+
+## Out of scope
+
+- Vault login methods
+- token renewal/revoke
+- lease handling
+- write-back
+- namespace auto-discovery
+- Service Admin reconnect UX


### PR DESCRIPTION
## Summary
- adds read-only Vault/OpenBao source adapter support behind `@secretsbroker`
- supports explicit ref mappings to Vault/OpenBao paths and fields
- supports token auth from source config or `tokenEnv`
- maps backend states to broker outcomes: `source_auth_required`, `policy_denied`, `missing_ref`, `locked`, `source_unavailable`, `ready`
- exposes Vault/OpenBao source capabilities/status without leaking tokens
- documents the MVP source config, KV response shapes, state mapping, and out-of-scope areas

## Validation
- `go test ./...`
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- `pwsh -NoLogo -NoProfile -File .\scripts\verify.ps1` with `SERVICE_LASSO_HARNESS_BIN=C:\projects\service-lasso\service-lasso-harness\service-lasso-harness.exe`
- `git diff --check`

Closes #6.