### PR TITLE
ISS-24 normalize source lifecycle states

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -151,6 +151,8 @@ type auditEvent struct {
 	Operation string    `json:"operation"`
 	Ref       string    `json:"ref,omitempty"`
 	Outcome   string    `json:"outcome"`
+	State     string    `json:"state,omitempty"`
+	SourceID  string    `json:"sourceId,omitempty"`
 	ServiceID string    `json:"serviceId,omitempty"`
 	RequestID string    `json:"requestId,omitempty"`
 }
@@ -380,6 +382,7 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 				if sourceResult.Found {
 					result.Outcome = sourceResult.Outcome
 					result.Message = sourceResult.Message
+					_ = b.auditSourceLifecycle(ref, sourceResult, req.ServiceID, req.RequestID)
 					if sourceResult.Outcome == "ready" {
 						result.Value = sourceResult.Value
 						result.Metadata = &SecretMetadata{SourceID: sourceResult.SourceID, Version: "source"}
@@ -438,6 +441,14 @@ func (b *localBackend) saveStore(store localStoreFile) error {
 }
 
 func (b *localBackend) audit(operation, ref, outcome, requestServiceID, requestID string) error {
+	return b.writeAuditEvent(auditEvent{TS: b.now(), Operation: operation, Ref: ref, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID})
+}
+
+func (b *localBackend) auditSourceLifecycle(ref string, result sourceResolveResult, requestServiceID, requestID string) error {
+	return b.writeAuditEvent(auditEvent{TS: b.now(), Operation: "source_lifecycle", Ref: ref, Outcome: result.Outcome, State: result.Lifecycle.State, SourceID: result.SourceID, ServiceID: requestServiceID, RequestID: requestID})
+}
+
+func (b *localBackend) writeAuditEvent(event auditEvent) error {
 	if strings.TrimSpace(b.auditPath) == "" {
 		return nil
 	}
@@ -449,7 +460,7 @@ func (b *localBackend) audit(operation, ref, outcome, requestServiceID, requestI
 		return err
 	}
 	defer file.Close()
-	return json.NewEncoder(file).Encode(auditEvent{TS: b.now(), Operation: operation, Ref: ref, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID})
+	return json.NewEncoder(file).Encode(event)
 }
 
 func (b *localBackend) encrypt(value string) (secretPayload, error) {

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -49,11 +49,12 @@ type sourceRefConfig struct {
 }
 
 type sourceResolveResult struct {
-	Found    bool
-	Value    string
-	SourceID string
-	Outcome  string
-	Message  string
+	Found     bool
+	Value     string
+	SourceID  string
+	Outcome   string
+	Message   string
+	Lifecycle SourceLifecycle
 }
 
 func loadSourceConfig(path string) (sourceConfigFile, error) {
@@ -94,9 +95,10 @@ func (cfg sourceConfigFile) resolve(ref string) sourceResolveResult {
 		result := source.resolve(ref, refCfg)
 		result.Found = true
 		result.SourceID = source.SourceID
+		result.Lifecycle = normalizeSourceLifecycle(result.Outcome)
 		return result
 	}
-	return sourceResolveResult{Found: false, Outcome: "missing_ref", Message: "Secret ref was not found."}
+	return sourceResolveResult{Found: false, Outcome: "missing_ref", Message: "Secret ref was not found.", Lifecycle: normalizeSourceLifecycle("missing_ref")}
 }
 
 func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveResult {

--- a/cmd/secretsbroker/source_lifecycle.go
+++ b/cmd/secretsbroker/source_lifecycle.go
@@ -1,0 +1,44 @@
+package main
+
+import "strings"
+
+const defaultSourceRetryAfterMs = 30000
+
+type SourceLifecycle struct {
+	State        string `json:"state"`
+	Outcome      string `json:"outcome"`
+	NextAction   string `json:"nextAction,omitempty"`
+	Retryable    bool   `json:"retryable"`
+	RetryAfterMs int    `json:"retryAfterMs,omitempty"`
+}
+
+func normalizeSourceLifecycle(outcome string) SourceLifecycle {
+	outcome = strings.TrimSpace(outcome)
+	if outcome == "" {
+		outcome = "source_unavailable"
+	}
+	switch outcome {
+	case "ready":
+		return SourceLifecycle{State: "connected", Outcome: outcome, Retryable: false}
+	case "missing_ref":
+		return SourceLifecycle{State: "missing", Outcome: outcome, NextAction: "check_ref", Retryable: false}
+	case "policy_denied":
+		return SourceLifecycle{State: "denied", Outcome: outcome, NextAction: "review_policy", Retryable: false}
+	case "source_auth_required":
+		return SourceLifecycle{State: "auth_required", Outcome: outcome, NextAction: "reconnect_source", Retryable: false}
+	case "identity_expired":
+		return SourceLifecycle{State: "revoked", Outcome: outcome, NextAction: "renew_identity", Retryable: false}
+	case "locked":
+		return SourceLifecycle{State: "reconnect_required", Outcome: outcome, NextAction: "unlock_or_unseal_source", Retryable: false}
+	case "invalid_ref":
+		return SourceLifecycle{State: "config_error", Outcome: outcome, NextAction: "fix_source_mapping", Retryable: false}
+	case "source_unavailable", "degraded":
+		return SourceLifecycle{State: "degraded", Outcome: outcome, NextAction: "retry_or_inspect_source", Retryable: true, RetryAfterMs: defaultSourceRetryAfterMs}
+	default:
+		return SourceLifecycle{State: "degraded", Outcome: outcome, NextAction: "inspect_source", Retryable: true, RetryAfterMs: defaultSourceRetryAfterMs}
+	}
+}
+
+func disabledSourceLifecycle() SourceLifecycle {
+	return SourceLifecycle{State: "disabled", Outcome: "disabled", NextAction: "enable_source", Retryable: false}
+}

--- a/cmd/secretsbroker/source_lifecycle_test.go
+++ b/cmd/secretsbroker/source_lifecycle_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSourceLifecycleStates(t *testing.T) {
+	tests := []struct {
+		outcome    string
+		state      string
+		nextAction string
+		retryable  bool
+	}{
+		{outcome: "ready", state: "connected"},
+		{outcome: "missing_ref", state: "missing", nextAction: "check_ref"},
+		{outcome: "policy_denied", state: "denied", nextAction: "review_policy"},
+		{outcome: "source_auth_required", state: "auth_required", nextAction: "reconnect_source"},
+		{outcome: "identity_expired", state: "revoked", nextAction: "renew_identity"},
+		{outcome: "locked", state: "reconnect_required", nextAction: "unlock_or_unseal_source"},
+		{outcome: "invalid_ref", state: "config_error", nextAction: "fix_source_mapping"},
+		{outcome: "source_unavailable", state: "degraded", nextAction: "retry_or_inspect_source", retryable: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			got := normalizeSourceLifecycle(tt.outcome)
+			if got.State != tt.state || got.Outcome != tt.outcome || got.NextAction != tt.nextAction || got.Retryable != tt.retryable {
+				t.Fatalf("lifecycle = %#v", got)
+			}
+			if tt.retryable && got.RetryAfterMs <= 0 {
+				t.Fatalf("retryable lifecycle missing retryAfterMs: %#v", got)
+			}
+		})
+	}
+}
+
+func TestSourceResolveResultCarriesNormalizedLifecycle(t *testing.T) {
+	t.Setenv("SOURCE_LIFECYCLE_SECRET", "secret-value")
+	cfg := sourceConfigFile{Sources: []sourceConfig{
+		{SourceID: "env-ready", Kind: "env", Enabled: true, Refs: map[string]sourceRefConfig{"ready/ref": {Env: "SOURCE_LIFECYCLE_SECRET"}}},
+		{SourceID: "env-missing", Kind: "env", Enabled: true, Refs: map[string]sourceRefConfig{"missing/ref": {Env: "SOURCE_LIFECYCLE_MISSING"}}},
+	}}
+	ready := cfg.resolve("ready/ref")
+	if ready.Outcome != "ready" || ready.Lifecycle.State != "connected" || ready.Value != "secret-value" {
+		t.Fatalf("ready result = %#v", ready)
+	}
+	missing := cfg.resolve("missing/ref")
+	if missing.Outcome != "source_unavailable" || missing.Lifecycle.State != "degraded" || !missing.Lifecycle.Retryable || missing.Value != "" {
+		t.Fatalf("missing env result = %#v", missing)
+	}
+}
+
+func TestSourceRegistryExposesSafeLifecycleMetadata(t *testing.T) {
+	t.Setenv("REGISTRY_ENV_SECRET", "do-not-leak")
+	backend := testBackend(t)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{
+		{SourceID: "env-source", Kind: "env", Enabled: true, Namespaces: []string{"services/api"}, Refs: map[string]sourceRefConfig{"services/api/SECRET": {Env: "REGISTRY_ENV_SECRET"}}},
+		{SourceID: "vault-auth", Kind: "vault", Enabled: true, Address: "https://vault.invalid", TokenEnv: "MISSING_VAULT_TOKEN", Refs: map[string]sourceRefConfig{"vault/ref": {Path: "secret/data/ref", Field: "value"}}},
+		{SourceID: "bad-source", Kind: "unknown", Enabled: true},
+	}}
+	registry := defaultSourceRegistry(backend)
+	byID := map[string]SourceStatus{}
+	for _, source := range registry.Sources {
+		byID[source.SourceID] = source
+	}
+	if byID["local"].State != "connected" || byID["local"].Outcome != "ready" {
+		t.Fatalf("local status = %#v", byID["local"])
+	}
+	if byID["env-source"].State != "connected" || byID["env-source"].Outcome != "ready" {
+		t.Fatalf("env status = %#v", byID["env-source"])
+	}
+	if byID["vault-auth"].State != "auth_required" || byID["vault-auth"].NextAction != "reconnect_source" {
+		t.Fatalf("vault status = %#v", byID["vault-auth"])
+	}
+	if byID["bad-source"].State != "config_error" || byID["bad-source"].NextAction != "fix_source_mapping" {
+		t.Fatalf("bad status = %#v", byID["bad-source"])
+	}
+	if strings.Contains(string(mustJSON(t, registry)), "do-not-leak") {
+		t.Fatalf("source registry leaked secret value: %#v", registry)
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes
+}
+
+func TestSourceLifecycleAuditRedactsValues(t *testing.T) {
+	backend := testBackend(t)
+	if err := os.Setenv("AUDIT_SOURCE_SECRET", "audit-secret-value"); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Unsetenv("AUDIT_SOURCE_SECRET")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "env-audit", Kind: "env", Enabled: true, Refs: map[string]sourceRefConfig{"services/api/AUDIT_SECRET": {Env: "AUDIT_SOURCE_SECRET"}}}}}
+	res := backend.resolve(resolveRequest{RequestID: "req-audit", ServiceID: "api", Refs: []string{"services/api/AUDIT_SECRET"}})
+	if res.Results[0].Outcome != "ready" || res.Results[0].Value != "audit-secret-value" {
+		t.Fatalf("resolve = %#v", res.Results[0])
+	}
+	bytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(bytes)
+	if strings.Contains(text, "audit-secret-value") {
+		t.Fatalf("audit leaked source secret: %s", text)
+	}
+	for _, want := range []string{"source_lifecycle", "connected", "env-audit", "ready"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("audit missing %q: %s", want, text)
+		}
+	}
+}

