### PR TITLE
ISS-25 add threat model hardening pass

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	localStoreVersion = 1
-	localStoreSource  = "local"
+	localStoreVersion            = 1
+	localStoreSource             = "local"
+	maxSecretBearingRequestBytes = 1 << 20
 )
 
 var (
@@ -529,8 +530,8 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			return
 		}
 		var req writeSecretRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
 			return
 		}
 		res, err := backend.writeSecret(req)
@@ -555,8 +556,8 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			return
 		}
 		var req generatedSecretCaptureRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
 			return
 		}
 		res, err := backend.captureGeneratedSecret(req)
@@ -587,12 +588,26 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			return
 		}
 		var req resolveRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
 			return
 		}
 		writeJSON(w, http.StatusOK, backend.resolve(req))
 	})
+}
+
+func decodeSecretBearingJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSecretBearingRequestBytes)
+	return json.NewDecoder(r.Body).Decode(dst)
+}
+
+func writeDecodeError(w http.ResponseWriter, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeAPIError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request body exceeds the local API size limit.", "policy_denied", "reduce_request_size")
+		return
+	}
+	writeAPIError(w, http.StatusBadRequest, "invalid_request", "Request body is not valid JSON.", "invalid_ref", "")
 }
 
 func writeAPIError(w http.ResponseWriter, status int, code, message, outcome, nextAction string) {

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -35,6 +37,36 @@ func TestHTTPGeneratedSecretWritebackCapture(t *testing.T) {
 	}
 	if captured.Outcome != "ready" || !captured.RefreshRequired || captured.Ref != "services/api-service/runtime/API_TOKEN" {
 		t.Fatalf("writeback response = %#v", captured)
+	}
+}
+
+func TestSecretBearingEndpointRejectsOversizedBodyWithoutLeakingToken(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := `{"ref":"openclaw/anthropic/api_key","value":"` + strings.Repeat("x", maxSecretBearingRequestBytes) + `"}`
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/secrets", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized status = %d", res.StatusCode)
+	}
+	payload, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(payload, []byte("test-token")) || bytes.Contains(payload, []byte(strings.Repeat("x", 64))) {
+		t.Fatalf("oversized error leaked sensitive input: %s", payload)
 	}
 }
 

--- a/cmd/secretsbroker/session.go
+++ b/cmd/secretsbroker/session.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
@@ -94,11 +95,22 @@ func (s localAPISecurity) require(w http.ResponseWriter, r *http.Request) bool {
 	if got == "" {
 		got = strings.TrimSpace(r.Header.Get("X-SecretsBroker-Token"))
 	}
-	if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+	if got == "" || !constantTimeTokenEqual(got, expected) {
 		writeAPIError(w, http.StatusUnauthorized, "unauthorized", "A valid local API token is required.", "policy_denied", "authenticate_local_session")
 		return false
 	}
 	return true
+}
+
+func constantTimeTokenEqual(got, expected string) bool {
+	got = strings.TrimSpace(got)
+	expected = strings.TrimSpace(expected)
+	if got == "" || expected == "" {
+		return false
+	}
+	gotHash := sha256.Sum256([]byte(got))
+	expectedHash := sha256.Sum256([]byte(expected))
+	return subtle.ConstantTimeCompare(gotHash[:], expectedHash[:]) == 1
 }
 
 func bearerToken(header string) string {

--- a/cmd/secretsbroker/session_test.go
+++ b/cmd/secretsbroker/session_test.go
@@ -37,6 +37,18 @@ func TestLocalAPISecurityRequiresConfiguredToken(t *testing.T) {
 	}
 }
 
