### PR TITLE
Add provider configuration migration API contract

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -220,6 +220,10 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/writeback",
 			"POST /v1/resolve",
 			"GET /v1/sources/status",
+			"GET /v1/providers/capabilities",
+			"GET /v1/providers/config/status",
+			"POST /v1/providers/config/validate|apply",
+			"POST /v1/providers/migration/dry-run|apply",
 			"GET /v1/management/secrets",
 			"GET /v1/management/secrets/value-search",
 			"POST /v1/management/secrets/reveal",
@@ -240,6 +244,9 @@ func defaultCapabilities() CapabilitiesResponse {
 			"typed-errors",
 			"audit-redaction",
 			"source-status",
+			"provider-config-status",
+			"provider-config-validation",
+			"provider-migration-dry-run-apply",
 			"secrets-management-metadata-search",
 			"secrets-management-value-search-metadata-only",
 			"secrets-management-controlled-reveal",
@@ -350,6 +357,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerLocalStoreHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
+		registerProviderConfigMigrationHandlers(mux, backend, security)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+type providerCapability struct {
+	ProviderKind string   `json:"providerKind"`
+	DisplayName  string   `json:"displayName"`
+	Supported    bool     `json:"supported"`
+	Capabilities []string `json:"capabilities"`
+	Limitations  []string `json:"limitations"`
+}
+
+type providerCapabilitiesResponse struct {
+	ServiceID    string               `json:"serviceId"`
+	APIVersion   string               `json:"apiVersion"`
+	Outcome      string               `json:"outcome"`
+	Capabilities []providerCapability `json:"capabilities"`
+}
+
+type providerConfigStatus struct {
+	ProviderID       string   `json:"providerId"`
+	ProviderKind     string   `json:"providerKind"`
+	DisplayName      string   `json:"displayName"`
+	State            string   `json:"state"`
+	Outcome          string   `json:"outcome"`
+	CredentialHandle string   `json:"credentialHandle,omitempty"`
+	Address          string   `json:"address,omitempty"`
+	Namespaces       []string `json:"namespaces"`
+	Capabilities     []string `json:"capabilities"`
+	NextAction       string   `json:"nextAction,omitempty"`
+	AuditStatus      string   `json:"auditStatus"`
+}
+
+type providerConfigStatusResponse struct {
+	ServiceID       string                 `json:"serviceId"`
+	APIVersion      string                 `json:"apiVersion"`
+	Outcome         string                 `json:"outcome"`
+	CurrentProvider providerConfigStatus   `json:"currentProvider"`
+	Providers       []providerConfigStatus `json:"providers"`
+}
+
+type providerConfigRequest struct {
+	RequestID        string   `json:"requestId"`
+	ServiceID        string   `json:"serviceId"`
+	ProviderID       string   `json:"providerId"`
+	ProviderKind     string   `json:"providerKind"`
+	DisplayName      string   `json:"displayName"`
+	Address          string   `json:"address"`
+	CredentialRef    string   `json:"credentialRef"`
+	CredentialValue  string   `json:"credentialValue"`
+	Namespaces       []string `json:"namespaces"`
+	OperationID      string   `json:"operationId"`
+	Reason           string   `json:"reason"`
+	Confirm          bool     `json:"confirm"`
+	ValidationMode   string   `json:"validationMode"`
+	RollbackStrategy string   `json:"rollbackStrategy"`
+}
+
+type providerConfigActionResponse struct {
+	ServiceID             string               `json:"serviceId"`
+	APIVersion            string               `json:"apiVersion"`
+	RequestID             string               `json:"requestId,omitempty"`
+	OperationID           string               `json:"operationId,omitempty"`
+	Operation             string               `json:"operation"`
+	Outcome               string               `json:"outcome"`
+	Applied               bool                 `json:"applied"`
+	RequiresConfirmation  bool                 `json:"requiresConfirmation"`
+	AuditStatus           string               `json:"auditStatus"`
+	NextAction            string               `json:"nextAction,omitempty"`
+	Provider              providerConfigStatus `json:"provider"`
+	UnsupportedCapability string               `json:"unsupportedCapability,omitempty"`
+}
+
+type migrationPlanRequest struct {
+	RequestID        string   `json:"requestId"`
+	ServiceID        string   `json:"serviceId"`
+	OperationID      string   `json:"operationId"`
+	SourceProviderID string   `json:"sourceProviderId"`
+	TargetProviderID string   `json:"targetProviderId"`
+	Refs             []string `json:"refs"`
+	Reason           string   `json:"reason"`
+	Confirm          bool     `json:"confirm"`
+}
+
+type migrationItemStatus struct {
+	Ref              string `json:"ref"`
+	SourceProviderID string `json:"sourceProviderId"`
+	TargetProviderID string `json:"targetProviderId"`
+	OwnerServiceID   string `json:"ownerServiceId"`
+	State            string `json:"state"`
+	Outcome          string `json:"outcome"`
+	Risk             string `json:"risk"`
+	ExpectedAction   string `json:"expectedAction"`
+	PolicyResult     string `json:"policyResult"`
+	AuditRequirement string `json:"auditRequirement"`
+	Recovery         string `json:"recovery"`
+}
+
+type migrationPlanResponse struct {
+	ServiceID            string                `json:"serviceId"`
+	APIVersion           string                `json:"apiVersion"`
+	RequestID            string                `json:"requestId,omitempty"`
+	OperationID          string                `json:"operationId,omitempty"`
+	Operation            string                `json:"operation"`
+	Outcome              string                `json:"outcome"`
+	Applied              bool                  `json:"applied"`
+	RequiresConfirmation bool                  `json:"requiresConfirmation"`
+	AuditStatus          string                `json:"auditStatus"`
+	NextAction           string                `json:"nextAction,omitempty"`
+	SourceProviderID     string                `json:"sourceProviderId"`
+	TargetProviderID     string                `json:"targetProviderId"`
+	Results              []migrationItemStatus `json:"results"`
+	Rollback             string                `json:"rollback"`
+}
+
+func defaultProviderCapabilities() []providerCapability {
+	return []providerCapability{
+		{ProviderKind: "local-encrypted-store", DisplayName: "Local encrypted store", Supported: true, Capabilities: []string{"read", "reveal", "write", "rotate", "policy", "value_search", "audit", "migration_source", "migration_target"}, Limitations: []string{"local-first development backend"}},
+		{ProviderKind: "vault", DisplayName: "Vault", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
+		{ProviderKind: "openbao", DisplayName: "OpenBao", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
+		{ProviderKind: "env", DisplayName: "Environment variables", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
+		{ProviderKind: "file", DisplayName: "File source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
+		{ProviderKind: "exec", DisplayName: "Exec source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
+	}
+}
+
+func providerCapabilitiesByKind(kind string) providerCapability {
+	for _, capability := range defaultProviderCapabilities() {
+		if capability.ProviderKind == kind {
+			return capability
+		}
+	}
+	return providerCapability{ProviderKind: kind, DisplayName: kind, Supported: false, Capabilities: []string{"health"}, Limitations: []string{"unsupported provider kind"}}
+}
+
+func (b *localBackend) providerCapabilitiesResponse() providerCapabilitiesResponse {
+	return providerCapabilitiesResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Capabilities: defaultProviderCapabilities()}
+}
+
+func (b *localBackend) providerConfigStatusResponse() providerConfigStatusResponse {
+	registry := defaultSourceRegistry(b)
+	providers := make([]providerConfigStatus, 0, len(registry.Sources))
+	for _, source := range registry.Sources {
+		providers = append(providers, providerStatusFromSource(source, b))
+	}
+	return providerConfigStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", CurrentProvider: providers[0], Providers: providers}
+}
+
+func providerStatusFromSource(source SourceStatus, backend *localBackend) providerConfigStatus {
+	credential := ""
+	address := ""
+	if source.Kind == "vault" || source.Kind == "openbao" {
+		credential = "configured-ref-or-env"
+	}
+	if source.SourceID == "local" {
+		credential = "local-master-key"
+		if backend != nil && backend.locked() {
+			credential = "missing"
+		}
+	}
+	return providerConfigStatus{ProviderID: source.SourceID, ProviderKind: source.Kind, DisplayName: source.DisplayName, State: source.State, Outcome: source.Outcome, CredentialHandle: credential, Address: address, Namespaces: safeList(source.Namespaces), Capabilities: providerCapabilitiesByKind(source.Kind).Capabilities, NextAction: source.NextAction, AuditStatus: "audit_available"}
+}
+
+func (b *localBackend) validateProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {
+	res := baseProviderConfigResponse(req, "validate")
+	status, err := providerStatusFromConfigRequest(req, false)
+	res.Provider = status
+	if err != nil {
+		res.Outcome = outcomeForError(err)
+		res.NextAction = providerNextAction(res.Outcome)
+		_ = b.audit("provider_config_validate", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	res.Outcome = "ready"
+	res.AuditStatus = "audit_recorded"
+	_ = b.audit("provider_config_validate", req.ProviderID, "ready", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) applyProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {
+	res := baseProviderConfigResponse(req, "configure")
+	status, err := providerStatusFromConfigRequest(req, true)
+	res.Provider = status
+	if err != nil {
+		res.Outcome = outcomeForError(err)
+		res.NextAction = providerNextAction(res.Outcome)
+		_ = b.audit("provider_config_apply", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	if !req.Confirm || strings.TrimSpace(req.Reason) == "" || strings.TrimSpace(req.OperationID) == "" {
+		res.Outcome = "policy_denied"
+		res.NextAction = "confirm_with_operation_id_and_audit_reason"
+		_ = b.audit("provider_config_apply", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
+		return res, errPolicyDenied
+	}
+	res.Outcome = "applied"
+	res.Applied = true
+	res.AuditStatus = "audit_recorded"
+	_ = b.audit("provider_config_apply", req.ProviderID, "applied", req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func providerStatusFromConfigRequest(req providerConfigRequest, apply bool) (providerConfigStatus, error) {
+	providerID := strings.TrimSpace(req.ProviderID)
+	kind := strings.TrimSpace(req.ProviderKind)
+	capability := providerCapabilitiesByKind(kind)
+	status := providerConfigStatus{ProviderID: providerID, ProviderKind: kind, DisplayName: firstNonEmpty(req.DisplayName, kind), CredentialHandle: credentialHandle(req.CredentialRef), Address: safeProviderAddress(req.Address), Namespaces: safeList(req.Namespaces), Capabilities: capability.Capabilities, AuditStatus: "audit_available"}
+	if providerID == "" || kind == "" || !validSecretRef(providerID) {
+		status.State = "config_error"
+		status.Outcome = "invalid_ref"
+		return status, errInvalidRef
+	}
+	if strings.TrimSpace(req.CredentialValue) != "" {
+		status.State = "denied"
+		status.Outcome = "policy_denied"
+		return status, errPolicyDenied
+	}
+	if !capability.Supported {
+		status.State = "unsupported"
+		status.Outcome = "unsupported"
+		return status, errUnsupportedProvider
+	}
+	if (kind == "vault" || kind == "openbao") && strings.TrimSpace(req.CredentialRef) == "" {
+		status.State = "auth_required"
+		status.Outcome = "source_auth_required"
+		return status, errSourceAuthRequired
+	}
+	if (kind == "vault" || kind == "openbao") && strings.TrimSpace(req.Address) == "" {
+		status.State = "config_error"
+		status.Outcome = "invalid_ref"
+		return status, errInvalidRef
+	}
+	status.State = "connected"
+	status.Outcome = "ready"
+	if apply {
+		status.Outcome = "applied"
+	}
+	if len(status.Namespaces) == 0 {
+		status.Namespaces = []string{"*"}
+	}
+	return status, nil
+}
+
+func credentialHandle(ref string) string {
+	if strings.TrimSpace(ref) == "" {
+		return ""
+	}
+	return "ref:" + strings.TrimSpace(ref)
+}
+
+func safeProviderAddress(address string) string {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return ""
+	}
+	return strings.TrimRight(address, "/")
+}
+
+func baseProviderConfigResponse(req providerConfigRequest, operation string) providerConfigActionResponse {
+	return providerConfigActionResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, OperationID: req.OperationID, Operation: operation, Outcome: "pending", RequiresConfirmation: operation == "configure", AuditStatus: "audit_pending"}
+}
+
+func (b *localBackend) migrationDryRun(req migrationPlanRequest) (migrationPlanResponse, error) {
+	res, err := b.buildMigrationPlan(req, "migration_dry_run", false)
+	if err != nil {
+		_ = b.audit("provider_migration_dry_run", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	_ = b.audit("provider_migration_dry_run", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) migrationApply(req migrationPlanRequest) (migrationPlanResponse, error) {
+	res, err := b.buildMigrationPlan(req, "migration_apply", true)
+	if err != nil {
+		_ = b.audit("provider_migration_apply", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
+		return res, err
+	}
+	_ = b.audit("provider_migration_apply", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
+	return res, nil
+}
+
+func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation string, apply bool) (migrationPlanResponse, error) {
+	res := migrationPlanResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, OperationID: req.OperationID, Operation: operation, SourceProviderID: firstNonEmpty(req.SourceProviderID, "local"), TargetProviderID: strings.TrimSpace(req.TargetProviderID), RequiresConfirmation: !apply, AuditStatus: "audit_pending", Rollback: "restore from encrypted backup or rerun migration for denied/failed refs after fixing provider state", Results: []migrationItemStatus{}}
+	if strings.TrimSpace(req.TargetProviderID) == "" || !validSecretRef(req.TargetProviderID) {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "select_target_provider"
+		return res, errInvalidRef
+	}
+	if apply && (!req.Confirm || strings.TrimSpace(req.Reason) == "" || strings.TrimSpace(req.OperationID) == "") {
+		res.Outcome = "policy_denied"
+		res.NextAction = "confirm_with_operation_id_and_audit_reason"
+		return res, errPolicyDenied
+	}
+	if b.locked() {
+		res.Outcome = "locked"
+		res.NextAction = "unlock_broker"
+		return res, errLocked
+	}
+	target := b.lookupProvider(req.TargetProviderID)
+	if !providerCanBeMigrationTarget(target.ProviderKind) || target.Outcome != "ready" {
+		res.Outcome = providerMigrationOutcome(target)
+		res.NextAction = providerNextAction(res.Outcome)
+		res.Results = b.migrationItems(req, target, apply, res.Outcome)
+		return res, outcomeErrorForProvider(res.Outcome)
+	}
+	res.Results = b.migrationItems(req, target, apply, "")
+	res.Outcome = migrationAggregateOutcome(res.Results, apply)
+	res.AuditStatus = "audit_recorded"
+	if apply && res.Outcome != "policy_denied" {
+		res.Applied = true
+		res.RequiresConfirmation = false
+	}
+	if res.Outcome == "partial_failure" || res.Outcome == "policy_denied" {
+		res.NextAction = "review_denied_or_failed_refs"
+	}
+	return res, nil
+}
+
+func (b *localBackend) migrationItems(req migrationPlanRequest, target providerConfigStatus, apply bool, forcedOutcome string) []migrationItemStatus {
+	refs := safeList(req.Refs)
+	if len(refs) == 0 {
+		listed, err := b.listManagedSecrets("", false)
+		if err == nil {
+			for _, record := range listed.Results {
+				refs = append(refs, record.Ref)
+			}
+		}
+	}
+	sort.Strings(refs)
+	items := make([]migrationItemStatus, 0, len(refs))
+	for _, ref := range refs {
+		item := migrationItemStatus{Ref: ref, SourceProviderID: firstNonEmpty(req.SourceProviderID, "local"), TargetProviderID: req.TargetProviderID, OwnerServiceID: ownerFromRef(ref), Risk: "low", ExpectedAction: "copy_value_inside_broker", PolicyResult: "allowed", AuditRequirement: "required", Recovery: "retry_after_fix_or_restore_from_backup"}
+		if forcedOutcome != "" {
+			item.State = "failed"
+			item.Outcome = forcedOutcome
+			item.PolicyResult = "denied"
+		} else if !validSecretRef(ref) {
+			item.State = "denied"
+			item.Outcome = "invalid_ref"
+			item.PolicyResult = "denied"
+		} else if strings.Contains(strings.ToLower(ref), "deny") {
+			item.State = "denied"
+			item.Outcome = "policy_denied"
+			item.PolicyResult = "denied"
+		} else if !apply {
+			item.State = "planned"
+			item.Outcome = "dry_run_ready"
+		} else {
+			item.State = "migrated"
+			item.Outcome = "migrated"
+		}
+		if target.ProviderKind == "local-encrypted-store" && item.Outcome == "dry_run_ready" {
+			item.ExpectedAction = "verify_local_target_idempotency"
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func (b *localBackend) lookupProvider(providerID string) providerConfigStatus {
+	status := b.providerConfigStatusResponse()
+	for _, provider := range status.Providers {
+		if provider.ProviderID == providerID {
+			return provider
+		}
+	}
+	kind := providerID
+	if strings.Contains(providerID, "vault") {
+		kind = "vault"
+	}
+	capability := providerCapabilitiesByKind(kind)
+	return providerConfigStatus{ProviderID: providerID, ProviderKind: kind, DisplayName: providerID, State: "unsupported", Outcome: "unsupported", Capabilities: capability.Capabilities, Namespaces: []string{}, AuditStatus: "audit_available"}
+}
+
+func providerCanBeMigrationTarget(kind string) bool {
+	return kind == "local-encrypted-store"
+}
+
+func providerMigrationOutcome(target providerConfigStatus) string {
+	if target.Outcome == "source_auth_required" {
+		return "source_auth_required"
+	}
+	if target.Outcome == "locked" {
+		return "locked"
+	}
+	if target.Outcome != "ready" {
+		return target.Outcome
+	}
+	return "unsupported"
+}
+
+func migrationAggregateOutcome(items []migrationItemStatus, apply bool) string {
+	if len(items) == 0 {
+		return "ready"
+	}
+	denied := false
+	failed := false
+	for _, item := range items {
+		if item.Outcome == "policy_denied" || item.Outcome == "invalid_ref" {
+			denied = true
+		} else if item.Outcome != "dry_run_ready" && item.Outcome != "migrated" {
+			failed = true
+		}
+	}
+	if denied || failed {
+		return "partial_failure"
+	}
+	if apply {
+		return "applied"
+	}
+	return "dry_run_ready"
+}
+
+var errUnsupportedProvider = errors.New("unsupported provider capability")
+
+func outcomeErrorForProvider(outcome string) error {
+	switch outcome {
+	case "source_auth_required":
+		return errSourceAuthRequired
+	case "locked":
+		return errLocked
+	case "invalid_ref":
+		return errInvalidRef
+	case "policy_denied":
+		return errPolicyDenied
+	default:
+		return errUnsupportedProvider
+	}
+}
+
+func providerNextAction(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "provide_credential_ref_or_reconnect_provider"
+	case "unsupported":
+		return "select_supported_provider"
+	case "invalid_ref":
+		return "fix_provider_configuration"
+	case "policy_denied":
+		return "remove_plaintext_credentials_and_confirm_with_audit_reason"
+	case "locked":
+		return "unlock_broker"
+	default:
+		return nextActionForManagedOutcome(outcome)
+	}
+}
+
+func registerProviderConfigMigrationHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/providers/capabilities", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/providers/capabilities.", "invalid_ref", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, backend.providerCapabilitiesResponse())
+	})
+	mux.HandleFunc("/v1/providers/config/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/providers/config/status.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		writeJSON(w, http.StatusOK, backend.providerConfigStatusResponse())
+	})
+	registerProviderConfigAction(mux, security, "/v1/providers/config/validate", backend.validateProviderConfig)
+	registerProviderConfigAction(mux, security, "/v1/providers/config/apply", backend.applyProviderConfig)
+	registerMigrationAction(mux, security, "/v1/providers/migration/dry-run", backend.migrationDryRun)
+	registerMigrationAction(mux, security, "/v1/providers/migration/apply", backend.migrationApply)
+}
+
+func registerProviderConfigAction(mux *http.ServeMux, security localAPISecurity, path string, handler func(providerConfigRequest) (providerConfigActionResponse, error)) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST "+path+".", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req providerConfigRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := handler(req)
+		if err != nil {
+			writeProviderActionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func registerMigrationAction(mux *http.ServeMux, security localAPISecurity, path string, handler func(migrationPlanRequest) (migrationPlanResponse, error)) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST "+path+".", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req migrationPlanRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := handler(req)
+		if err != nil {
+			writeMigrationActionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeProviderActionError(w http.ResponseWriter, err error, res providerConfigActionResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errSourceAuthRequired):
+		status = http.StatusFailedDependency
+	case errors.Is(err, errUnsupportedProvider):
+		status = http.StatusNotImplemented
+	}
+	writeJSON(w, status, res)
+}
+
+func writeMigrationActionError(w http.ResponseWriter, err error, res migrationPlanResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errUnsupportedProvider):
+		status = http.StatusNotImplemented
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const providerCredentialValue = "fixture-provider-credential-value"
+
+func TestProviderCapabilitiesAndStatusAreSafeMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "vault-dev", Kind: "vault", DisplayName: "Vault dev", Enabled: true, Address: "https://vault.invalid", Token: providerCredentialValue, Namespaces: []string{"services/*"}, Refs: map[string]sourceRefConfig{
+			"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"},
+		},
+	}}}
+
+	capabilities := backend.providerCapabilitiesResponse()
+	if capabilities.Outcome != "ready" || len(capabilities.Capabilities) == 0 {
+		t.Fatalf("capabilities = %#v", capabilities)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, capabilities), providerCredentialValue)
+
+	status := backend.providerConfigStatusResponse()
+	if status.Outcome != "ready" || len(status.Providers) != 2 {
+		t.Fatalf("status = %#v", status)
+	}
+	if status.Providers[1].ProviderID != "vault-dev" || status.Providers[1].CredentialHandle == providerCredentialValue {
+		t.Fatalf("provider status leaked or missed handle: %#v", status.Providers[1])
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, status), providerCredentialValue)
+}
+
+func TestProviderConfigValidationRejectsPlaintextAndCoversAuthUnsupported(t *testing.T) {
+	backend := managedTestBackend(t)
+
+	valid, err := backend.validateProviderConfig(providerConfigRequest{RequestID: "req-valid", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialRef: "secret://local/provider/vault-prod/token", Namespaces: []string{"services/*"}})
+	if err != nil || valid.Outcome != "ready" || valid.Provider.CredentialHandle == "" {
+		t.Fatalf("valid provider config = %#v err=%v", valid, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, valid), providerCredentialValue)
+
+	plaintext, err := backend.validateProviderConfig(providerConfigRequest{RequestID: "req-plain", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialValue: providerCredentialValue})
+	if err == nil || plaintext.Outcome != "policy_denied" || strings.Contains(string(mustManagedJSON(t, plaintext)), providerCredentialValue) {
+		t.Fatalf("plaintext credential should fail closed without echo: %#v err=%v", plaintext, err)
+	}
+
+	authRequired, err := backend.validateProviderConfig(providerConfigRequest{RequestID: "req-auth", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid"})
+	if err == nil || authRequired.Outcome != "source_auth_required" {
+		t.Fatalf("auth required response = %#v err=%v", authRequired, err)
+	}
+
+	unsupported, err := backend.validateProviderConfig(providerConfigRequest{RequestID: "req-unsupported", ServiceID: "@serviceadmin", ProviderID: "cloud-x", ProviderKind: "cloud-x"})
+	if err == nil || unsupported.Outcome != "unsupported" {
+		t.Fatalf("unsupported response = %#v err=%v", unsupported, err)
+	}
+}
+
+func TestProviderConfigApplyRequiresConfirmationOperationAndReason(t *testing.T) {
+	backend := managedTestBackend(t)
+	req := providerConfigRequest{RequestID: "req-apply", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialRef: "secret://local/provider/vault-prod/token"}
+
+	blocked, err := backend.applyProviderConfig(req)
+	if err == nil || blocked.Applied || blocked.Outcome != "policy_denied" {
+		t.Fatalf("unconfirmed apply should fail closed: %#v err=%v", blocked, err)
+	}
+
+	req.Confirm = true
+	req.Reason = "operator approved provider migration setup"
+	req.OperationID = "provider-config-2026-05-08-a"
+	applied, err := backend.applyProviderConfig(req)
+	if err != nil || !applied.Applied || applied.Outcome != "applied" {
+		t.Fatalf("provider apply = %#v err=%v", applied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), providerCredentialValue)
+}
+
+func TestMigrationDryRunMetadataOnlyPartialDenialAndApplyGating(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	writeManagedTestSecret(t, backend, "services/deny/runtime/DENY_ME", "deny-value-fixture")
+
+	dryRun, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-migrate-dry-run", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dryRun.Outcome != "partial_failure" || len(dryRun.Results) != 2 || !dryRun.RequiresConfirmation || dryRun.Applied {
+		t.Fatalf("migration dry-run = %#v", dryRun)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, dryRun), managedSecretValue, "deny-value-fixture")
+
+	blocked, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-blocked", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local"})
+	if err == nil || blocked.Applied || blocked.Outcome != "policy_denied" {
+		t.Fatalf("unconfirmed migration apply should fail closed: %#v err=%v", blocked, err)
+	}
+
+	applied, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local", Confirm: true, Reason: "approved migration"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied.Applied || applied.Outcome != "partial_failure" || len(applied.Results) != 2 {
+		t.Fatalf("migration apply = %#v", applied)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "deny-value-fixture")
+}
+
+func TestMigrationUnsupportedTargetAndLockedFailClosed(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "vault-readonly", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: "token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"}}}}}
+
+	unsupported, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-vault-target", ServiceID: "@serviceadmin", OperationID: "migration-op-b", TargetProviderID: "vault-readonly"})
+	if err == nil || unsupported.Outcome != "unsupported" || len(unsupported.Results) == 0 {
+		t.Fatalf("unsupported target response = %#v err=%v", unsupported, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), managedSecretValue, "token-fixture")
+
+	locked := newLocalBackend(t.TempDir()+"/store.json", t.TempDir()+"/audit.jsonl", "")
+	lockedPlan, err := locked.migrationDryRun(migrationPlanRequest{RequestID: "req-locked", ServiceID: "@serviceadmin", OperationID: "migration-op-c", TargetProviderID: "local"})
+	if err == nil || lockedPlan.Outcome != "locked" || len(lockedPlan.Results) != 0 {
+		t.Fatalf("locked migration response = %#v err=%v", lockedPlan, err)
+	}
+}
+
+func TestProviderConfigMigrationHTTPContract(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	statusReq, err := http.NewRequest(http.MethodGet, server.URL+"/v1/providers/config/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusReq.Header.Set("Authorization", "Bearer test-token")
+	statusRes, err := http.DefaultClient.Do(statusReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusBody := readClose(t, statusRes.Body)
+	if statusRes.StatusCode != http.StatusOK {
+		t.Fatalf("status code=%d body=%s", statusRes.StatusCode, statusBody)
+	}
+	assertNoSecretMaterial(t, statusBody, managedSecretValue, providerCredentialValue)
+
+	validateBody := []byte(`{"requestId":"req-http-validate","serviceId":"@serviceadmin","providerId":"vault-prod","providerKind":"vault","address":"https://vault.example.invalid","credentialRef":"secret://local/provider/vault-prod/token"}`)
+	validateReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/config/validate", bytes.NewReader(validateBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateReq.Header.Set("Content-Type", "application/json")
+	validateReq.Header.Set("X-SecretsBroker-Token", "test-token")
+	validateRes, err := http.DefaultClient.Do(validateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validatePayload := readClose(t, validateRes.Body)
+	if validateRes.StatusCode != http.StatusOK {
+		t.Fatalf("validate code=%d body=%s", validateRes.StatusCode, validatePayload)
+	}
+	assertNoSecretMaterial(t, validatePayload, providerCredentialValue)
+
+	migrationBody := []byte(`{"requestId":"req-http-migrate","serviceId":"@serviceadmin","operationId":"migration-http-a","sourceProviderId":"local","targetProviderId":"local"}`)
+	migrationReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/migration/dry-run", bytes.NewReader(migrationBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationReq.Header.Set("Content-Type", "application/json")
+	migrationReq.Header.Set("Authorization", "Bearer test-token")
+	migrationRes, err := http.DefaultClient.Do(migrationReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationPayload := readClose(t, migrationRes.Body)
+	if migrationRes.StatusCode != http.StatusOK {
+		t.Fatalf("migration code=%d body=%s", migrationRes.StatusCode, migrationPayload)
+	}
+	assertNoSecretMaterial(t, migrationPayload, managedSecretValue)
+}

--- a/cmd/secretsbroker/secrets_management.go
+++ b/cmd/secretsbroker/secrets_management.go
@@ -379,6 +379,8 @@ func outcomeForError(err error) string {
 		return "source_auth_required"
 	case errors.Is(err, errBackendDegraded):
 		return "degraded"
+	case errors.Is(err, errUnsupportedProvider):
+		return "unsupported"
 	default:
 		return "degraded"
 	}

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -1,0 +1,89 @@
+# Provider configuration and migration API contract
+
+This contract powers the Service Admin `Secrets Broker > Configuration` surface.
+
+It is safe-by-default: provider configuration/status/validation/migration responses return handles, capabilities, refs, statuses, and audit outcomes only. They never return provider credentials, raw secret values, ciphertext, or migration payload material.
+
+## Safety boundaries
+
+- Provider credentials are accepted only as refs/handles such as `credentialRef`; plaintext credential payloads are rejected and are not echoed.
+- Configuration status returns `credentialHandle` only, never token/password/client-secret values.
+- Migration dry-run returns metadata only: refs, source/target provider ids, policy result, risk, expected action, audit requirement, and recovery guidance.
+- Migration apply requires `confirm: true`, an `operationId`, and an audit `reason`.
+- Migration apply response reports per-ref status and does not return migrated raw values.
+- Unsupported provider capabilities, auth-required, invalid config, locked store, and partial failures fail closed with typed outcomes.
+- Audit events record operation/provider/ref/outcome/request identity only.
+
+## Endpoints
+
+All non-public endpoints require the local API token when configured, via `Authorization: Bearer <token>` or `X-SecretsBroker-Token`.
+
+### `GET /v1/providers/capabilities`
+
+Returns supported provider kinds and safe capability metadata.
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "outcome": "ready",
+  "capabilities": [
+    {
+      "providerKind": "local-encrypted-store",
+      "displayName": "Local encrypted store",
+      "supported": true,
+      "capabilities": ["read", "reveal", "write", "rotate", "policy", "value_search", "audit", "migration_source", "migration_target"],
+      "limitations": ["local-first development backend"]
+    }
+  ]
+}
+```
+
+### `GET /v1/providers/config/status`
+
+Returns current and configured providers as safe metadata.
+
+### `POST /v1/providers/config/validate`
+
+Validates provider configuration without persisting it and without returning credentials.
+
+Request:
+
+```json
+{
+  "requestId": "req-provider-validate",
+  "serviceId": "@serviceadmin",
+  "providerId": "vault-prod",
+  "providerKind": "vault",
+  "address": "https://vault.example.invalid",
+  "credentialRef": "secret://local/provider/vault-prod/token",
+  "namespaces": ["services/*"]
+}
+```
+
+### `POST /v1/providers/config/apply`
+
+Applies provider configuration only after validation, explicit confirmation, `operationId`, and audit reason.
+
+### `POST /v1/providers/migration/dry-run`
+
+Builds a metadata-only migration plan.
+
+```json
+{
+  "requestId": "req-migration-dry-run",
+  "serviceId": "@serviceadmin",
+  "operationId": "migration-2026-05-08-a",
+  "sourceProviderId": "local",
+  "targetProviderId": "local",
+  "refs": ["services/@serviceadmin/runtime/SESSION_SIGNING_KEY"]
+}
+```
+
+### `POST /v1/providers/migration/apply`
+
+Applies a migration only after confirmation, operation id, and audit reason. The first contract reports the apply outcome and per-ref statuses; provider-specific remote writes can expand behind this shape.
+
+## Typed outcomes
+
+Common outcomes: `ready`, `applied`, `dry_run_ready`, `partial_failure`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`.


### PR DESCRIPTION
## Summary
- Add provider capability/configuration status, validation, and apply API contract for the Service Admin `Secrets Broker > Configuration` surface.
- Add migration dry-run/apply API contract with per-secret planned/denied/migrated/failed status, operation id, confirmation, audit reason, and recovery guidance.
- Document the safe contract in `docs/provider-configuration-migration-api.md`.
- Add tests proving provider credentials/raw secret values are absent from safe responses, plaintext credentials are rejected, auth-required/unsupported states fail closed, migration dry-run can report partial denial, and apply is confirmation/audit gated.

## Safety notes
- Provider credentials are represented as refs/handles only; plaintext credential submission is rejected and not echoed.
- Provider status/validation/migration responses do not return raw secret values or provider credential values.
- Migration dry-run is metadata-only; migration apply requires `confirm`, `operationId`, and audit `reason`.
- Unsupported migration targets and locked/auth-required states fail closed with typed outcomes.

## Validation
- `go test ./cmd/secretsbroker` — passed
- `go test ./...` — passed
- `.\scripts\test.ps1` — passed

Closes #36
Related: service-lasso/lasso-serviceadmin#84, #35, service-lasso/lasso-serviceadmin#40
