### PR TITLE
ISS-9 add generated secret write-back capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The first bootstrap slice provides:
   - `GET /state`
   - `GET /capabilities`
   - `POST /v1/secrets`
+  - `POST /v1/writeback`
   - `POST /v1/resolve`
   - `GET /v1/sources/status`
 - CLI-style commands:
@@ -54,7 +55,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. OS wrapper enrollment, policy, and write-back implementations are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -23,9 +23,13 @@ const (
 )
 
 var (
-	errLocked     = errors.New("secrets broker store is locked")
-	errMissingRef = errors.New("secret ref was not found")
-	errInvalidRef = errors.New("invalid secret ref")
+	errLocked             = errors.New("secrets broker store is locked")
+	errMissingRef         = errors.New("secret ref was not found")
+	errInvalidRef         = errors.New("invalid secret ref")
+	errPolicyDenied       = errors.New("write-back policy denied")
+	errIdentityExpired    = errors.New("launch identity expired")
+	errSourceAuthRequired = errors.New("source authentication required")
+	errBackendDegraded    = errors.New("backend degraded")
 )
 
 type localBackend struct {
@@ -77,6 +81,46 @@ type writeSecretResponse struct {
 	Ref        string         `json:"ref"`
 	Outcome    string         `json:"outcome"`
 	Metadata   SecretMetadata `json:"metadata"`
+}
+
+type writebackPolicy struct {
+	AllowedNamespaces []string `json:"allowedNamespaces"`
+	AllowedOperations []string `json:"allowedOperations"`
+}
+
+type writebackIdentity struct {
+	ServiceID string `json:"serviceId"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+type generatedSecretCaptureRequest struct {
+	RequestID          string            `json:"requestId"`
+	Identity           writebackIdentity `json:"identity"`
+	Policy             writebackPolicy   `json:"policy"`
+	Operation          string            `json:"operation"`
+	Namespace          string            `json:"namespace"`
+	Ref                string            `json:"ref"`
+	Value              string            `json:"value"`
+	Metadata           map[string]string `json:"metadata"`
+	RefreshRequired    bool              `json:"refreshRequired"`
+	ReconnectRequired  bool              `json:"reconnectRequired"`
+	InvalidateRefs     []string          `json:"invalidateRefs"`
+	SourceAuthRequired bool              `json:"sourceAuthRequired"`
+}
+
+type generatedSecretCaptureResponse struct {
+	ServiceID         string         `json:"serviceId"`
+	APIVersion        string         `json:"apiVersion"`
+	RequestID         string         `json:"requestId,omitempty"`
+	OwnerServiceID    string         `json:"ownerServiceId"`
+	Operation         string         `json:"operation"`
+	Namespace         string         `json:"namespace"`
+	Ref               string         `json:"ref"`
+	Outcome           string         `json:"outcome"`
+	RefreshRequired   bool           `json:"refreshRequired"`
+	ReconnectRequired bool           `json:"reconnectRequired"`
+	InvalidatedRefs   []string       `json:"invalidatedRefs"`
+	Metadata          SecretMetadata `json:"metadata,omitempty"`
 }
 
 type resolveRequest struct {
@@ -174,6 +218,134 @@ func (b *localBackend) writeSecret(req writeSecretRequest) (writeSecretResponse,
 	}
 	_ = b.audit("write", ref, "ready", "", "")
 	return writeSecretResponse{ServiceID: serviceID, APIVersion: apiVersion, Ref: ref, Outcome: "ready", Metadata: metadata}, nil
+}
+
+func normalizeWritebackOperation(operation string) string {
+	operation = strings.TrimSpace(operation)
+	if operation == "" {
+		return "create"
+	}
+	return operation
+}
+
+func validWritebackOperation(operation string) bool {
+	switch operation {
+	case "create", "update", "rotate", "delete":
+		return true
+	default:
+		return false
+	}
+}
+
+func namespaceAllowed(namespace string, allowed []string) bool {
+	for _, candidate := range allowed {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func operationAllowed(operation string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if strings.TrimSpace(candidate) == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *localBackend) captureGeneratedSecret(req generatedSecretCaptureRequest) (generatedSecretCaptureResponse, error) {
+	operation := normalizeWritebackOperation(req.Operation)
+	namespace := strings.TrimSpace(req.Namespace)
+	ref := strings.Trim(strings.TrimSpace(req.Ref), "/")
+	fullRef := strings.Trim(namespace+"/"+ref, "/")
+	service := strings.TrimSpace(req.Identity.ServiceID)
+	response := generatedSecretCaptureResponse{
+		ServiceID:         serviceID,
+		APIVersion:        apiVersion,
+		RequestID:         req.RequestID,
+		OwnerServiceID:    service,
+		Operation:         operation,
+		Namespace:         namespace,
+		Ref:               fullRef,
+		RefreshRequired:   req.RefreshRequired,
+		ReconnectRequired: req.ReconnectRequired,
+		InvalidatedRefs:   safeList(req.InvalidateRefs),
+	}
+
+	if namespace == "" || !validSecretRef(namespace) || ref == "" || !validSecretRef(fullRef) || !validWritebackOperation(operation) {
+		_ = b.audit("writeback_capture", fullRef, "invalid_ref", service, req.RequestID)
+		response.Outcome = "invalid_ref"
+		return response, errInvalidRef
+	}
+	if service == "" {
+		_ = b.audit("writeback_capture", fullRef, "identity_expired", service, req.RequestID)
+		response.Outcome = "identity_expired"
+		return response, errIdentityExpired
+	}
+	if strings.TrimSpace(req.Identity.ExpiresAt) != "" {
+		expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(req.Identity.ExpiresAt))
+		if err != nil || !expiresAt.After(b.now()) {
+			_ = b.audit("writeback_capture", fullRef, "identity_expired", service, req.RequestID)
+			response.Outcome = "identity_expired"
+			return response, errIdentityExpired
+		}
+	}
+	if !namespaceAllowed(namespace, req.Policy.AllowedNamespaces) || !operationAllowed(operation, req.Policy.AllowedOperations) {
+		_ = b.audit("writeback_capture", fullRef, "policy_denied", service, req.RequestID)
+		response.Outcome = "policy_denied"
+		return response, errPolicyDenied
+	}
+	if req.SourceAuthRequired {
+		_ = b.audit("writeback_capture", fullRef, "source_auth_required", service, req.RequestID)
+		response.Outcome = "source_auth_required"
+		return response, errSourceAuthRequired
+	}
+	if b.locked() {
+		_ = b.audit("writeback_capture", fullRef, "locked", service, req.RequestID)
+		response.Outcome = "locked"
+		return response, errLocked
+	}
+	if operation == "delete" {
+		store, err := b.loadStore()
+		if err != nil {
+			_ = b.audit("writeback_capture", fullRef, "degraded", service, req.RequestID)
+			response.Outcome = "degraded"
+			return response, errBackendDegraded
+		}
+		delete(store.Secrets, fullRef)
+		store.UpdatedAt = b.now()
+		if err := b.saveStore(store); err != nil {
+			_ = b.audit("writeback_capture", fullRef, "degraded", service, req.RequestID)
+			response.Outcome = "degraded"
+			return response, errBackendDegraded
+		}
+		_ = b.audit("writeback_capture", fullRef, "ready", service, req.RequestID)
+		response.Outcome = "ready"
+		return response, nil
+	}
+
+	metadata := map[string]string{"sourceId": firstNonEmpty(req.Metadata["sourceId"], "generated:"+service)}
+	written, err := b.writeSecret(writeSecretRequest{Ref: fullRef, Value: req.Value, Metadata: metadata})
+	if err != nil {
+		if errors.Is(err, errLocked) {
+			response.Outcome = "locked"
+			return response, err
+		}
+		if errors.Is(err, errInvalidRef) {
+			response.Outcome = "invalid_ref"
+			return response, err
+		}
+		_ = b.audit("writeback_capture", fullRef, "degraded", service, req.RequestID)
+		response.Outcome = "degraded"
+		return response, errBackendDegraded
+	}
+	_ = b.audit("writeback_capture", fullRef, "ready", service, req.RequestID)
+	response.Outcome = "ready"
+	response.Metadata = written.Metadata
+	return response, nil
 }
 
 func (b *localBackend) resolve(req resolveRequest) resolveResponse {
@@ -360,6 +532,38 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			writeAPIError(w, http.StatusServiceUnavailable, "locked", "Secrets Broker local store is locked.", "locked", "unlock_broker")
 		default:
 			writeAPIError(w, http.StatusInternalServerError, "store_error", "Local store write failed.", "degraded", "inspect_sources")
+		}
+	})
+
+	mux.HandleFunc("/v1/writeback", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/writeback.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req generatedSecretCaptureRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+			return
+		}
+		res, err := backend.captureGeneratedSecret(req)
+		switch {
+		case err == nil:
+			writeJSON(w, http.StatusOK, res)
+		case errors.Is(err, errInvalidRef):
+			writeAPIError(w, http.StatusBadRequest, "invalid_ref", "Generated secret write-back ref is invalid.", "invalid_ref", "")
+		case errors.Is(err, errIdentityExpired):
+			writeAPIError(w, http.StatusUnauthorized, "identity_expired", "Launch identity is missing, invalid, or expired.", "identity_expired", "renew_launch_identity")
+		case errors.Is(err, errPolicyDenied):
+			writeAPIError(w, http.StatusForbidden, "policy_denied", "Write-back policy denied this generated secret capture.", "policy_denied", "review_policy")
+		case errors.Is(err, errSourceAuthRequired):
+			writeAPIError(w, http.StatusFailedDependency, "source_auth_required", "Source authentication is required before write-back can proceed.", "source_auth_required", "reconnect_source")
+		case errors.Is(err, errLocked):
+			writeAPIError(w, http.StatusServiceUnavailable, "locked", "Secrets Broker local store is locked.", "locked", "unlock_broker")
+		default:
+			writeAPIError(w, http.StatusServiceUnavailable, "degraded", "Write-back backend is degraded.", "degraded", "inspect_sources")
 		}
 	})
 

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -8,6 +8,36 @@ import (
 	"testing"
 )
 
+func TestHTTPGeneratedSecretWritebackCapture(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-writeback-http","identity":{"serviceId":"api-service","expiresAt":"2026-05-07T00:05:00Z"},"policy":{"allowedNamespaces":["services/api-service"],"allowedOperations":["create","update"]},"operation":"create","namespace":"services/api-service","ref":"runtime/API_TOKEN","value":"generated-http-secret","refreshRequired":true}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/writeback", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("writeback status = %d", res.StatusCode)
+	}
+	var captured generatedSecretCaptureResponse
+	if err := json.NewDecoder(res.Body).Decode(&captured); err != nil {
+		t.Fatal(err)
+	}
+	if captured.Outcome != "ready" || !captured.RefreshRequired || captured.Ref != "services/api-service/runtime/API_TOKEN" {
+		t.Fatalf("writeback response = %#v", captured)
+	}
+}
+
 func TestLocalStoreHTTPWriteAndResolve(t *testing.T) {
 	backend := testBackend(t)
 	state := "ready"

--- a/cmd/secretsbroker/local_store_test.go
+++ b/cmd/secretsbroker/local_store_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,108 @@ func TestLocalBackendResolveBatchOutcomes(t *testing.T) {
 		if !strings.Contains(string(auditBytes), want) {
 			t.Fatalf("audit missing %q: %s", want, string(auditBytes))
 		}
+	}
+}
+
+func TestGeneratedSecretCaptureEnforcesWritebackPolicyAndRedactsAudit(t *testing.T) {
+	backend := testBackend(t)
+	res, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID:         "req-writeback-1",
+		Identity:          writebackIdentity{ServiceID: "api-service", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:            writebackPolicy{AllowedNamespaces: []string{"services/api-service"}, AllowedOperations: []string{"create", "update", "rotate"}},
+		Operation:         "create",
+		Namespace:         "services/api-service",
+		Ref:               "runtime/API_TOKEN",
+		Value:             "generated-secret-value",
+		RefreshRequired:   true,
+		ReconnectRequired: true,
+		InvalidateRefs:    []string{"services/api-service/runtime/API_TOKEN"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "ready" || res.Ref != "services/api-service/runtime/API_TOKEN" {
+		t.Fatalf("capture response = %#v", res)
+	}
+	resolved := backend.resolve(resolveRequest{ServiceID: "api-service", Refs: []string{"services/api-service/runtime/API_TOKEN"}})
+	if resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "generated-secret-value" {
+		t.Fatalf("resolved generated secret = %#v", resolved.Results[0])
+	}
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(auditBytes), "generated-secret-value") {
+		t.Fatalf("audit contains plaintext generated secret: %s", string(auditBytes))
+	}
+	for _, want := range []string{"writeback_capture", "api-service", "ready"} {
+		if !strings.Contains(string(auditBytes), want) {
+			t.Fatalf("audit missing %q: %s", want, string(auditBytes))
+		}
+	}
+}
+
+func TestGeneratedSecretCaptureDistinctFailureOutcomes(t *testing.T) {
+	tests := []struct {
+		name        string
+		backend     func(t *testing.T) *localBackend
+		req         generatedSecretCaptureRequest
+		wantErr     error
+		wantOutcome string
+	}{
+		{
+			name:        "policy denied",
+			backend:     testBackend,
+			req:         generatedSecretCaptureRequest{Identity: writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"}, Policy: writebackPolicy{AllowedNamespaces: []string{"other"}, AllowedOperations: []string{"create"}}, Operation: "create", Namespace: "services/api", Ref: "runtime/token", Value: "secret"},
+			wantErr:     errPolicyDenied,
+			wantOutcome: "policy_denied",
+		},
+		{
+			name:        "expired identity",
+			backend:     testBackend,
+			req:         generatedSecretCaptureRequest{Identity: writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-06T23:59:00Z"}, Policy: writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}}, Operation: "create", Namespace: "services/api", Ref: "runtime/token", Value: "secret"},
+			wantErr:     errIdentityExpired,
+			wantOutcome: "identity_expired",
+		},
+		{
+			name:        "locked broker",
+			backend:     func(t *testing.T) *localBackend { b := testBackend(t); b.masterKey = ""; return b },
+			req:         generatedSecretCaptureRequest{Identity: writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"}, Policy: writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}}, Operation: "create", Namespace: "services/api", Ref: "runtime/token", Value: "secret"},
+			wantErr:     errLocked,
+			wantOutcome: "locked",
+		},
+		{
+			name:        "source auth required",
+			backend:     testBackend,
+			req:         generatedSecretCaptureRequest{Identity: writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"}, Policy: writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}}, Operation: "create", Namespace: "services/api", Ref: "runtime/token", Value: "secret", SourceAuthRequired: true},
+			wantErr:     errSourceAuthRequired,
+			wantOutcome: "source_auth_required",
+		},
+		{
+			name: "degraded backend",
+			backend: func(t *testing.T) *localBackend {
+				b := testBackend(t)
+				if err := os.MkdirAll(b.storePath, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				return b
+			},
+			req:         generatedSecretCaptureRequest{Identity: writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"}, Policy: writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}}, Operation: "create", Namespace: "services/api", Ref: "runtime/token", Value: "secret"},
+			wantErr:     errBackendDegraded,
+			wantOutcome: "degraded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.backend(t).captureGeneratedSecret(tt.req)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if res.Outcome != tt.wantOutcome {
+				t.Fatalf("outcome = %q, want %q", res.Outcome, tt.wantOutcome)
+			}
+		})
 	}
 }
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -213,6 +213,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /state",
 			"GET /capabilities",
 			"POST /v1/secrets",
+			"POST /v1/writeback",
 			"POST /v1/resolve",
 			"GET /v1/sources/status",
 		},
@@ -230,9 +231,11 @@ func defaultCapabilities() CapabilitiesResponse {
 			"env-source",
 			"file-source",
 			"exec-source",
+			"write-back-policy",
+			"generated-secret-capture",
 		},
 		FutureFeatures: []string{
-			"write-back",
+			"external-backend-write-back",
 		},
 		Outcomes: append([]string(nil), typedOutcomes...),
 	}

--- a/docs/writeback-policy.md
+++ b/docs/writeback-policy.md
@@ -1,0 +1,95 @@
+# Write-back policy and generated secret capture
+
+_Status: initial bounded contract implemented for issue #9._
+
+`@secretsbroker` accepts generated or refreshed secrets through `POST /v1/writeback` only when the caller presents an explicit launch identity and write-back policy.
+
+## Endpoint
+
+```http
+POST /v1/writeback
+Authorization: Bearer <local-api-token>
+Content-Type: application/json
+```
+
+Request shape:
+
+```json
+{
+  "requestId": "req-123",
+  "identity": {
+    "serviceId": "api-service",
+    "expiresAt": "2026-05-07T00:05:00Z"
+  },
+  "policy": {
+    "allowedNamespaces": ["services/api-service"],
+    "allowedOperations": ["create", "update", "rotate"]
+  },
+  "operation": "create",
+  "namespace": "services/api-service",
+  "ref": "runtime/API_TOKEN",
+  "value": "<generated secret value>",
+  "refreshRequired": true,
+  "reconnectRequired": true,
+  "invalidateRefs": ["services/api-service/runtime/API_TOKEN"]
+}
+```
+
+Response shape:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "req-123",
+  "ownerServiceId": "api-service",
+  "operation": "create",
+  "namespace": "services/api-service",
+  "ref": "services/api-service/runtime/API_TOKEN",
+  "outcome": "ready",
+  "refreshRequired": true,
+  "reconnectRequired": true,
+  "invalidatedRefs": ["services/api-service/runtime/API_TOKEN"],
+  "metadata": {
+    "sourceId": "generated:api-service",
+    "version": "<timestamp>",
+    "createdAt": "<timestamp>",
+    "updatedAt": "<timestamp>"
+  }
+}
+```
+
+## Policy model
+
+- `identity.serviceId` scopes ownership and audit attribution.
+- `identity.expiresAt` is optional in local bootstrap mode, but when present it must be a future RFC3339 timestamp.
+- `policy.allowedNamespaces` must include the requested namespace, or `*`.
+- `policy.allowedOperations` must include the requested operation.
+- Supported operations are `create`, `update`, `rotate`, and `delete`.
+- The stored secret ref is `namespace/ref`; the payload is encrypted in the local store.
+
+This first slice keeps policy explicit in the capture request so Service Lasso can pass a scoped launch-time grant. Later policy storage can move the grants into durable broker-owned config without changing the outcome vocabulary.
+
+## Outcomes
+
+`POST /v1/writeback` returns typed outcomes without exposing secret payload values:
+
+- `ready`: capture succeeded.
+- `invalid_ref`: namespace/ref/operation shape is malformed.
+- `identity_expired`: launch identity is missing, invalid, or expired.
+- `policy_denied`: namespace or operation is outside the supplied grant.
+- `locked`: local broker store is locked.
+- `source_auth_required`: source/backend authentication must be reconnected before write-back.
+- `degraded`: backend/store write path is degraded.
+
+## Refresh, invalidation, and reconnect semantics
+
+The capture API echoes these caller-supplied control hints for Service Lasso/operator clients:
+
+- `refreshRequired`: consumers should refresh materialized env/config using the captured value.
+- `reconnectRequired`: the generating service or dependent clients may need reconnect/restart after capture.
+- `invalidateRefs`: specific refs whose cached/materialized values should be invalidated.
+
+## Audit redaction
+
+Every write-back attempt records an audit event with operation, ref, outcome, request id, and service id. Secret payload values are never written to audit JSONL.


### PR DESCRIPTION
## Summary
- add `POST /v1/writeback` generated secret capture endpoint
- enforce service identity expiry plus namespace/operation write-back policy before storing generated secrets
- return distinct outcomes for policy denied, expired identity, locked broker, source auth required, degraded backend, and invalid refs
- audit write-back attempts without secret payload values
- document write-back policy/capture semantics and expose capability metadata

## Validation
- PASS: `go test ./...`
- PASS: `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS: `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS: `git diff --check`

Issue: #9