+func TestConstantTimeTokenEqualTrimsAndRejectsMismatches(t *testing.T) {
+	if !constantTimeTokenEqual(" secret-token ", "secret-token") {
+		t.Fatalf("trimmed matching tokens should pass")
+	}
+	if constantTimeTokenEqual("secret-token-extra", "secret-token") {
+		t.Fatalf("different length token should reject")
+	}
+	if constantTimeTokenEqual("", "secret-token") {
+		t.Fatalf("empty token should reject")
+	}
+}
+
 func TestLocalAPISecurityAcceptsBearerAndRejectsWrongToken(t *testing.T) {
 	sec := localAPISecurity{token: "secret-token"}
 	badReq := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -52,6 +52,10 @@ X-SecretsBroker-Token: <token>
 
 If no token is configured, secret-bearing endpoints return `503 security_not_configured` rather than accepting unauthenticated access.
 
+Token checks trim whitespace, hash both presented and expected tokens, and then compare fixed-size digests in constant time. This avoids length-dependent token comparison behavior while keeping responses generic.
+
+Secret-bearing endpoints cap request bodies at 1 MiB before JSON decode. Oversized requests return `413 request_too_large` with a safe fixed message; request content and bearer tokens are not echoed.
+
 ## CLI helpers
 
 Generate a local development token:
@@ -92,6 +96,21 @@ No server token configured:
     "message": "Secret-bearing endpoints require SECRETSBROKER_API_TOKEN or --api-token.",
     "outcome": "policy_denied",
     "nextAction": "configure_api_token",
+    "affectedRefs": [],
+    "affectedServices": []
+  }
+}
+```
+
+Oversized body:
+
+```json
+{
+  "error": {
+    "code": "request_too_large",
+    "message": "Request body exceeds the local API size limit.",
+    "outcome": "policy_denied",
+    "nextAction": "reduce_request_size",
     "affectedRefs": [],
     "affectedServices": []
   }

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -14,6 +14,7 @@ This slice establishes the first local access boundary for the loopback HTTP dev
 Secret-bearing endpoints require a local API token:
 
 - `POST /v1/secrets`
+- `POST /v1/writeback`
 - `POST /v1/resolve`
 
 Safe bootstrap/status endpoints remain unauthenticated:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,145 @@
+# Secrets Broker Threat Model and Hardening Pass
+
+Status: baseline hardening pass
+Issue: #25
+
+## Scope
+
+This document covers the current `@secretsbroker` baseline: local encrypted store, portable master key, loopback HTTP API, source adapters, write-back capture, audit events, backup/restore, and UI-facing diagnostics.
+
+The broker is local-first. It is not yet a multi-tenant remote secret service and should not be exposed as one.
+
+## Assets
+
+- Secret plaintext values resolved for launched services.
+- Encrypted local-store payloads and backup artifacts.
+- Portable master key / recovery material.
+- Local API session token.
+- Source adapter credentials such as Vault/OpenBao tokens.
+- Launch identity and write-back policy claims.
+- Audit trail integrity and redaction boundaries.
+
+## Trust boundaries
+
+| Boundary | Trusted side | Untrusted or lower-trust side |
+| --- | --- | --- |
+| Local API token | Broker process and authorized local clients | Other local processes, browser pages, service code without token |
+| Store encryption | Broker with master key loaded | Store file, backups, filesystem copies |
+| Source adapter config | Operator-managed config | Source outputs, exec adapters, external secret managers |
+| Write-back policy | Launcher/Service Lasso identity and policy model | Service-provided write-back request body |
+| Audit/diagnostics | Metadata only | Secret values, tokens, raw credentials |
+
+## Threats and current mitigations
+
+### Local attacker on the same host
+
+Threats:
+- Reads store or backup files from disk.
+- Calls secret-bearing HTTP endpoints.
+- Replays or guesses local API token.
+- Reads logs/audit output looking for values.
+
+Current mitigations:
+- Store payloads use AES-256-GCM with per-secret nonces and a key derived from the portable master key.
+- Store, audit, and backup writes use owner-only file modes where the platform honors them (`0600` files, `0700` directories).
+- Secret-bearing endpoints require a configured local API token and return `503 security_not_configured` rather than falling open.
+- Token comparison hashes both candidate and expected token before constant-time compare to avoid length-dependent comparison behavior.
+- Secret-bearing request bodies are capped at 1 MiB before JSON decode to limit accidental or malicious memory pressure.
+- Error envelopes and audit events carry codes, refs, states, source ids, service ids, and request ids only; they do not include plaintext values or tokens.
+
+Residual risk:
+- A privileged local attacker can read process memory, environment variables, command lines, or key files. Prefer key files with OS permissions over shell history or process arguments.
+- Loopback HTTP is a development/bootstrap transport. Production should move to OS-authenticated named pipes or Unix sockets.
+
+### Malicious or compromised service
+
+Threats:
+- Requests refs outside its namespace.
+- Attempts write-back into another service namespace.
+- Sends oversized request bodies.
+- Replays launch identity after expiry.
+
+Current mitigations:
+- Write-back capture validates namespace, ref, operation, launch identity service id, expiry, allowed namespaces, and allowed operations before storing generated values.
+- Invalid, denied, expired, and source-auth-required write-back attempts produce typed errors and audit events without storing values.
+- Secret-bearing HTTP endpoints require the local API token before request bodies are processed.
+- Request-size limits apply to write, resolve, and write-back endpoints.
+
+Residual risk:
+- Resolve currently authenticates the local API token but does not yet enforce per-service/ref policy. That belongs in the planned policy engine.
+
+### Compromised source adapter
+
+Threats:
+- External source returns errors intended to leak credentials or confuse UI state.
+- Exec source exfiltrates environment or runs an unexpected command.
+- Vault/OpenBao token is missing, expired, denied, or source is sealed/unavailable.
+
+Current mitigations:
+- Source lifecycle normalization exposes safe state/outcome/nextAction/retry metadata instead of raw provider errors.
+- Source lifecycle audit events record source id, ref, state, outcome, service id, and request id only.
+- Exec adapters run with an empty environment, validate command presence, can restrict commands to trusted directories, reject symlink commands by default, enforce timeout, and cap stdout.
+- Vault/OpenBao handling maps missing/unauthorized/forbidden/not-found/sealed/unavailable outcomes into typed lifecycle states without returning token values.
+
+Residual risk:
+- Exec sources are powerful local code execution hooks. Operators should keep them disabled unless needed and restrict `trustedDirs`.
+- Persistent source config protection is currently delegated to filesystem permissions.
+
+### Log and diagnostic leakage
+
+Threats:
+- Secret values, bearer tokens, source tokens, or oversized request content appear in errors, audit JSONL, status, or source registry output.
+
+Current mitigations:
+- API errors use fixed safe messages.
+- Audit events omit values by schema.
+- Source registry status includes source ids/kinds/capabilities/lifecycle metadata but no raw ref values or source credentials.
+- Oversized-body errors do not echo request content or authorization tokens.
+- Backup/key responses expose key ids/versions and counts, not plaintext secrets or master key material.
+
+Residual risk:
+- CLI invocations that pass keys/tokens directly as flags may be visible through shell history or process listings. Use `--master-key-file`, env injection from a trusted launcher, or future OS credential stores where possible.
+
+### Replayed launch token or identity
+
+Threats:
+- A service reuses an expired launch identity to write generated secrets.
+- A service broadens operation or namespace in its request body.
+
+Current mitigations:
+- Write-back capture rejects missing or expired identities.
+- Write-back capture requires the requested namespace and operation to be allowed by the provided policy.
+- Denied/expired attempts are audited with metadata only.
+
+Residual risk:
+- The current request shape is foundation-level and does not yet include signed/issuer-verified launch identities. A follow-up policy/identity issue should add signed scoped leases.
+
+### Backup exfiltration
+
+Threats:
+- Attacker copies backup artifact and tries offline decryption.
+- Operator restores with the wrong key.
+- Backup metadata reveals too much.
+
+Current mitigations:
+- Backup artifact contains encrypted store payloads, counts, timestamps, key id/version, and service metadata; it does not contain plaintext secret values.
+- Restore verifies artifact shape, secret count, key id, and decryptability before writing the store.
+- Wrong-key restore fails with `errInvalidBackupKey` and does not overwrite the local store.
+
+Residual risk:
+- Backup plus matching master key is sufficient to recover secrets. Store backup artifacts and key/recovery material separately.
+
+## Small hardening changes in this pass
+
+- Local API token comparison now hashes both sides before constant-time comparison.
+- Secret-bearing HTTP endpoints now cap request bodies at 1 MiB before JSON decode and return a safe `request_too_large` error.
+- Added regression tests that oversized requests do not echo the bearer token or large request value.
+
+## Follow-up candidates
+
+These are intentionally out of scope for this bounded slice unless already tracked elsewhere:
+
+1. Add signed, scoped launch identity leases for resolve/write-back requests: [#29](https://github.com/service-lasso/lasso-secretsbroker/issues/29).
+2. Add per-service/ref resolve authorization policy enforcement: [#30](https://github.com/service-lasso/lasso-secretsbroker/issues/30).
+3. Replace production loopback HTTP with OS-authenticated named pipe / Unix socket transport: [#31](https://github.com/service-lasso/lasso-secretsbroker/issues/31).
+4. Add source config file permission checks and audit tamper-evidence: [#32](https://github.com/service-lasso/lasso-secretsbroker/issues/32).


### PR DESCRIPTION
## Summary

- Add `docs/threat-model.md` covering local attacker, malicious service, compromised source adapter, log leakage, replayed launch identity, and backup exfiltration scenarios.
- Harden local API token comparison by hashing both presented and expected tokens before constant-time digest comparison.
- Cap secret-bearing HTTP request bodies at 1 MiB and return safe `request_too_large` errors without echoing request content or bearer tokens.
- Update local API security docs with token comparison and request-size behavior.
- Add regression tests for token comparison and oversized secret-bearing request redaction.
- Create linked follow-up issues for non-trivial findings: #29, #30, #31, #32.

## Follow-up issues created

- #29 signed scoped launch identity leases
- #30 per-service ref policy for resolve requests
- #31 OS-authenticated IPC production transport
- #32 source config permission and audit tamper-evidence hardening

## Validation

- `go test ./...`
- `git diff --check`
- `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`

Closes #25.