--- a/cmd/secretsbroker/source_lifecycle_test.go
+++ b/cmd/secretsbroker/source_lifecycle_test.go
@@ -58,6 +58,7 @@ func TestSourceRegistryExposesSafeLifecycleMetadata(t *testing.T) {
 	backend.sources = sourceConfigFile{Sources: []sourceConfig{
 		{SourceID: "env-source", Kind: "env", Enabled: true, Namespaces: []string{"services/api"}, Refs: map[string]sourceRefConfig{"services/api/SECRET": {Env: "REGISTRY_ENV_SECRET"}}},
 		{SourceID: "vault-auth", Kind: "vault", Enabled: true, Address: "https://vault.invalid", TokenEnv: "MISSING_VAULT_TOKEN", Refs: map[string]sourceRefConfig{"vault/ref": {Path: "secret/data/ref", Field: "value"}}},
+		{SourceID: "disabled-source", Kind: "env", Enabled: false, Refs: map[string]sourceRefConfig{"disabled/ref": {Env: "REGISTRY_ENV_SECRET"}}},
 		{SourceID: "bad-source", Kind: "unknown", Enabled: true},
 	}}
 	registry := defaultSourceRegistry(backend)
@@ -73,6 +74,9 @@ func TestSourceRegistryExposesSafeLifecycleMetadata(t *testing.T) {
 	}
 	if byID["vault-auth"].State != "auth_required" || byID["vault-auth"].NextAction != "reconnect_source" {
 		t.Fatalf("vault status = %#v", byID["vault-auth"])
+	}
+	if byID["disabled-source"].State != "disabled" || byID["disabled-source"].Outcome != "disabled" || byID["disabled-source"].NextAction != "enable_source" {
+		t.Fatalf("disabled status = %#v", byID["disabled-source"])
 	}
 	if byID["bad-source"].State != "config_error" || byID["bad-source"].NextAction != "fix_source_mapping" {
 		t.Fatalf("bad status = %#v", byID["bad-source"])

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -62,7 +62,7 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 		},
 	}
 	if backend != nil {
-		for _, source := range backend.sources.enabledSources() {
+		for _, source := range backend.sources.Sources {
 			lifecycle := sourceRegistryLifecycle(source)
 			status := SourceStatus{
 				SourceID:         source.SourceID,

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -11,17 +11,22 @@ type SourceRegistry struct {
 }
 
 type SourceStatus struct {
-	SourceID         string   `json:"sourceId"`
-	Kind             string   `json:"kind"`
-	DisplayName      string   `json:"displayName"`
-	Enabled          bool     `json:"enabled"`
-	Critical         bool     `json:"critical"`
-	Priority         int      `json:"priority"`
-	Capabilities     []string `json:"capabilities"`
-	Namespaces       []string `json:"namespaces"`
-	State            string   `json:"state"`
-	AffectedRefs     []string `json:"affectedRefs"`
-	AffectedServices []string `json:"affectedServices"`
+	SourceID         string          `json:"sourceId"`
+	Kind             string          `json:"kind"`
+	DisplayName      string          `json:"displayName"`
+	Enabled          bool            `json:"enabled"`
+	Critical         bool            `json:"critical"`
+	Priority         int             `json:"priority"`
+	Capabilities     []string        `json:"capabilities"`
+	Namespaces       []string        `json:"namespaces"`
+	State            string          `json:"state"`
+	Outcome          string          `json:"outcome"`
+	NextAction       string          `json:"nextAction,omitempty"`
+	Retryable        bool            `json:"retryable"`
+	RetryAfterMs     int             `json:"retryAfterMs,omitempty"`
+	Lifecycle        SourceLifecycle `json:"lifecycle"`
+	AffectedRefs     []string        `json:"affectedRefs"`
+	AffectedServices []string        `json:"affectedServices"`
 }
 
 type sourceStatusResponse struct {
@@ -31,10 +36,11 @@ type sourceStatusResponse struct {
 }
 
 func defaultSourceRegistry(backend *localBackend) SourceRegistry {
-	state := "locked"
+	outcome := "locked"
 	if backend != nil && !backend.locked() {
-		state = "ready"
+		outcome = "ready"
 	}
+	localLifecycle := normalizeSourceLifecycle(outcome)
 	sources := []SourceStatus{
 		{
 			SourceID:         "local",
@@ -45,13 +51,19 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 			Priority:         0,
 			Capabilities:     []string{"read", "write", "health"},
 			Namespaces:       []string{"*"},
-			State:            state,
+			State:            localLifecycle.State,
+			Outcome:          localLifecycle.Outcome,
+			NextAction:       localLifecycle.NextAction,
+			Retryable:        localLifecycle.Retryable,
+			RetryAfterMs:     localLifecycle.RetryAfterMs,
+			Lifecycle:        localLifecycle,
 			AffectedRefs:     []string{},
 			AffectedServices: []string{},
 		},
 	}
 	if backend != nil {
 		for _, source := range backend.sources.enabledSources() {
+			lifecycle := sourceRegistryLifecycle(source)
 			status := SourceStatus{
 				SourceID:         source.SourceID,
 				Kind:             source.Kind,
@@ -61,7 +73,12 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 				Priority:         source.Priority,
 				Capabilities:     capabilitiesForSourceKind(source.Kind),
 				Namespaces:       safeList(source.Namespaces),
-				State:            sourceRegistryState(source),
+				State:            lifecycle.State,
+				Outcome:          lifecycle.Outcome,
+				NextAction:       lifecycle.NextAction,
+				Retryable:        lifecycle.Retryable,
+				RetryAfterMs:     lifecycle.RetryAfterMs,
+				Lifecycle:        lifecycle,
 				AffectedRefs:     []string{},
 				AffectedServices: []string{},
 			}
@@ -74,17 +91,26 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 	return SourceRegistry{Sources: sources}
 }
 
-func sourceRegistryState(source sourceConfig) string {
+func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
+	if !source.Enabled {
+		return disabledSourceLifecycle()
+	}
 	switch source.Kind {
+	case "env", "file", "exec":
+		if len(source.Refs) == 0 {
+			return normalizeSourceLifecycle("missing_ref")
+		}
 	case "vault", "openbao":
 		if strings.TrimSpace(source.Address) == "" {
-			return "invalid_ref"
+			return normalizeSourceLifecycle("invalid_ref")
 		}
 		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
-			return "source_auth_required"
+			return normalizeSourceLifecycle("source_auth_required")
 		}
+	default:
+		return normalizeSourceLifecycle("invalid_ref")
 	}
-	return "ready"
+	return normalizeSourceLifecycle("ready")
 }
 
 func capabilitiesForSourceKind(kind string) []string {

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -44,6 +44,7 @@ func TestSourceRegistryMapsVaultAuthStateWithoutTokenLeak(t *testing.T) {
 
 func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {
 	backend := newLocalBackend("store.json", "audit.jsonl", "master-key")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "disabled-source", Kind: "env", Enabled: false, Refs: map[string]sourceRefConfig{"disabled/ref": {Env: "SHOULD_NOT_LEAK"}}}}}
 	state := "ready"
 	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{}))
 	defer server.Close()
@@ -60,7 +61,10 @@ func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
 		t.Fatal(err)
 	}
-	if len(body.Sources) != 1 || body.Sources[0].SourceID != "local" || body.Sources[0].State != "connected" || body.Sources[0].Outcome != "ready" {
+	if len(body.Sources) != 2 || body.Sources[0].SourceID != "local" || body.Sources[0].State != "connected" || body.Sources[0].Outcome != "ready" {
 		t.Fatalf("body = %#v", body)
+	}
+	if body.Sources[1].SourceID != "disabled-source" || body.Sources[1].State != "disabled" || body.Sources[1].NextAction != "enable_source" {
+		t.Fatalf("disabled body = %#v", body.Sources[1])
 	}
 }

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -12,14 +12,14 @@ func TestDefaultSourceRegistryReflectsLocalKeyState(t *testing.T) {
 	if len(locked.Sources) != 1 {
 		t.Fatalf("sources = %d", len(locked.Sources))
 	}
-	if locked.Sources[0].SourceID != "local" || locked.Sources[0].State != "locked" {
+	if locked.Sources[0].SourceID != "local" || locked.Sources[0].State != "reconnect_required" || locked.Sources[0].Outcome != "locked" {
 		t.Fatalf("locked source = %#v", locked.Sources[0])
 	}
 	assertContains(t, locked.Sources[0].Capabilities, "read")
 	assertContains(t, locked.Sources[0].Namespaces, "*")
 
 	ready := defaultSourceRegistry(newLocalBackend("store.json", "audit.jsonl", "master-key"))
-	if ready.Sources[0].State != "ready" {
+	if ready.Sources[0].State != "connected" || ready.Sources[0].Outcome != "ready" {
 		t.Fatalf("ready source = %#v", ready.Sources[0])
 	}
 }
@@ -35,7 +35,7 @@ func TestSourceRegistryMapsVaultAuthStateWithoutTokenLeak(t *testing.T) {
 		t.Fatalf("sources = %#v", registry.Sources)
 	}
 	vault := registry.Sources[1]
-	if vault.SourceID != "vault-prod" || vault.State != "source_auth_required" {
+	if vault.SourceID != "vault-prod" || vault.State != "auth_required" || vault.Outcome != "source_auth_required" {
 		t.Fatalf("vault source = %#v", vault)
 	}
 	assertContains(t, vault.Capabilities, "read")
@@ -60,7 +60,7 @@ func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
 		t.Fatal(err)
 	}
-	if len(body.Sources) != 1 || body.Sources[0].SourceID != "local" || body.Sources[0].State != "ready" {
+	if len(body.Sources) != 1 || body.Sources[0].SourceID != "local" || body.Sources[0].State != "connected" || body.Sources[0].Outcome != "ready" {
 		t.Fatalf("body = %#v", body)
 	}
 }

--- a/docs/provider-source-registry.md
+++ b/docs/provider-source-registry.md
@@ -1,7 +1,7 @@
 # Provider Connection and Source Registry Model
 
-Status: initial model  
-Issue: #12
+Status: lifecycle normalization implemented
+Issues: #12, #24
 
 ## Purpose
 
@@ -31,7 +31,15 @@ A source registry entry describes a configured backend/source without revealing 
   "priority": 0,
   "capabilities": ["read", "write", "health"],
   "namespaces": ["*"],
-  "state": "ready",
+  "state": "connected",
+  "outcome": "ready",
+  "nextAction": "",
+  "retryable": false,
+  "lifecycle": {
+    "state": "connected",
+    "outcome": "ready",
+    "retryable": false
+  },
   "affectedRefs": [],
   "affectedServices": []
 }
@@ -102,18 +110,23 @@ Canonical capability names:
 - `reconnect`
 - `auth-required`
 
-## Source states
+## Source lifecycle states
 
-Canonical source states align with broker outcomes:
+Source lifecycle states are normalized for UI/API consumers while preserving the lower-level broker outcome that caused the state:
 
-- `ready`
-- `setup_needed`
-- `locked`
-- `source_auth_required`
-- `degraded`
-- `source_unavailable`
-- `identity_expired`
-- `policy_denied`
+| Lifecycle state | Common outcomes | Meaning | Next action |
+| --- | --- | --- | --- |
+| `connected` | `ready` | Source is configured and usable. | none |
+| `missing` | `missing_ref` | Requested ref/path/field is absent. | `check_ref` |
+| `denied` | `policy_denied` | Source policy denied the request. | `review_policy` |
+| `auth_required` | `source_auth_required` | Credentials are missing, expired, or unauthorized. | `reconnect_source` |
+| `revoked` | `identity_expired` | Launch/session identity is no longer valid. | `renew_identity` |
+| `reconnect_required` | `locked` | Local store is locked or external source is sealed. | `unlock_or_unseal_source` |
+| `config_error` | `invalid_ref` | Source or ref mapping is invalid. | `fix_source_mapping` |
+| `degraded` | `source_unavailable`, `degraded` | Source is temporarily unavailable or refresh failed. | `retry_or_inspect_source` |
+| `disabled` | `disabled` | Source is configured but disabled. | `enable_source` |
+
+`degraded` outcomes are retryable and include bounded `retryAfterMs` metadata. Status and audit surfaces report refs, source ids, states, outcomes, and next actions only; they must not include raw credentials or secret values.
 
 ## Namespace mapping
 
@@ -139,15 +152,18 @@ The local store can act as default fallback with namespace `*`.
 
 ## Current implemented MVP
 
-This slice adds an in-process registry with the default local source:
+The implemented registry includes the default local source plus configured `env`, `file`, `exec`, `vault`, and `openbao` sources:
 
-- `sourceId`: `local`
-- `kind`: `local-encrypted-store`
-- `capabilities`: `read`, `write`, `health`
-- `namespaces`: `*`
-- state follows broker store/key state:
-  - no master key => `locked`
-  - master key available => `ready`
+- `sourceId`: visible stable source identifier
+- `kind`: `local-encrypted-store`, `env`, `file`, `exec`, `vault`, or `openbao`
+- `capabilities`: source-safe capabilities such as `read`, `write`, and `health`
+- `namespaces`: claimed namespaces or `*`
+- `state`/`outcome`/`nextAction`/`retryable`: normalized lifecycle view
+- `lifecycle`: structured lifecycle object mirroring the normalized fields
+
+Local source state follows broker store/key state:
+- no master key => lifecycle `reconnect_required`, outcome `locked`
+- master key available => lifecycle `connected`, outcome `ready`
 
 Endpoint:
 
@@ -155,12 +171,11 @@ Endpoint:
 GET /v1/sources/status
 ```
 
-Secret values are not returned.
+Secret values are not returned. Source lifecycle audit events also redact values and record only operation, source id, ref, state, outcome, service id, and request id.
 
 ## Out of scope
 
-- env/file/exec adapters
-- Vault/OpenBao adapter
 - AWS/1Password/Bitwarden/BWS adapters
 - persistent registry config UI
 - policy engine
+- active background refresh scheduler beyond per-request lifecycle normalization


### PR DESCRIPTION
## Summary

- Add canonical source lifecycle normalization (`connected`, `missing`, `denied`, `auth_required`, `revoked`, `reconnect_required`, `config_error`, `degraded`, `disabled`) with safe next-action and retry metadata.
- Thread normalized lifecycle through source resolve results, source status API payloads, and redacted lifecycle audit events.
- Update provider/source registry docs to describe lifecycle states, outcome mapping, retry/backoff metadata, and redaction boundaries.
- Add tests for local/env/file/exec/Vault-style lifecycle outcomes, source status metadata redaction, and lifecycle audit redaction.

## Validation

- `go test ./...`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`

## Process

- Selected after #23 completion; Dagu #1 remains Blocked / Human Needed and was skipped.
- Please independently validate before merge; I will not merge without an explicit validation verdict.

Closes #24.
