### PR TITLE
ISS-23 add backup restore rotation flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ The first bootstrap slice provides:
   - `secretsbroker status`
   - `secretsbroker key status`
   - `secretsbroker key generate`
+  - `secretsbroker key rotate`
+  - `secretsbroker backup create`
+  - `secretsbroker backup restore`
   - `secretsbroker session status`
   - `secretsbroker session generate`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`.
 
 ## Local development
 

--- a/cmd/secretsbroker/backup_restore.go
+++ b/cmd/secretsbroker/backup_restore.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const backupArtifactVersion = 1
+
+var (
+	errInvalidBackupArtifact = errors.New("invalid backup artifact")
+	errInvalidBackupKey      = errors.New("backup key material cannot decrypt artifact")
+	errMissingBackupPath     = errors.New("backup path is required")
+	errMissingNewMasterKey   = errors.New("new master key is required")
+)
+
+type backupArtifact struct {
+	Version         int            `json:"version"`
+	ServiceID       string         `json:"serviceId"`
+	APIVersion      string         `json:"apiVersion"`
+	CreatedAt       time.Time      `json:"createdAt"`
+	StoreKeyID      string         `json:"storeKeyId"`
+	StoreKeyVersion string         `json:"storeKeyVersion"`
+	SecretCount     int            `json:"secretCount"`
+	Store           localStoreFile `json:"store"`
+}
+
+type backupCreateResponse struct {
+	ServiceID       string    `json:"serviceId"`
+	APIVersion      string    `json:"apiVersion"`
+	Outcome         string    `json:"outcome"`
+	Path            string    `json:"path"`
+	CreatedAt       time.Time `json:"createdAt"`
+	StoreKeyID      string    `json:"storeKeyId"`
+	StoreKeyVersion string    `json:"storeKeyVersion"`
+	SecretCount     int       `json:"secretCount"`
+	Warning         string    `json:"warning"`
+}
+
+type backupRestoreResponse struct {
+	ServiceID       string    `json:"serviceId"`
+	APIVersion      string    `json:"apiVersion"`
+	Outcome         string    `json:"outcome"`
+	Path            string    `json:"path"`
+	RestoredAt      time.Time `json:"restoredAt"`
+	StoreKeyID      string    `json:"storeKeyId"`
+	StoreKeyVersion string    `json:"storeKeyVersion"`
+	SecretCount     int       `json:"secretCount"`
+}
+
+type keyRotateResponse struct {
+	ServiceID       string    `json:"serviceId"`
+	APIVersion      string    `json:"apiVersion"`
+	Outcome         string    `json:"outcome"`
+	RotatedAt       time.Time `json:"rotatedAt"`
+	OldKeyID        string    `json:"oldKeyId"`
+	NewKeyID        string    `json:"newKeyId"`
+	StoreKeyVersion string    `json:"storeKeyVersion"`
+	SecretCount     int       `json:"secretCount"`
+}
+
+func runBackup(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown backup command %q", "")
+	}
+	switch args[0] {
+	case "create":
+		return runBackupCreate(args[1:])
+	case "restore":
+		return runBackupRestore(args[1:])
+	default:
+		return fmt.Errorf("unknown backup command %q", args[0])
+	}
+}
+
+func runBackupCreate(args []string) error {
+	fs := flag.NewFlagSet("backup create", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	outPath := fs.String("out", getenvDefault("SECRETSBROKER_BACKUP_PATH", ""), "backup artifact output path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	res, err := newLocalBackend(*storePath, *auditPath, material.Value).createBackup(*outPath)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runBackupRestore(args []string) error {
+	fs := flag.NewFlagSet("backup restore", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	inPath := fs.String("in", getenvDefault("SECRETSBROKER_BACKUP_PATH", ""), "backup artifact input path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	res, err := newLocalBackend(*storePath, *auditPath, material.Value).restoreBackup(*inPath)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runKeyRotate(args []string) error {
+	fs := flag.NewFlagSet("key rotate", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "current portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing current portable master key")
+	newMasterKey := fs.String("new-master-key", getenvDefault("SECRETSBROKER_NEW_MASTER_KEY", ""), "new portable master key")
+	newMasterKeyFile := fs.String("new-master-key-file", getenvDefault("SECRETSBROKER_NEW_MASTER_KEY_FILE", ""), "file containing new portable master key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	current, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	next, err := loadKeyMaterial(*newMasterKey, *newMasterKeyFile)
+	if errors.Is(err, errLocked) {
+		return errMissingNewMasterKey
+	}
+	if err != nil {
+		return err
+	}
+	res, err := newLocalBackend(*storePath, *auditPath, current.Value).rotateMasterKey(next.Value)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func (b *localBackend) createBackup(path string) (backupCreateResponse, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return backupCreateResponse{}, errMissingBackupPath
+	}
+	if b.locked() {
+		_ = b.audit("backup_create", "", "locked", "", "")
+		return backupCreateResponse{}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		_ = b.audit("backup_create", "", "degraded", "", "")
+		return backupCreateResponse{}, errBackendDegraded
+	}
+	if err := b.verifyStoreDecryptable(store); err != nil {
+		_ = b.audit("backup_create", "", "degraded", "", "")
+		return backupCreateResponse{}, errInvalidBackupKey
+	}
+	now := b.now()
+	artifact := backupArtifact{
+		Version:         backupArtifactVersion,
+		ServiceID:       serviceID,
+		APIVersion:      apiVersion,
+		CreatedAt:       now,
+		StoreKeyID:      masterKeyID(b.masterKey),
+		StoreKeyVersion: masterKeyVersion,
+		SecretCount:     len(store.Secrets),
+		Store:           store,
+	}
+	if err := writeBackupArtifact(path, artifact); err != nil {
+		_ = b.audit("backup_create", "", "degraded", "", "")
+		return backupCreateResponse{}, err
+	}
+	_ = b.audit("backup_create", "", "ready", "", "")
+	return backupCreateResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Path: path, CreatedAt: now, StoreKeyID: artifact.StoreKeyID, StoreKeyVersion: artifact.StoreKeyVersion, SecretCount: artifact.SecretCount, Warning: "Backup contains encrypted secret payloads only. Keep it with the matching portable master key or recovery material."}, nil
+}
+
+func (b *localBackend) restoreBackup(path string) (backupRestoreResponse, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return backupRestoreResponse{}, errMissingBackupPath
+	}
+	if b.locked() {
+		_ = b.audit("backup_restore", "", "locked", "", "")
+		return backupRestoreResponse{}, errLocked
+	}
+	artifact, err := readBackupArtifact(path)
+	if err != nil {
+		_ = b.audit("backup_restore", "", "invalid_ref", "", "")
+		return backupRestoreResponse{}, err
+	}
+	if err := b.verifyStoreDecryptable(artifact.Store); err != nil {
+		_ = b.audit("backup_restore", "", "locked", "", "")
+		return backupRestoreResponse{}, errInvalidBackupKey
+	}
+	restored := artifact.Store
+	restored.UpdatedAt = b.now()
+	if err := b.saveStore(restored); err != nil {
+		_ = b.audit("backup_restore", "", "degraded", "", "")
+		return backupRestoreResponse{}, errBackendDegraded
+	}
+	_ = b.audit("backup_restore", "", "ready", "", "")
+	return backupRestoreResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Path: path, RestoredAt: b.now(), StoreKeyID: artifact.StoreKeyID, StoreKeyVersion: artifact.StoreKeyVersion, SecretCount: artifact.SecretCount}, nil
+}
+
+func (b *localBackend) rotateMasterKey(newMasterKey string) (keyRotateResponse, error) {
+	newMasterKey = strings.TrimSpace(newMasterKey)
+	if newMasterKey == "" {
+		return keyRotateResponse{}, errMissingNewMasterKey
+	}
+	if b.locked() {
+		_ = b.audit("key_rotate", "", "locked", "", "")
+		return keyRotateResponse{}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		_ = b.audit("key_rotate", "", "degraded", "", "")
+		return keyRotateResponse{}, errBackendDegraded
+	}
+	plaintext := make(map[string]string, len(store.Secrets))
+	for ref, entry := range store.Secrets {
+		value, err := b.decrypt(entry.Payload)
+		if err != nil {
+			_ = b.audit("key_rotate", ref, "degraded", "", "")
+			return keyRotateResponse{}, errInvalidBackupKey
+		}
+		plaintext[ref] = value
+	}
+	oldKeyID := masterKeyID(b.masterKey)
+	b.masterKey = newMasterKey
+	for ref, value := range plaintext {
+		entry := store.Secrets[ref]
+		payload, err := b.encrypt(value)
+		if err != nil {
+			_ = b.audit("key_rotate", ref, "degraded", "", "")
+			return keyRotateResponse{}, err
+		}
+		entry.Payload = payload
+		entry.Metadata.UpdatedAt = b.now()
+		store.Secrets[ref] = entry
+	}
+	store.UpdatedAt = b.now()
+	if err := b.saveStore(store); err != nil {
+		_ = b.audit("key_rotate", "", "degraded", "", "")
+		return keyRotateResponse{}, errBackendDegraded
+	}
+	_ = b.audit("key_rotate", "", "ready", "", "")
+	return keyRotateResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", RotatedAt: b.now(), OldKeyID: oldKeyID, NewKeyID: masterKeyID(newMasterKey), StoreKeyVersion: masterKeyVersion, SecretCount: len(store.Secrets)}, nil
+}
+
+func (b *localBackend) verifyStoreDecryptable(store localStoreFile) error {
+	for _, entry := range store.Secrets {
+		if _, err := b.decrypt(entry.Payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBackupArtifact(path string, artifact backupArtifact) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, bytes, 0o600)
+}
+
+func readBackupArtifact(path string) (backupArtifact, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return backupArtifact{}, err
+	}
+	var artifact backupArtifact
+	if err := json.Unmarshal(bytes, &artifact); err != nil {
+		return backupArtifact{}, errInvalidBackupArtifact
+	}
+	if artifact.Version != backupArtifactVersion || artifact.ServiceID != serviceID || artifact.APIVersion != apiVersion || artifact.Store.Version != localStoreVersion || artifact.Store.Secrets == nil {
+		return backupArtifact{}, errInvalidBackupArtifact
+	}
+	if artifact.SecretCount != len(artifact.Store.Secrets) {
+		return backupArtifact{}, errInvalidBackupArtifact
+	}
+	return artifact, nil
+}
+
+func encodeIndented(out *os.File, value any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}

--- a/cmd/secretsbroker/backup_restore.go
+++ b/cmd/secretsbroker/backup_restore.go
@@ -201,6 +201,10 @@ func (b *localBackend) restoreBackup(path string) (backupRestoreResponse, error)
 		_ = b.audit("backup_restore", "", "invalid_ref", "", "")
 		return backupRestoreResponse{}, err
 	}
+	if artifact.StoreKeyID != "" && artifact.StoreKeyID != masterKeyID(b.masterKey) {
+		_ = b.audit("backup_restore", "", "locked", "", "")
+		return backupRestoreResponse{}, errInvalidBackupKey
+	}
 	if err := b.verifyStoreDecryptable(artifact.Store); err != nil {
 		_ = b.audit("backup_restore", "", "locked", "", "")
 		return backupRestoreResponse{}, errInvalidBackupKey

--- a/cmd/secretsbroker/backup_restore_test.go
+++ b/cmd/secretsbroker/backup_restore_test.go
@@ -70,6 +70,25 @@ func TestRestoreWithWrongOrMissingKeyFailsSafely(t *testing.T) {
 	}
 }
 
+func TestRestoreWithWrongKeyRejectsEmptyBackupByKeyID(t *testing.T) {
+	backend := testBackend(t)
+	backupPath := filepath.Join(t.TempDir(), "empty-backup.json")
+	created, err := backend.createBackup(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.SecretCount != 0 || created.StoreKeyID != masterKeyID("test-master-key") {
+		t.Fatalf("empty backup response = %#v", created)
+	}
+	wrongKey := newLocalBackend(filepath.Join(t.TempDir(), "wrong-empty-store.json"), filepath.Join(t.TempDir(), "wrong-empty-audit.jsonl"), "wrong-master-key")
+	if _, err := wrongKey.restoreBackup(backupPath); !errors.Is(err, errInvalidBackupKey) {
+		t.Fatalf("wrong key empty restore err = %v", err)
+	}
+	if _, err := os.Stat(wrongKey.storePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("wrong-key empty restore should not write store, stat err = %v", err)
+	}
+}
+
 func TestKeyRotationReencryptsStoreAndPreservesResolvability(t *testing.T) {
 	backend := testBackend(t)
 	_, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/SESSION_KEY", Value: "session-secret"})

--- a/cmd/secretsbroker/backup_restore_test.go
+++ b/cmd/secretsbroker/backup_restore_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBackupRestoreCreatesEncryptedPortableArtifact(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/DB_PASSWORD", Value: "db-secret-value", Metadata: map[string]string{"sourceId": "local-test"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupPath := filepath.Join(t.TempDir(), "secretsbroker-backup.json")
+	created, err := backend.createBackup(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != "ready" || created.SecretCount != 1 || created.StoreKeyID != masterKeyID("test-master-key") {
+		t.Fatalf("backup response = %#v", created)
+	}
+	artifactBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(artifactBytes), "db-secret-value") {
+		t.Fatalf("backup leaked plaintext secret: %s", string(artifactBytes))
+	}
+
+	restored := newLocalBackend(filepath.Join(t.TempDir(), "restored-store.json"), filepath.Join(t.TempDir(), "restored-audit.jsonl"), "test-master-key")
+	restored.now = backend.now
+	restoreRes, err := restored.restoreBackup(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restoreRes.Outcome != "ready" || restoreRes.SecretCount != 1 {
+		t.Fatalf("restore response = %#v", restoreRes)
+	}
+	resolved := restored.resolve(resolveRequest{ServiceID: "api", Refs: []string{"services/api/DB_PASSWORD"}})
+	if resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "db-secret-value" {
+		t.Fatalf("restored resolve = %#v", resolved.Results[0])
+	}
+}
+
+func TestRestoreWithWrongOrMissingKeyFailsSafely(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/API_TOKEN", Value: "token-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupPath := filepath.Join(t.TempDir(), "backup.json")
+	if _, err := backend.createBackup(backupPath); err != nil {
+		t.Fatal(err)
+	}
+
+	locked := newLocalBackend(filepath.Join(t.TempDir(), "locked-store.json"), filepath.Join(t.TempDir(), "locked-audit.jsonl"), "")
+	if _, err := locked.restoreBackup(backupPath); !errors.Is(err, errLocked) {
+		t.Fatalf("locked restore err = %v", err)
+	}
+	wrongKey := newLocalBackend(filepath.Join(t.TempDir(), "wrong-store.json"), filepath.Join(t.TempDir(), "wrong-audit.jsonl"), "wrong-master-key")
+	if _, err := wrongKey.restoreBackup(backupPath); !errors.Is(err, errInvalidBackupKey) {
+		t.Fatalf("wrong key restore err = %v", err)
+	}
+	if _, err := os.Stat(wrongKey.storePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("wrong-key restore should not write store, stat err = %v", err)
+	}
+}
+
+func TestKeyRotationReencryptsStoreAndPreservesResolvability(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/SESSION_KEY", Value: "session-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(oldBytes), masterKeyID("test-master-key")) {
+		t.Fatalf("old store missing original key id: %s", string(oldBytes))
+	}
+
+	rotated, err := backend.rotateMasterKey("next-master-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.Outcome != "ready" || rotated.OldKeyID != masterKeyID("test-master-key") || rotated.NewKeyID != masterKeyID("next-master-key") || rotated.SecretCount != 1 {
+		t.Fatalf("rotation response = %#v", rotated)
+	}
+	resolved := backend.resolve(resolveRequest{ServiceID: "api", Refs: []string{"services/api/SESSION_KEY"}})
+	if resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "session-secret" {
+		t.Fatalf("rotated resolve = %#v", resolved.Results[0])
+	}
+	newBytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(newBytes), "session-secret") {
+		t.Fatalf("rotated store leaked plaintext secret: %s", string(newBytes))
+	}
+	if strings.Contains(string(newBytes), masterKeyID("test-master-key")) || !strings.Contains(string(newBytes), masterKeyID("next-master-key")) {
+		t.Fatalf("rotated store key metadata not updated: %s", string(newBytes))
+	}
+	staleKey := newLocalBackend(backend.storePath, filepath.Join(t.TempDir(), "stale-audit.jsonl"), "test-master-key")
+	staleResolved := staleKey.resolve(resolveRequest{ServiceID: "api", Refs: []string{"services/api/SESSION_KEY"}})
+	if staleResolved.Results[0].Outcome != "degraded" || staleResolved.Results[0].Value != "" {
+		t.Fatalf("stale key resolve = %#v", staleResolved.Results[0])
+	}
+}
+
+func TestBackupArtifactValidationRejectsTamperedMetadata(t *testing.T) {
+	backend := testBackend(t)
+	_, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/SECRET", Value: "value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupPath := filepath.Join(t.TempDir(), "backup.json")
+	if _, err := backend.createBackup(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact backupArtifact
+	if err := json.Unmarshal(bytes, &artifact); err != nil {
+		t.Fatal(err)
+	}
+	artifact.SecretCount = 99
+	tampered, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backupPath, tampered, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.restoreBackup(backupPath); !errors.Is(err, errInvalidBackupArtifact) {
+		t.Fatalf("tampered restore err = %v", err)
+	}
+}

--- a/cmd/secretsbroker/key_material.go
+++ b/cmd/secretsbroker/key_material.go
@@ -49,6 +49,8 @@ func runKey(args []string) error {
 		return printKeyStatus(args[1:])
 	case "generate":
 		return printGeneratedKey()
+	case "rotate":
+		return runKeyRotate(args[1:])
 	default:
 		return fmt.Errorf("unknown key command %q", args[0])
 	}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -119,6 +119,8 @@ func run(args []string) error {
 		return printStatus(args[1:])
 	case "key":
 		return runKey(args[1:])
+	case "backup":
+		return runBackup(args[1:])
 	case "session":
 		return runSession(args[1:])
 	case "version":
@@ -134,12 +136,13 @@ func run(args []string) error {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|session|version>")
+	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|backup|session|version>")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
 	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
 	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key foundation")
+	fmt.Fprintln(os.Stderr, "  backup  Create or restore encrypted local-store backup artifacts")
 	fmt.Fprintln(os.Stderr, "  session Manage local API session/token foundation")
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
 }
@@ -216,6 +219,8 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/writeback",
 			"POST /v1/resolve",
 			"GET /v1/sources/status",
+			"CLI secretsbroker backup create|restore",
+			"CLI secretsbroker key rotate",
 		},
 		Features: []string{
 			"liveness",
@@ -233,6 +238,8 @@ func defaultCapabilities() CapabilitiesResponse {
 			"exec-source",
 			"write-back-policy",
 			"generated-secret-capture",
+			"encrypted-backup-restore",
+			"master-key-rotation",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",

--- a/docs/backup-restore-rotation.md
+++ b/docs/backup-restore-rotation.md
@@ -1,0 +1,109 @@
+# Backup, Restore, and Key Rotation
+
+Status: implemented foundation slice
+Issue: #23
+
+## Goals
+
+The local-first Secrets Broker can now create encrypted backup artifacts, restore them into a fresh instance when the matching portable master key is available, and rotate/re-encrypt local store payloads under a new portable master key.
+
+The backup flow never exports plaintext secret values. Backup artifacts contain the encrypted local store plus metadata needed for diagnostics and recovery planning.
+
+## Backup artifact format
+
+`secretsbroker backup create` writes a JSON artifact:
+
+```json
+{
+  "version": 1,
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "createdAt": "2026-05-08T00:00:00Z",
+  "storeKeyId": "mk-0123456789abcdef",
+  "storeKeyVersion": "v1",
+  "secretCount": 2,
+  "store": {
+    "version": 1,
+    "serviceId": "@secretsbroker",
+    "secrets": {
+      "services/api/DB_PASSWORD": {
+        "metadata": { "sourceId": "local" },
+        "payload": {
+          "alg": "AES-256-GCM",
+          "keyId": "mk-0123456789abcdef",
+          "keyVersion": "v1",
+          "nonce": "...",
+          "ciphertext": "..."
+        }
+      }
+    }
+  }
+}
+```
+
+The artifact is safe from plaintext secret export, but it is still sensitive operational data. Store it separately from the portable master key or recovery material.
+
+## Create a backup
+
+```powershell
+secretsbroker backup create `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\portable-master-key.txt `
+  --out .\backups\secretsbroker-backup.json
+```
+
+The broker verifies the current key can decrypt stored payloads before writing the artifact. Missing or wrong key material fails safely instead of creating a misleading backup.
+
+## Restore into a fresh instance
+
+```powershell
+secretsbroker backup restore `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\portable-master-key.txt `
+  --in .\backups\secretsbroker-backup.json
+```
+
+Restore validates:
+
+- artifact version, service id, API version, store version, and secret count
+- required portable master key availability
+- that every encrypted payload decrypts with the supplied key
+
+A missing key returns locked behavior. A wrong key returns an actionable backup-key failure and does not write the target store.
+
+## Rotate the portable master key
+
+```powershell
+secretsbroker key rotate `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\old-portable-master-key.txt `
+  --new-master-key-file .\secure\new-portable-master-key.txt
+```
+
+Rotation decrypts all current payloads using the existing key, re-encrypts them under the new key, updates payload key metadata, writes an audit event, and preserves resolvability for callers using the new key.
+
+Keep the previous key until the rotated backup and store are verified, then retire it according to the operator's key-retention policy.
+
+## Audit and recovery limits
+
+Audit events are emitted for:
+
+- `backup_create`
+- `backup_restore`
+- `key_rotate`
+
+Events include operation, outcome, timestamp, and scoped ref where relevant. They never include plaintext secret values.
+
+What can be recovered:
+
+- an encrypted backup plus the matching portable master key can restore all local encrypted store entries
+- a rotated store can be backed up and restored with the new portable master key
+
+What cannot be recovered:
+
+- without the matching portable master key or future recovery shares, encrypted payloads cannot be decrypted
+- source-backed secrets that were never materialized into the local store must still be recovered from their source provider
+- a tampered or incompatible backup artifact is rejected rather than partially restored


### PR DESCRIPTION
## Summary

- Add encrypted backup artifact creation and restore flows for the local encrypted store.
- Add portable master-key rotation/re-encryption flow with audit events and preserved resolvability.
- Add tests for encrypted backup, fresh-instance restore, wrong/missing key safety, key rotation, stale-key failure, and tampered artifact rejection.
- Document operator backup/restore/rotation flow and recovery limits.

## Validation

- `go test ./...`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`

## Process

- Selected after #403 completion; Dagu #1 remains Blocked / Human Needed and was skipped.
- Please independently validate before merge; I will not merge without an explicit validation verdict.

Closes #23.
