### PR TITLE
ISS-8 add OpenClaw SecretRef resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The first bootstrap slice provides:
   - `GET /v1/sources/status`
 - CLI-style commands:
   - `secretsbroker serve`
+  - `secretsbroker-resolve`
   - `secretsbroker status`
   - `secretsbroker key status`
   - `secretsbroker key generate`
@@ -55,7 +56,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker-resolve/main.go
+++ b/cmd/secretsbroker-resolve/main.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	protocolVersion = 1
+	providerName    = "service-lasso-secretsbroker"
+	apiVersion      = "secretsbroker.local/v1"
+)
+
+type execSecretRequest struct {
+	ProtocolVersion int      `json:"protocolVersion"`
+	Provider        string   `json:"provider"`
+	IDs             []string `json:"ids"`
+}
+
+type execSecretResponse struct {
+	ProtocolVersion int               `json:"protocolVersion"`
+	Values          map[string]string `json:"values,omitempty"`
+	Errors          map[string]string `json:"errors,omitempty"`
+	Error           string            `json:"error,omitempty"`
+	Outcome         string            `json:"outcome,omitempty"`
+}
+
+type brokerResolveRequest struct {
+	RequestID string   `json:"requestId"`
+	ServiceID string   `json:"serviceId"`
+	Purpose   string   `json:"purpose"`
+	Refs      []string `json:"refs"`
+}
+
+type brokerResolveResponse struct {
+	ServiceID  string                `json:"serviceId"`
+	APIVersion string                `json:"apiVersion"`
+	RequestID  string                `json:"requestId,omitempty"`
+	Results    []brokerResolveResult `json:"results"`
+}
+
+type brokerResolveResult struct {
+	Ref     string `json:"ref"`
+	Outcome string `json:"outcome"`
+	Value   string `json:"value,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type brokerErrorEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		Message    string `json:"message"`
+		Outcome    string `json:"outcome"`
+		NextAction string `json:"nextAction,omitempty"`
+	} `json:"error"`
+}
+
+type resolverConfig struct {
+	BrokerURL string
+	Token     string
+	Policy    []string
+	Timeout   time.Duration
+	Stdin     io.Reader
+	Stdout    io.Writer
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("secretsbroker-resolve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	brokerURL := fs.String("broker-url", getenvDefault("SECRETSBROKER_URL", "http://127.0.0.1:17890"), "local @secretsbroker URL")
+	token := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "local API token")
+	tokenFile := fs.String("api-token-file", getenvDefault("SECRETSBROKER_API_TOKEN_FILE", ""), "file containing local API token")
+	policy := fs.String("allow", getenvDefault("SECRETSBROKER_RESOLVE_ALLOW", "openclaw/*"), "comma-separated allowed SecretRef prefixes")
+	timeoutMs := fs.Int("timeout-ms", 3000, "broker request timeout in milliseconds")
+	if err := fs.Parse(args); err != nil {
+		writeProtocolError(stdout, "invalid_request", "invalid resolver flags")
+		return err
+	}
+	resolvedToken := strings.TrimSpace(*token)
+	if resolvedToken == "" && strings.TrimSpace(*tokenFile) != "" {
+		bytes, err := os.ReadFile(strings.TrimSpace(*tokenFile))
+		if err != nil {
+			writeProtocolError(stdout, "policy_denied", "local API token file could not be read")
+			return err
+		}
+		resolvedToken = strings.TrimSpace(string(bytes))
+	}
+	cfg := resolverConfig{BrokerURL: *brokerURL, Token: resolvedToken, Policy: splitCSV(*policy), Timeout: time.Duration(*timeoutMs) * time.Millisecond, Stdin: stdin, Stdout: stdout}
+	return resolveFromBroker(cfg)
+}
+
+func resolveFromBroker(cfg resolverConfig) error {
+	var req execSecretRequest
+	if err := json.NewDecoder(cfg.Stdin).Decode(&req); err != nil {
+		writeProtocolError(cfg.Stdout, "invalid_request", "request body is not valid JSON")
+		return err
+	}
+	if req.ProtocolVersion != protocolVersion || req.Provider != providerName {
+		writeProtocolError(cfg.Stdout, "invalid_request", "unsupported SecretRef exec provider request")
+		return errors.New("unsupported request")
+	}
+	if len(req.IDs) == 0 {
+		return writeProtocolResponse(cfg.Stdout, execSecretResponse{ProtocolVersion: protocolVersion, Values: map[string]string{}})
+	}
+	for _, id := range req.IDs {
+		if !allowedRef(id, cfg.Policy) {
+			writeRefError(cfg.Stdout, req.IDs, id, "policy_denied")
+			return errors.New("policy denied")
+		}
+	}
+	if strings.TrimSpace(cfg.Token) == "" {
+		writeProtocolError(cfg.Stdout, "policy_denied", "local API token is not configured")
+		return errors.New("missing local api token")
+	}
+
+	body, err := json.Marshal(brokerResolveRequest{RequestID: "openclaw-secretref", ServiceID: "openclaw", Purpose: "secretref-exec-provider", Refs: req.IDs})
+	if err != nil {
+		writeProtocolError(cfg.Stdout, "degraded", "request could not be encoded")
+		return err
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, strings.TrimRight(cfg.BrokerURL, "/")+"/v1/resolve", bytes.NewReader(body))
+	if err != nil {
+		writeProtocolError(cfg.Stdout, "degraded", "broker URL is invalid")
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+cfg.Token)
+	client := http.Client{Timeout: cfg.Timeout}
+	res, err := client.Do(httpReq)
+	if err != nil {
+		writeProtocolError(cfg.Stdout, "degraded", "local @secretsbroker is unavailable")
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		outcome := brokerHTTPOutcome(res.Body)
+		writeProtocolError(cfg.Stdout, outcome, "local @secretsbroker returned "+outcome)
+		return errors.New(outcome)
+	}
+	var broker brokerResolveResponse
+	if err := json.NewDecoder(res.Body).Decode(&broker); err != nil {
+		writeProtocolError(cfg.Stdout, "degraded", "broker response was not valid JSON")
+		return err
+	}
+	values := map[string]string{}
+	errorsByRef := map[string]string{}
+	for _, result := range broker.Results {
+		if result.Outcome == "ready" {
+			values[result.Ref] = result.Value
+		} else {
+			errorsByRef[result.Ref] = normalizeOutcome(result.Outcome)
+		}
+	}
+	if len(errorsByRef) > 0 {
+		return writeProtocolResponse(cfg.Stdout, execSecretResponse{ProtocolVersion: protocolVersion, Values: values, Errors: errorsByRef, Outcome: firstOutcome(errorsByRef)})
+	}
+	return writeProtocolResponse(cfg.Stdout, execSecretResponse{ProtocolVersion: protocolVersion, Values: values})
+}
+
+func allowedRef(ref string, allowed []string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.ContainsAny(ref, " \t\r\n") || strings.Contains(ref, "..") {
+		return false
+	}
+	for _, pattern := range allowed {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if pattern == "*" || ref == pattern {
+			return true
+		}
+		if strings.HasSuffix(pattern, "/*") && strings.HasPrefix(ref, strings.TrimSuffix(pattern, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+func brokerHTTPOutcome(body io.Reader) string {
+	var envelope brokerErrorEnvelope
+	if err := json.NewDecoder(io.LimitReader(body, 65536)).Decode(&envelope); err == nil {
+		return normalizeOutcome(firstNonEmpty(envelope.Error.Outcome, envelope.Error.Code))
+	}
+	return "degraded"
+}
+
+func normalizeOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "locked", "missing_ref", "policy_denied", "source_auth_required", "degraded":
+		return strings.TrimSpace(outcome)
+	case "source_unavailable":
+		return "degraded"
+	default:
+		return "degraded"
+	}
+}
+
+func firstOutcome(errorsByRef map[string]string) string {
+	for _, outcome := range errorsByRef {
+		return outcome
+	}
+	return ""
+}
+
+func writeRefError(w io.Writer, ids []string, ref string, outcome string) {
+	errorsByRef := map[string]string{}
+	for _, id := range ids {
+		if id == ref {
+			errorsByRef[id] = outcome
+		}
+	}
+	_ = writeProtocolResponse(w, execSecretResponse{ProtocolVersion: protocolVersion, Values: map[string]string{}, Errors: errorsByRef, Outcome: outcome})
+}
+
+func writeProtocolError(w io.Writer, outcome, message string) {
+	_ = writeProtocolResponse(w, execSecretResponse{ProtocolVersion: protocolVersion, Error: message, Outcome: normalizeOutcome(outcome)})
+}
+
+func writeProtocolResponse(w io.Writer, res execSecretResponse) error {
+	if res.Values == nil && res.Errors == nil && res.Error == "" {
+		res.Values = map[string]string{}
+	}
+	return json.NewEncoder(w).Encode(res)
+}
+
+func getenvDefault(name, fallback string) string {
+	if value := os.Getenv(name); strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}

--- a/cmd/secretsbroker-resolve/main_test.go
+++ b/cmd/secretsbroker-resolve/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSecretsbrokerResolveReturnsOpenClawExecProviderValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/resolve" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("authorization header = %q", r.Header.Get("Authorization"))
+		}
+		var req brokerResolveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if req.ServiceID != "openclaw" || req.Purpose != "secretref-exec-provider" {
+			t.Fatalf("broker request = %#v", req)
+		}
+		json.NewEncoder(w).Encode(brokerResolveResponse{ServiceID: "@secretsbroker", APIVersion: apiVersion, Results: []brokerResolveResult{{Ref: "openclaw/anthropic/api_key", Outcome: "ready", Value: "secret-value"}}})
+	}))
+	defer server.Close()
+
+	var out strings.Builder
+	err := resolveFromBroker(resolverConfig{BrokerURL: server.URL, Token: "test-token", Policy: []string{"openclaw/*"}, Timeout: time.Second, Stdin: strings.NewReader(`{"protocolVersion":1,"provider":"service-lasso-secretsbroker","ids":["openclaw/anthropic/api_key"]}`), Stdout: &out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res execSecretResponse
+	if err := json.Unmarshal([]byte(out.String()), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.ProtocolVersion != 1 || res.Values["openclaw/anthropic/api_key"] != "secret-value" {
+		t.Fatalf("response = %#v", res)
+	}
+	if strings.Contains(out.String(), "error") || strings.Contains(out.String(), "stderr") {
+		t.Fatalf("unexpected error protocol output: %s", out.String())
+	}
+}
+
+func TestSecretsbrokerResolveEnforcesOpenClawPolicyBeforeBrokerCall(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer server.Close()
+
+	var out strings.Builder
+	err := resolveFromBroker(resolverConfig{BrokerURL: server.URL, Token: "test-token", Policy: []string{"openclaw/*"}, Timeout: time.Second, Stdin: strings.NewReader(`{"protocolVersion":1,"provider":"service-lasso-secretsbroker","ids":["other/service_key"]}`), Stdout: &out})
+	if err == nil {
+		t.Fatal("expected policy error")
+	}
+	if called {
+		t.Fatal("broker was called for denied ref")
+	}
+	var res execSecretResponse
+	if err := json.Unmarshal([]byte(out.String()), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "policy_denied" || res.Errors["other/service_key"] != "policy_denied" || len(res.Values) != 0 {
+		t.Fatalf("response = %#v", res)
+	}
+}
+
+func TestSecretsbrokerResolveMapsTypedBrokerErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		result brokerResolveResult
+		want   string
+	}{
+		{name: "locked http error", status: http.StatusServiceUnavailable, body: `{"error":{"code":"locked","outcome":"locked"}}`, want: "locked"},
+		{name: "missing ref result", status: http.StatusOK, result: brokerResolveResult{Ref: "openclaw/missing", Outcome: "missing_ref"}, want: "missing_ref"},
+		{name: "source auth result", status: http.StatusOK, result: brokerResolveResult{Ref: "openclaw/token", Outcome: "source_auth_required"}, want: "source_auth_required"},
+		{name: "policy result", status: http.StatusOK, result: brokerResolveResult{Ref: "openclaw/token", Outcome: "policy_denied"}, want: "policy_denied"},
+		{name: "degraded result", status: http.StatusOK, result: brokerResolveResult{Ref: "openclaw/token", Outcome: "source_unavailable"}, want: "degraded"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				if tt.status == http.StatusOK {
+					json.NewEncoder(w).Encode(brokerResolveResponse{Results: []brokerResolveResult{tt.result}})
+					return
+				}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			var out strings.Builder
+			err := resolveFromBroker(resolverConfig{BrokerURL: server.URL, Token: "test-token", Policy: []string{"openclaw/*"}, Timeout: time.Second, Stdin: strings.NewReader(`{"protocolVersion":1,"provider":"service-lasso-secretsbroker","ids":["openclaw/token"]}`), Stdout: &out})
+			if tt.status != http.StatusOK && err == nil {
+				t.Fatal("expected http error")
+			}
+			var res execSecretResponse
+			if err := json.Unmarshal([]byte(out.String()), &res); err != nil {
+				t.Fatal(err)
+			}
+			if res.Outcome != tt.want {
+				t.Fatalf("outcome = %q, want %q, response %s", res.Outcome, tt.want, out.String())
+			}
+		})
+	}
+}

--- a/docs/openclaw-secretref-resolver.md
+++ b/docs/openclaw-secretref-resolver.md
@@ -1,0 +1,92 @@
+# OpenClaw SecretRef exec resolver
+
+_Status: initial bounded adapter contract implemented for issue #8._
+
+`secretsbroker-resolve` is a small command for OpenClaw's `exec` SecretRef provider. It lets OpenClaw resolve `openclaw/*` refs through local `@secretsbroker` without storing upstream provider API keys directly in OpenClaw env/config.
+
+## Command
+
+```text
+secretsbroker-resolve
+```
+
+The command reads one JSON request from stdin and writes one JSON response to stdout. It does not use stderr as a secret transport.
+
+OpenClaw exec provider request:
+
+```json
+{"protocolVersion":1,"provider":"service-lasso-secretsbroker","ids":["openclaw/anthropic/api_key"]}
+```
+
+Successful response:
+
+```json
+{"protocolVersion":1,"values":{"openclaw/anthropic/api_key":"...secret..."}}
+```
+
+Typed error response:
+
+```json
+{"protocolVersion":1,"values":{},"errors":{"openclaw/anthropic/api_key":"locked"},"outcome":"locked"}
+```
+
+Transport/setup errors use the same protocol envelope:
+
+```json
+{"protocolVersion":1,"error":"local @secretsbroker is unavailable","outcome":"degraded"}
+```
+
+## Local broker connection
+
+Defaults:
+
+- broker URL: `http://127.0.0.1:17890`
+- allowed refs: `openclaw/*`
+- timeout: `3000ms`
+
+Configuration options:
+
+```text
+--broker-url <url>       override local broker URL
+--api-token <token>      local broker API token
+--api-token-file <path>  file containing local broker API token
+--allow <patterns>       comma-separated allowlist, default openclaw/*
+--timeout-ms <ms>        broker request timeout
+```
+
+Equivalent env vars:
+
+- `SECRETSBROKER_URL`
+- `SECRETSBROKER_API_TOKEN`
+- `SECRETSBROKER_API_TOKEN_FILE`
+- `SECRETSBROKER_RESOLVE_ALLOW`
+
+The resolver authenticates to `POST /v1/resolve` using the local API token. The token identifies the local broker session; the resolver sends `serviceId: "openclaw"` and `purpose: "secretref-exec-provider"` in the broker resolve request for audit attribution.
+
+## Policy
+
+The resolver enforces an OpenClaw-scoped policy before contacting the broker.
+
+Default allowlist:
+
+```text
+openclaw/*
+```
+
+Denied refs produce `policy_denied` and are not sent to `@secretsbroker`.
+
+## Typed outcomes
+
+The resolver preserves or maps broker outcomes into OpenClaw-readable typed errors:
+
+- `locked`
+- `missing_ref`
+- `policy_denied`
+- `source_auth_required`
+- `degraded`
+
+`source_unavailable` is reported as `degraded` for the exec provider boundary.
+
+## Startup boundary
+
+`@secretsbroker` must be started independently by Service Lasso before OpenClaw uses `secretsbroker-resolve` for SecretRefs. This avoids a circular dependency where OpenClaw would need broker-backed secrets to start the broker itself.

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -14,6 +14,7 @@ try {
   $env:GOOS = 'windows'
   $env:GOARCH = 'amd64'
   go build -o (Join-Path $staging 'secretsbroker.exe') ./cmd/secretsbroker
+  go build -o (Join-Path $staging 'secretsbroker-resolve.exe') ./cmd/secretsbroker-resolve
 }
 finally {
   Pop-Location

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -19,11 +19,12 @@ mkdir -p "$STAGING"
 (
   cd "$ROOT"
   GOOS="$GOOS_VALUE" GOARCH=amd64 go build -o "$STAGING/secretsbroker" ./cmd/secretsbroker
+  GOOS="$GOOS_VALUE" GOARCH=amd64 go build -o "$STAGING/secretsbroker-resolve" ./cmd/secretsbroker-resolve
 )
 
 cp -R "$ROOT/config" "$STAGING/config"
 cp "$ROOT/service.json" "$STAGING/service.json"
-chmod +x "$STAGING/secretsbroker"
+chmod +x "$STAGING/secretsbroker" "$STAGING/secretsbroker-resolve"
 
 rm -f "$TAR_PATH"
 tar -czf "$TAR_PATH" -C "$STAGING" .

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -24,7 +24,9 @@ try {
   $tmp = Join-Path $root '.tmp\test'
   New-Item -ItemType Directory -Force -Path $tmp | Out-Null
   $exe = Join-Path $tmp 'secretsbroker.exe'
+  $resolverExe = Join-Path $tmp 'secretsbroker-resolve.exe'
   go build -o $exe ./cmd/secretsbroker
+  go build -o $resolverExe ./cmd/secretsbroker-resolve
 
   $status = & $exe status | ConvertFrom-Json
   if ($status.serviceId -ne '@secretsbroker') {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,6 +37,7 @@ go test ./...
 TMP="$ROOT/.tmp/test"
 mkdir -p "$TMP"
 go build -o "$TMP/secretsbroker" ./cmd/secretsbroker
+go build -o "$TMP/secretsbroker-resolve" ./cmd/secretsbroker-resolve
 
 STATUS_JSON="$($TMP/secretsbroker status)"
 STATUS_JSON="$STATUS_JSON" python3 - <<'PY'


### PR DESCRIPTION
## Summary
- add `secretsbroker-resolve` OpenClaw exec SecretRef adapter command
- implement stdin/stdout protocol for `service-lasso-secretsbroker` provider requests
- authenticate to local `@secretsbroker` with local API token and call `POST /v1/resolve`
- enforce default OpenClaw-scoped `openclaw/*` policy before contacting the broker
- return typed protocol errors for locked broker, missing refs, policy denied, source auth required, and degraded backend without stderr-as-secret behavior
- package/test the resolver binary alongside `secretsbroker`
- document setup, policy, typed outcomes, and startup boundary

## Validation
- PASS: `go test ./...`
- PASS: `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS: `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- PASS: inspected `dist/secretsbroker-win32.zip` includes `secretsbroker-resolve.exe`
- PASS: `git diff --check`
- SKIP: `scripts/verify.ps1` because `service-lasso-harness` was not on PATH and `SERVICE_LASSO_HARNESS_BIN` was not set locally

Issue: #8
