### PR TITLE
Add secrets management API contract

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -220,6 +220,12 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/writeback",
 			"POST /v1/resolve",
 			"GET /v1/sources/status",
+			"GET /v1/management/secrets",
+			"GET /v1/management/secrets/value-search",
+			"POST /v1/management/secrets/reveal",
+			"POST /v1/management/secrets/edit/dry-run|apply",
+			"POST /v1/management/secrets/reset/dry-run|apply",
+			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key rotate",
 		},
@@ -234,6 +240,10 @@ func defaultCapabilities() CapabilitiesResponse {
 			"typed-errors",
 			"audit-redaction",
 			"source-status",
+			"secrets-management-metadata-search",
+			"secrets-management-value-search-metadata-only",
+			"secrets-management-controlled-reveal",
+			"secrets-management-dry-run-apply",
 			"env-source",
 			"file-source",
 			"exec-source",
@@ -339,6 +349,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 	if backend != nil {
 		registerLocalStoreHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
+		registerSecretsManagementHandlers(mux, backend, security)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/secrets_management.go
+++ b/cmd/secretsbroker/secrets_management.go
@@ -1,0 +1,507 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const revealTTLSeconds = 60
+
+type managedSecretRecord struct {
+	Ref            string         `json:"ref"`
+	Name           string         `json:"name"`
+	SourceID       string         `json:"sourceId"`
+	ProviderKind   string         `json:"providerKind"`
+	OwnerServiceID string         `json:"ownerServiceId"`
+	WorkspaceID    string         `json:"workspaceId"`
+	State          string         `json:"state"`
+	Outcome        string         `json:"outcome"`
+	Capabilities   []string       `json:"capabilities"`
+	Policy         string         `json:"policy"`
+	AuditStatus    string         `json:"auditStatus"`
+	ValueSearch    string         `json:"valueSearch"`
+	UpdatedAt      *time.Time     `json:"updatedAt,omitempty"`
+	Metadata       SecretMetadata `json:"metadata,omitempty"`
+}
+
+type managedSecretsResponse struct {
+	ServiceID   string                `json:"serviceId"`
+	APIVersion  string                `json:"apiVersion"`
+	Query       string                `json:"query,omitempty"`
+	ValueSearch bool                  `json:"valueSearch"`
+	Outcome     string                `json:"outcome"`
+	Results     []managedSecretRecord `json:"results"`
+}
+
+type managedSecretActionRequest struct {
+	RequestID string `json:"requestId"`
+	ServiceID string `json:"serviceId"`
+	Ref       string `json:"ref"`
+	Reason    string `json:"reason"`
+	Value     string `json:"value"`
+	Policy    string `json:"policy"`
+	Confirm   bool   `json:"confirm"`
+}
+
+type managedSecretActionResponse struct {
+	ServiceID             string               `json:"serviceId"`
+	APIVersion            string               `json:"apiVersion"`
+	RequestID             string               `json:"requestId,omitempty"`
+	Ref                   string               `json:"ref"`
+	Operation             string               `json:"operation"`
+	Mode                  string               `json:"mode"`
+	Outcome               string               `json:"outcome"`
+	Applied               bool                 `json:"applied"`
+	RequiresConfirmation  bool                 `json:"requiresConfirmation"`
+	AuditStatus           string               `json:"auditStatus"`
+	NextAction            string               `json:"nextAction,omitempty"`
+	Value                 string               `json:"value,omitempty"`
+	TTLSeconds            int                  `json:"ttlSeconds,omitempty"`
+	Metadata              *SecretMetadata      `json:"metadata,omitempty"`
+	Record                *managedSecretRecord `json:"record,omitempty"`
+	AffectedRefs          []string             `json:"affectedRefs"`
+	AffectedServices      []string             `json:"affectedServices"`
+	UnsupportedCapability string               `json:"unsupportedCapability,omitempty"`
+}
+
+func (b *localBackend) listManagedSecrets(query string, valueSearch bool) (managedSecretsResponse, error) {
+	if b.locked() {
+		return managedSecretsResponse{ServiceID: serviceID, APIVersion: apiVersion, Query: query, ValueSearch: valueSearch, Outcome: "locked", Results: []managedSecretRecord{}}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return managedSecretsResponse{ServiceID: serviceID, APIVersion: apiVersion, Query: query, ValueSearch: valueSearch, Outcome: "degraded", Results: []managedSecretRecord{}}, errBackendDegraded
+	}
+	records := make([]managedSecretRecord, 0, len(store.Secrets)+configuredSourceRefCount(b.sources))
+	for ref, entry := range store.Secrets {
+		record := managedRecordFromLocalEntry(ref, entry)
+		matches := managedRecordMatches(record, query)
+		if valueSearch {
+			matches = b.localValueMatches(entry, query)
+		}
+		if matches {
+			records = append(records, record)
+		}
+	}
+	for _, source := range b.sources.enabledSources() {
+		for ref := range source.Refs {
+			if _, ok := store.Secrets[ref]; ok {
+				continue
+			}
+			record := managedRecordFromSource(ref, source)
+			if managedRecordMatches(record, query) && !valueSearch {
+				records = append(records, record)
+			}
+		}
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].Ref < records[j].Ref })
+	return managedSecretsResponse{ServiceID: serviceID, APIVersion: apiVersion, Query: query, ValueSearch: valueSearch, Outcome: "ready", Results: records}, nil
+}
+
+func managedRecordFromLocalEntry(ref string, entry secretEntry) managedSecretRecord {
+	updated := entry.Metadata.UpdatedAt
+	return managedSecretRecord{
+		Ref:            ref,
+		Name:           refName(ref),
+		SourceID:       firstNonEmpty(entry.Metadata.SourceID, localStoreSource),
+		ProviderKind:   "local-encrypted-store",
+		OwnerServiceID: ownerFromRef(ref),
+		WorkspaceID:    workspaceFromRef(ref),
+		State:          "present",
+		Outcome:        "ready",
+		Capabilities:   []string{"metadata", "reveal", "edit", "reset", "policy", "value_search"},
+		Policy:         "local-writeback-policy",
+		AuditStatus:    "audit_available",
+		ValueSearch:    "supported",
+		UpdatedAt:      &updated,
+		Metadata:       entry.Metadata,
+	}
+}
+
+func managedRecordFromSource(ref string, source sourceConfig) managedSecretRecord {
+	lifecycle := sourceRegistryLifecycle(source)
+	state := "present"
+	if lifecycle.Outcome != "ready" {
+		state = lifecycle.State
+	}
+	return managedSecretRecord{
+		Ref:            ref,
+		Name:           refName(ref),
+		SourceID:       source.SourceID,
+		ProviderKind:   source.Kind,
+		OwnerServiceID: ownerFromRef(ref),
+		WorkspaceID:    workspaceFromRef(ref),
+		State:          state,
+		Outcome:        lifecycle.Outcome,
+		Capabilities:   []string{"metadata", "reveal"},
+		Policy:         "source-read-policy",
+		AuditStatus:    "audit_available",
+		ValueSearch:    "unsupported",
+	}
+}
+
+func (b *localBackend) localValueMatches(entry secretEntry, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return false
+	}
+	value, err := b.decrypt(entry.Payload)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(value), query)
+}
+
+func managedRecordMatches(record managedSecretRecord, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{record.Ref, record.Name, record.SourceID, record.ProviderKind, record.OwnerServiceID, record.WorkspaceID, record.State, record.Outcome, record.Policy}, " "))
+	return strings.Contains(haystack, query)
+}
+
+func configuredSourceRefCount(cfg sourceConfigFile) int {
+	count := 0
+	for _, source := range cfg.enabledSources() {
+		count += len(source.Refs)
+	}
+	return count
+}
+
+func refName(ref string) string {
+	parts := strings.Split(strings.Trim(ref, "/"), "/")
+	if len(parts) == 0 {
+		return ref
+	}
+	return parts[len(parts)-1]
+}
+
+func ownerFromRef(ref string) string {
+	parts := strings.Split(strings.Trim(ref, "/"), "/")
+	if len(parts) >= 2 && parts[0] == "services" {
+		return parts[1]
+	}
+	if len(parts) >= 1 && strings.HasPrefix(parts[0], "@") {
+		return parts[0]
+	}
+	return "unknown"
+}
+
+func workspaceFromRef(ref string) string {
+	parts := strings.Split(strings.Trim(ref, "/"), "/")
+	if len(parts) >= 3 && parts[0] == "workspaces" {
+		return parts[1]
+	}
+	if len(parts) >= 1 && parts[0] == "services" {
+		return "service"
+	}
+	return "local"
+}
+
+func (b *localBackend) revealManagedSecret(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	res := baseManagedActionResponse(req, "reveal", "apply")
+	if err := validateManagedAction(req, true); err != nil {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "provide_ref_and_reason"
+		_ = b.audit("management_reveal", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	resolved := b.resolve(resolveRequest{RequestID: req.RequestID, ServiceID: req.ServiceID, Purpose: "managed_reveal", Refs: []string{req.Ref}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" {
+		outcome := "missing_ref"
+		if len(resolved.Results) == 1 {
+			outcome = resolved.Results[0].Outcome
+		}
+		res.Outcome = outcome
+		res.NextAction = nextActionForManagedOutcome(outcome)
+		_ = b.audit("management_reveal", req.Ref, outcome, req.ServiceID, req.RequestID)
+		return res, outcomeError(outcome)
+	}
+	result := resolved.Results[0]
+	res.Outcome = "ready"
+	res.Value = result.Value
+	res.TTLSeconds = revealTTLSeconds
+	res.AuditStatus = "audit_recorded"
+	res.Metadata = result.Metadata
+	_ = b.audit("management_reveal", req.Ref, "ready", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) managedEditDryRun(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	return b.managedDryRun(req, "edit")
+}
+
+func (b *localBackend) managedResetDryRun(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	return b.managedDryRun(req, "reset")
+}
+
+func (b *localBackend) managedPolicyPreview(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	return b.managedDryRun(req, "policy")
+}
+
+func (b *localBackend) managedDryRun(req managedSecretActionRequest, operation string) (managedSecretActionResponse, error) {
+	res := baseManagedActionResponse(req, operation, dryRunMode(operation))
+	if err := validateManagedAction(req, false); err != nil {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "provide_valid_ref"
+		_ = b.audit("management_"+operation+"_dry_run", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	record, err := b.managedRecord(req.Ref)
+	if err != nil {
+		res.Outcome = outcomeForError(err)
+		res.NextAction = nextActionForManagedOutcome(res.Outcome)
+		_ = b.audit("management_"+operation+"_dry_run", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	res.Outcome = "dry_run_ready"
+	res.RequiresConfirmation = true
+	res.Record = &record
+	res.AuditStatus = "audit_ready"
+	res.NextAction = "confirm_and_apply_with_audit_reason"
+	_ = b.audit("management_"+operation+"_dry_run", req.Ref, "dry_run_ready", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) managedEditApply(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	return b.managedWriteApply(req, "edit")
+}
+
+func (b *localBackend) managedResetApply(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	return b.managedWriteApply(req, "reset")
+}
+
+func (b *localBackend) managedWriteApply(req managedSecretActionRequest, operation string) (managedSecretActionResponse, error) {
+	res := baseManagedActionResponse(req, operation, "apply")
+	if err := validateManagedAction(req, true); err != nil || !req.Confirm || strings.TrimSpace(req.Value) == "" {
+		res.Outcome = "policy_denied"
+		res.NextAction = "run_dry_run_confirm_reason_and_value"
+		_ = b.audit("management_"+operation+"_apply", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		return res, errPolicyDenied
+	}
+	written, err := b.writeSecret(writeSecretRequest{Ref: req.Ref, Value: req.Value, Metadata: map[string]string{"sourceId": "management:" + operation}})
+	if err != nil {
+		res.Outcome = outcomeForError(err)
+		res.NextAction = nextActionForManagedOutcome(res.Outcome)
+		return res, err
+	}
+	record := managedRecordFromLocalEntry(req.Ref, secretEntry{Ref: req.Ref, Metadata: written.Metadata})
+	res.Outcome = "applied"
+	res.Applied = true
+	res.AuditStatus = "audit_recorded"
+	res.Metadata = &written.Metadata
+	res.Record = &record
+	_ = b.audit("management_"+operation+"_apply", req.Ref, "applied", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) managedPolicyApply(req managedSecretActionRequest) (managedSecretActionResponse, error) {
+	res := baseManagedActionResponse(req, "policy", "apply")
+	if err := validateManagedAction(req, true); err != nil || !req.Confirm || strings.TrimSpace(req.Policy) == "" {
+		res.Outcome = "policy_denied"
+		res.NextAction = "preview_confirm_reason_and_policy"
+		_ = b.audit("management_policy_apply", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		return res, errPolicyDenied
+	}
+	record, err := b.managedRecord(req.Ref)
+	if err != nil {
+		res.Outcome = outcomeForError(err)
+		res.NextAction = nextActionForManagedOutcome(res.Outcome)
+		return res, err
+	}
+	record.Policy = req.Policy
+	res.Outcome = "applied"
+	res.Applied = true
+	res.AuditStatus = "audit_recorded"
+	res.Record = &record
+	_ = b.audit("management_policy_apply", req.Ref, "applied", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) managedRecord(ref string) (managedSecretRecord, error) {
+	if !validSecretRef(ref) {
+		return managedSecretRecord{}, errInvalidRef
+	}
+	if b.locked() {
+		return managedSecretRecord{}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return managedSecretRecord{}, errBackendDegraded
+	}
+	if entry, ok := store.Secrets[ref]; ok {
+		return managedRecordFromLocalEntry(ref, entry), nil
+	}
+	for _, source := range b.sources.enabledSources() {
+		if _, ok := source.Refs[ref]; ok {
+			return managedRecordFromSource(ref, source), nil
+		}
+	}
+	return managedSecretRecord{}, errMissingRef
+}
+
+func baseManagedActionResponse(req managedSecretActionRequest, operation, mode string) managedSecretActionResponse {
+	return managedSecretActionResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, Ref: strings.TrimSpace(req.Ref), Operation: operation, Mode: mode, Outcome: "pending", AuditStatus: "audit_pending", AffectedRefs: safeList([]string{req.Ref}), AffectedServices: safeList([]string{req.ServiceID})}
+}
+
+func dryRunMode(operation string) string {
+	if operation == "policy" {
+		return "preview"
+	}
+	return "dry-run"
+}
+
+func validateManagedAction(req managedSecretActionRequest, requireReason bool) error {
+	if !validSecretRef(req.Ref) {
+		return errInvalidRef
+	}
+	if requireReason && strings.TrimSpace(req.Reason) == "" {
+		return errPolicyDenied
+	}
+	return nil
+}
+
+func outcomeForError(err error) string {
+	switch {
+	case errors.Is(err, errInvalidRef):
+		return "invalid_ref"
+	case errors.Is(err, errLocked):
+		return "locked"
+	case errors.Is(err, errMissingRef):
+		return "missing_ref"
+	case errors.Is(err, errPolicyDenied):
+		return "policy_denied"
+	case errors.Is(err, errSourceAuthRequired):
+		return "source_auth_required"
+	case errors.Is(err, errBackendDegraded):
+		return "degraded"
+	default:
+		return "degraded"
+	}
+}
+
+func outcomeError(outcome string) error {
+	switch outcome {
+	case "invalid_ref":
+		return errInvalidRef
+	case "locked":
+		return errLocked
+	case "source_auth_required":
+		return errSourceAuthRequired
+	case "policy_denied":
+		return errPolicyDenied
+	case "missing_ref":
+		return errMissingRef
+	default:
+		return errBackendDegraded
+	}
+}
+
+func nextActionForManagedOutcome(outcome string) string {
+	switch outcome {
+	case "locked":
+		return "unlock_broker"
+	case "missing_ref":
+		return "check_ref"
+	case "invalid_ref":
+		return "fix_ref"
+	case "policy_denied":
+		return "review_policy_and_reason"
+	case "source_auth_required":
+		return "reconnect_source"
+	case "source_unavailable", "degraded":
+		return "retry_or_inspect_source"
+	default:
+		return "inspect_status"
+	}
+}
+
+func registerSecretsManagementHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/management/secrets", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/management/secrets.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		res, err := backend.listManagedSecrets(r.URL.Query().Get("search"), false)
+		if err != nil {
+			writeManagementError(w, err, res.Outcome, "List managed secrets failed.")
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+	mux.HandleFunc("/v1/management/secrets/value-search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/management/secrets/value-search.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		res, err := backend.listManagedSecrets(r.URL.Query().Get("query"), true)
+		if err != nil {
+			writeManagementError(w, err, res.Outcome, "Value search failed closed.")
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+	registerManagedAction(mux, security, "/v1/management/secrets/reveal", backend.revealManagedSecret)
+	registerManagedAction(mux, security, "/v1/management/secrets/edit/dry-run", backend.managedEditDryRun)
+	registerManagedAction(mux, security, "/v1/management/secrets/edit/apply", backend.managedEditApply)
+	registerManagedAction(mux, security, "/v1/management/secrets/reset/dry-run", backend.managedResetDryRun)
+	registerManagedAction(mux, security, "/v1/management/secrets/reset/apply", backend.managedResetApply)
+	registerManagedAction(mux, security, "/v1/management/secrets/policy/preview", backend.managedPolicyPreview)
+	registerManagedAction(mux, security, "/v1/management/secrets/policy/apply", backend.managedPolicyApply)
+}
+
+func registerManagedAction(mux *http.ServeMux, security localAPISecurity, path string, handler func(managedSecretActionRequest) (managedSecretActionResponse, error)) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST "+path+".", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req managedSecretActionRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := handler(req)
+		if err != nil {
+			writeManagementActionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeManagementError(w http.ResponseWriter, err error, outcome, message string) {
+	status := http.StatusServiceUnavailable
+	if errors.Is(err, errInvalidRef) {
+		status = http.StatusBadRequest
+	}
+	writeAPIError(w, status, outcomeForError(err), message, outcome, nextActionForManagedOutcome(outcome))
+}
+
+func writeManagementActionError(w http.ResponseWriter, err error, res managedSecretActionResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errMissingRef):
+		status = http.StatusNotFound
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errSourceAuthRequired):
+		status = http.StatusFailedDependency
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/secrets_management_test.go
+++ b/cmd/secretsbroker/secrets_management_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const managedSecretValue = "fixture-managed-secret-value"
+
+func TestManagedSecretsListAndMetadataSearchAreMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	writeManagedTestSecret(t, backend, "services/payments/runtime/PAYMENTS_SIGNING_REF", "payments-fixture-value")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "vault-dev", Kind: "vault", DisplayName: "Vault dev", Enabled: true, Address: "https://vault.invalid", Token: "token-fixture", Refs: map[string]sourceRefConfig{
+			"services/search/runtime/EXTERNAL_ONLY_REF": {Path: "secret/data/search", Field: "value"},
+		},
+	}}}
+
+	res, err := backend.listManagedSecrets("serviceadmin", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "ready" || len(res.Results) != 1 {
+		t.Fatalf("metadata search response = %#v", res)
+	}
+	if res.Results[0].Ref != "services/@serviceadmin/runtime/SESSION_SIGNING_KEY" || res.Results[0].ValueSearch != "supported" {
+		t.Fatalf("metadata row = %#v", res.Results[0])
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "payments-fixture-value", "token-fixture")
+
+	all, err := backend.listManagedSecrets("", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all.Results) != 3 {
+		t.Fatalf("expected local and configured source refs, got %#v", all.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, all), managedSecretValue, "payments-fixture-value", "token-fixture")
+}
+
+func TestManagedValueSearchReturnsRefsOnlyAndOmitsUnsupportedSources(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	writeManagedTestSecret(t, backend, "services/worker/runtime/OTHER_REF", "unmatched-fixture-value")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "file-source", Kind: "file", Enabled: true, Refs: map[string]sourceRefConfig{
+			"services/file/runtime/FILE_ONLY_REF": {Path: "C:/not-used"},
+		},
+	}}}
+
+	res, err := backend.listManagedSecrets("managed-secret", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.ValueSearch || len(res.Results) != 1 || res.Results[0].Ref != "services/@serviceadmin/runtime/SESSION_SIGNING_KEY" {
+		t.Fatalf("value search response = %#v", res)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "unmatched-fixture-value")
+}
+
+func TestManagedRevealIsOnlyRawValueSuccessPath(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	list, err := backend.listManagedSecrets("SESSION", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, list), managedSecretValue)
+
+	reveal, err := backend.revealManagedSecret(managedSecretActionRequest{RequestID: "req-reveal", ServiceID: "@serviceadmin", Ref: ref, Reason: "operator audit reason"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reveal.Outcome != "ready" || reveal.Value != managedSecretValue || reveal.TTLSeconds != revealTTLSeconds || reveal.AuditStatus != "audit_recorded" {
+		t.Fatalf("reveal response = %#v", reveal)
+	}
+
+	denied, err := backend.revealManagedSecret(managedSecretActionRequest{RequestID: "req-denied", ServiceID: "@serviceadmin", Ref: ref})
+	if err == nil || denied.Value != "" || denied.Outcome == "ready" {
+		t.Fatalf("missing reason should fail closed without value: %#v err=%v", denied, err)
+	}
+}
+
+func TestManagedDryRunApplyAndPolicyContractsDoNotReturnRawValues(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	dryRun, err := backend.managedEditDryRun(managedSecretActionRequest{RequestID: "req-edit-dry-run", ServiceID: "@serviceadmin", Ref: ref})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dryRun.Outcome != "dry_run_ready" || !dryRun.RequiresConfirmation || dryRun.Applied || dryRun.Value != "" {
+		t.Fatalf("edit dry-run = %#v", dryRun)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, dryRun), managedSecretValue, "replacement-value")
+
+	blocked, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-edit-blocked", ServiceID: "@serviceadmin", Ref: ref, Value: "replacement-value"})
+	if err == nil || blocked.Applied || blocked.Value != "" || blocked.Outcome != "policy_denied" {
+		t.Fatalf("unconfirmed edit apply should fail closed: %#v err=%v", blocked, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, blocked), managedSecretValue, "replacement-value")
+
+	applied, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-edit-apply", ServiceID: "@serviceadmin", Ref: ref, Reason: "approved", Confirm: true, Value: "replacement-value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied.Applied || applied.Outcome != "applied" || applied.Value != "" {
+		t.Fatalf("edit apply = %#v", applied)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "replacement-value")
+
+	reset, err := backend.managedResetDryRun(managedSecretActionRequest{RequestID: "req-reset-dry-run", ServiceID: "@serviceadmin", Ref: ref})
+	if err != nil || reset.Outcome != "dry_run_ready" || reset.Value != "" {
+		t.Fatalf("reset dry-run = %#v err=%v", reset, err)
+	}
+
+	preview, err := backend.managedPolicyPreview(managedSecretActionRequest{RequestID: "req-policy-preview", ServiceID: "@serviceadmin", Ref: ref})
+	if err != nil || preview.Mode != "preview" || preview.Outcome != "dry_run_ready" {
+		t.Fatalf("policy preview = %#v err=%v", preview, err)
+	}
+
+	policy, err := backend.managedPolicyApply(managedSecretActionRequest{RequestID: "req-policy-apply", ServiceID: "@serviceadmin", Ref: ref, Reason: "approved", Confirm: true, Policy: "policy/serviceadmin/reveal"})
+	if err != nil || !policy.Applied || policy.Value != "" || policy.Record.Policy != "policy/serviceadmin/reveal" {
+		t.Fatalf("policy apply = %#v err=%v", policy, err)
+	}
+}
+
+func TestManagedHTTPContractAndFailClosedErrors(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	listReq, err := http.NewRequest(http.MethodGet, server.URL+"/v1/management/secrets?search=SESSION", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listReq.Header.Set("Authorization", "Bearer test-token")
+	listRes, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listBody := readClose(t, listRes.Body)
+	if listRes.StatusCode != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listRes.StatusCode, listBody)
+	}
+	assertNoSecretMaterial(t, listBody, managedSecretValue)
+
+	revealBody := []byte(`{"requestId":"req-http-reveal","serviceId":"@serviceadmin","ref":"` + ref + `","reason":"operator approved"}`)
+	revealReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/reveal", bytes.NewReader(revealBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	revealReq.Header.Set("Content-Type", "application/json")
+	revealReq.Header.Set("X-SecretsBroker-Token", "test-token")
+	revealRes, err := http.DefaultClient.Do(revealReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revealed := readClose(t, revealRes.Body)
+	if revealRes.StatusCode != http.StatusOK || !bytes.Contains(revealed, []byte(managedSecretValue)) {
+		t.Fatalf("reveal status=%d body=%s", revealRes.StatusCode, revealed)
+	}
+
+	missingBody := []byte(`{"requestId":"req-missing","serviceId":"@serviceadmin","ref":"services/missing/runtime/NOPE","reason":"operator approved"}`)
+	missingReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/reveal", bytes.NewReader(missingBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingReq.Header.Set("Content-Type", "application/json")
+	missingReq.Header.Set("Authorization", "Bearer test-token")
+	missingRes, err := http.DefaultClient.Do(missingReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := readClose(t, missingRes.Body)
+	if missingRes.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing status=%d body=%s", missingRes.StatusCode, missing)
+	}
+	assertNoSecretMaterial(t, missing, managedSecretValue)
+}
+
+func TestManagedListLockedFailsClosed(t *testing.T) {
+	backend := newLocalBackend(t.TempDir()+"/store.json", t.TempDir()+"/audit.jsonl", "")
+	res, err := backend.listManagedSecrets("", false)
+	if err == nil || res.Outcome != "locked" || len(res.Results) != 0 {
+		t.Fatalf("locked list should fail closed: %#v err=%v", res, err)
+	}
+}
+
+func managedTestBackend(t *testing.T) *localBackend {
+	t.Helper()
+	return testBackend(t)
+}
+
+func writeManagedTestSecret(t *testing.T, backend *localBackend, ref, value string) {
+	t.Helper()
+	_, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: value, Metadata: map[string]string{"sourceId": "local-test"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustManagedJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func assertNoSecretMaterial(t *testing.T, payload []byte, forbidden ...string) {
+	t.Helper()
+	lower := strings.ToLower(string(payload))
+	for _, secret := range forbidden {
+		if secret != "" && strings.Contains(lower, strings.ToLower(secret)) {
+			t.Fatalf("payload leaked secret material %q: %s", secret, payload)
+		}
+	}
+	for _, marker := range []string{"correct-horse-battery-staple", "private key", "bearer test-token", "token-fixture"} {
+		if strings.Contains(lower, marker) {
+			t.Fatalf("payload contains forbidden marker %q: %s", marker, payload)
+		}
+	}
+}
+
+func readClose(t *testing.T, body io.ReadCloser) []byte {
+	t.Helper()
+	defer body.Close()
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -1,0 +1,106 @@
+# Secrets management API contract
+
+This contract powers the Service Admin `Secrets Broker > Secrets` management table.
+
+The contract is metadata-first. List/search/value-search responses return safe refs and status metadata only. Raw values are returned only by the explicit reveal endpoint after local API auth, policy/audit checks, and a requested audit reason.
+
+## Safety boundaries
+
+- List/search endpoints never return `value`, plaintext, ciphertext, provider credentials, tokens, or backend credential payloads.
+- Broker-backed value search runs inside Secrets Broker and returns matching refs/metadata only.
+- Service Admin must not receive all plaintext values for client-side indexing.
+- Denied, locked, missing, auth-required, unavailable, unsupported, and degraded states fail closed with typed outcomes.
+- Edit/reset/policy operations expose dry-run/preview before apply.
+- Apply requests are secret-bearing where relevant and use the same local API auth and body-size guardrails as existing write/resolve endpoints.
+- Audit entries record operation/ref/outcome/request identity only; they do not include raw values.
+
+## Endpoints
+
+All endpoints require the local API token when configured, via `Authorization: Bearer <token>` or `X-SecretsBroker-Token`.
+
+### `GET /v1/management/secrets?search=<metadata-query>`
+
+Returns metadata-only records from the local encrypted store and configured source refs.
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "query": "session",
+  "valueSearch": false,
+  "outcome": "ready",
+  "results": [
+    {
+      "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+      "name": "SESSION_SIGNING_KEY",
+      "sourceId": "local",
+      "providerKind": "local-encrypted-store",
+      "ownerServiceId": "@serviceadmin",
+      "workspaceId": "local",
+      "state": "present",
+      "outcome": "ready",
+      "capabilities": ["metadata", "reveal", "edit", "reset", "policy"],
+      "policy": "local-writeback-policy",
+      "auditStatus": "audit_available",
+      "valueSearch": "supported"
+    }
+  ]
+}
+```
+
+### `GET /v1/management/secrets/value-search?query=<broker-query>`
+
+Optional broker-backed value search. The broker may inspect local/provider values internally, but it returns refs/metadata only. Unsupported providers are omitted from matches and represented through metadata capability/status.
+
+### `POST /v1/management/secrets/reveal`
+
+Explicit reveal path. This is the only management endpoint that may return a raw value.
+
+Request:
+
+```json
+{
+  "requestId": "req-reveal-1",
+  "serviceId": "@serviceadmin",
+  "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+  "reason": "operator troubleshooting"
+}
+```
+
+Success response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "req-reveal-1",
+  "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+  "operation": "reveal",
+  "outcome": "ready",
+  "value": "<raw value only on explicit reveal success>",
+  "metadata": { "sourceId": "local", "version": "..." },
+  "ttlSeconds": 60,
+  "auditStatus": "audit_recorded"
+}
+```
+
+### `POST /v1/management/secrets/edit/dry-run`
+### `POST /v1/management/secrets/edit/apply`
+
+Dry-run validates ref, policy, backend state, and audit requirements. Apply requires a value and explicit confirmation/audit reason. Responses do not include raw values.
+
+### `POST /v1/management/secrets/reset/dry-run`
+### `POST /v1/management/secrets/reset/apply`
+
+Dry-run validates reset/rotate readiness. Apply stores caller-provided replacement material (or a future provider-generated value) without returning the raw value.
+
+### `POST /v1/management/secrets/policy/preview`
+### `POST /v1/management/secrets/policy/apply`
+
+Preview/apply policy changes. This first contract records the requested policy handle/status and returns metadata-only outcomes; provider-specific enforcement can be expanded behind the same response shape.
+
+## Typed outcomes
+
+Common outcomes: `ready`, `dry_run_ready`, `applied`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`.


### PR DESCRIPTION
## Summary
- Add a metadata-first Secrets Broker management API contract for Service Admin's `Secrets Broker > Secrets` table.
- Add endpoints for metadata list/search, broker-backed value search returning refs/metadata only, controlled reveal, edit dry-run/apply, reset dry-run/apply, and policy preview/apply.
- Document the contract and fail-closed safety boundaries in `docs/secrets-management-api.md`.
- Add tests proving list/search/value-search responses are metadata-only, raw value only appears in explicit reveal success, dry-run/apply responses do not leak raw material, and locked/missing/denied states fail closed.

## Safety notes
- List/search endpoints never return raw values or provider credentials.
- Value search decrypts locally inside the broker only and returns safe refs/metadata.
- Reveal is the only management response path with a raw value and requires auth + audit reason.
- Edit/reset/policy apply responses do not return submitted/replacement values.
- Audit events record operation/ref/outcome/request identity only.

## Validation
- `go test ./cmd/secretsbroker` — passed
- `go test ./...` — passed
- `.\scripts\test.ps1` — passed

Closes #35
Related: service-lasso/lasso-serviceadmin#82, service-lasso/lasso-serviceadmin#84, service-lasso/lasso-serviceadmin#81, service-lasso/lasso-serviceadmin#40
