### PR TITLE
ISS-39 add master-key unlock/import/re-wrap workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The first bootstrap slice provides:
   - `secretsbroker status`
   - `secretsbroker key status`
   - `secretsbroker key generate`
+  - `secretsbroker key initialize`
+  - `secretsbroker key unlock`
+  - `secretsbroker key import`
+  - `secretsbroker key rewrap`
+  - `secretsbroker key wrapper-status`
   - `secretsbroker key rotate`
   - `secretsbroker backup create`
   - `secretsbroker backup restore`
@@ -59,7 +64,7 @@ The first bootstrap slice provides:
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`. Cross-language Node/Go compatibility expectations and reusable fixture format are documented in `docs/parity-contract.md`, with baseline fixtures under `conformance/fixtures/`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; the implemented initialize/unlock/import/re-wrap lifecycle is documented in `docs/master-key-lifecycle.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`. Cross-language Node/Go compatibility expectations and reusable fixture format are documented in `docs/parity-contract.md`, with baseline fixtures under `conformance/fixtures/`.
 
 ## Local development
 

--- a/cmd/secretsbroker/key_lifecycle.go
+++ b/cmd/secretsbroker/key_lifecycle.go
@@ -1,0 +1,398 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	localWrapperVersion = 1
+	localWrapperAlg     = "AES-256-GCM"
+)
+
+var (
+	errInvalidMasterKey     = errors.New("invalid portable master key format")
+	errStoreAlreadyExists   = errors.New("local encrypted store already exists")
+	errUnsupportedOSWrapper = errors.New("os wrapper provider is unsupported")
+	errInvalidWrapper       = errors.New("local key wrapper is invalid")
+)
+
+type localKeyWrapper struct {
+	Version     int       `json:"version"`
+	ServiceID   string    `json:"serviceId"`
+	APIVersion  string    `json:"apiVersion"`
+	KeyID       string    `json:"keyId"`
+	KeyVersion  string    `json:"keyVersion"`
+	WrapperKind string    `json:"wrapperKind"`
+	OS          string    `json:"os"`
+	User        string    `json:"user"`
+	Machine     string    `json:"machine"`
+	Alg         string    `json:"alg"`
+	Nonce       string    `json:"nonce"`
+	Ciphertext  string    `json:"ciphertext"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+type keyLifecycleResponse struct {
+	ServiceID        string               `json:"serviceId"`
+	APIVersion       string               `json:"apiVersion"`
+	Outcome          string               `json:"outcome"`
+	State            string               `json:"state"`
+	Ready            bool                 `json:"ready"`
+	KeyID            string               `json:"keyId,omitempty"`
+	KeyVersion       string               `json:"keyVersion,omitempty"`
+	StorePath        string               `json:"storePath,omitempty"`
+	WrapperPath      string               `json:"wrapperPath,omitempty"`
+	Wrapper          *wrapperStatusDetail `json:"wrapper,omitempty"`
+	SecretCount      int                  `json:"secretCount"`
+	NextAction       string               `json:"nextAction"`
+	RecoveryGuidance string               `json:"recoveryGuidance"`
+}
+
+type wrapperStatusDetail struct {
+	Available     bool   `json:"available"`
+	Supported     bool   `json:"supported"`
+	WrapperKind   string `json:"wrapperKind"`
+	OS            string `json:"os"`
+	User          string `json:"user,omitempty"`
+	Machine       string `json:"machine,omitempty"`
+	KeyID         string `json:"keyId,omitempty"`
+	KeyVersion    string `json:"keyVersion,omitempty"`
+	State         string `json:"state"`
+	NextAction    string `json:"nextAction"`
+	FailureReason string `json:"failureReason,omitempty"`
+}
+
+type wrapperContext struct {
+	OS          string
+	User        string
+	Machine     string
+	Kind        string
+	Supported   bool
+	Unsupported string
+}
+
+func runKeyInitialize(args []string) error {
+	fs := flag.NewFlagSet("key initialize", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	res, err := backend.initializeStore(material.Value)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runKeyUnlock(args []string) error {
+	fs := flag.NewFlagSet("key unlock", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	res, err := backend.unlockWithMasterKey(material.Value)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runKeyImport(args []string) error {
+	return runKeyWrapOperation("key import", args, "key_import")
+}
+
+func runKeyRewrap(args []string) error {
+	return runKeyWrapOperation("key rewrap", args, "key_rewrap")
+}
+
+func runKeyWrapOperation(name string, args []string, operation string) error {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	wrapperPath := fs.String("wrapper", getenvDefault("SECRETSBROKER_WRAPPER_PATH", defaultWrapperPath()), "local OS wrapper path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	osName := fs.String("os", runtime.GOOS, "wrapper OS override for validation/testing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	res, err := backend.importOrRewrapMasterKey(*wrapperPath, material.Value, wrapperContextFor(*osName), operation)
+	if err != nil {
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runKeyWrapperStatus(args []string) error {
+	fs := flag.NewFlagSet("key wrapper-status", flag.ContinueOnError)
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	wrapperPath := fs.String("wrapper", getenvDefault("SECRETSBROKER_WRAPPER_PATH", defaultWrapperPath()), "local OS wrapper path")
+	osName := fs.String("os", runtime.GOOS, "wrapper OS override for validation/testing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	backend := newLocalBackend(defaultStorePath(), *auditPath, "")
+	res := wrapperStatusResponse(*wrapperPath, wrapperContextFor(*osName))
+	_ = backend.audit("key_wrapper_status", "", res.Outcome, "", "")
+	return encodeIndented(os.Stdout, res)
+}
+
+func (b *localBackend) initializeStore(masterKey string) (keyLifecycleResponse, error) {
+	if err := validatePortableMasterKey(masterKey); err != nil {
+		_ = b.audit("key_initialize", "", "locked", "", "")
+		return keyLifecycleResponse{}, err
+	}
+	if _, err := os.Stat(b.storePath); err == nil {
+		_ = b.audit("key_initialize", "", "degraded", "", "")
+		return keyLifecycleResponse{}, errStoreAlreadyExists
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		_ = b.audit("key_initialize", "", "degraded", "", "")
+		return keyLifecycleResponse{}, err
+	}
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: b.now(), UpdatedAt: b.now(), Secrets: map[string]secretEntry{}}
+	if err := b.saveStore(store); err != nil {
+		_ = b.audit("key_initialize", "", "degraded", "", "")
+		return keyLifecycleResponse{}, errBackendDegraded
+	}
+	_ = b.audit("key_initialize", "", "ready", "", "")
+	return keyLifecycleResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", State: "ready", Ready: true, KeyID: masterKeyID(masterKey), KeyVersion: masterKeyVersion, StorePath: b.storePath, SecretCount: 0, NextAction: "import_or_rewrap_for_local_os", RecoveryGuidance: "Store the portable master key securely, separately from encrypted store backups."}, nil
+}
+
+func (b *localBackend) unlockWithMasterKey(masterKey string) (keyLifecycleResponse, error) {
+	if err := validatePortableMasterKey(masterKey); err != nil {
+		_ = b.audit("key_unlock", "", "locked", "", "")
+		return keyLifecycleResponse{}, err
+	}
+	b.masterKey = strings.TrimSpace(masterKey)
+	state, secretCount, err := b.validateStoreForKey()
+	if err != nil {
+		_ = b.audit("key_unlock", "", state, "", "")
+		return keyLifecycleResponse{}, err
+	}
+	_ = b.audit("key_unlock", "", "ready", "", "")
+	return keyLifecycleResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", State: "ready", Ready: true, KeyID: masterKeyID(masterKey), KeyVersion: masterKeyVersion, StorePath: b.storePath, SecretCount: secretCount, NextAction: "operate_or_rewrap_for_local_os", RecoveryGuidance: "If this machine should unlock without manual key entry, run key import or key rewrap for the current OS/user wrapper."}, nil
+}
+
+func (b *localBackend) importOrRewrapMasterKey(wrapperPath, masterKey string, ctx wrapperContext, operation string) (keyLifecycleResponse, error) {
+	if !ctx.Supported {
+		_ = b.audit(operation, "", "degraded", "", "")
+		return keyLifecycleResponse{}, errUnsupportedOSWrapper
+	}
+	if err := validatePortableMasterKey(masterKey); err != nil {
+		_ = b.audit(operation, "", "locked", "", "")
+		return keyLifecycleResponse{}, err
+	}
+	b.masterKey = strings.TrimSpace(masterKey)
+	state, secretCount, err := b.validateStoreForKey()
+	if err != nil {
+		_ = b.audit(operation, "", state, "", "")
+		return keyLifecycleResponse{}, err
+	}
+	wrapper, err := wrapMasterKey(wrapperPath, masterKey, ctx, b.now())
+	if err != nil {
+		_ = b.audit(operation, "", "degraded", "", "")
+		return keyLifecycleResponse{}, err
+	}
+	_ = b.audit(operation, "", "ready", "", "")
+	detail := wrapper.detail(true, "ready", "")
+	return keyLifecycleResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", State: "ready", Ready: true, KeyID: wrapper.KeyID, KeyVersion: wrapper.KeyVersion, StorePath: b.storePath, WrapperPath: wrapperPath, Wrapper: &detail, SecretCount: secretCount, NextAction: "operate_normally", RecoveryGuidance: "Keep the portable master key in secure offline storage; this wrapper is only for the current OS/user/machine."}, nil
+}
+
+func (b *localBackend) validateStoreForKey() (string, int, error) {
+	if b.locked() {
+		return "locked", 0, errLocked
+	}
+	if _, err := os.Stat(b.storePath); errors.Is(err, os.ErrNotExist) {
+		return "setup_needed", 0, errMissingRef
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return "degraded", 0, errBackendDegraded
+	}
+	for _, entry := range store.Secrets {
+		if entry.Payload.KeyID != "" && entry.Payload.KeyID != masterKeyID(b.masterKey) {
+			return "locked", len(store.Secrets), errInvalidBackupKey
+		}
+		if _, err := b.decrypt(entry.Payload); err != nil {
+			return "degraded", len(store.Secrets), errBackendDegraded
+		}
+	}
+	return "ready", len(store.Secrets), nil
+}
+
+func validatePortableMasterKey(masterKey string) error {
+	masterKey = strings.TrimSpace(masterKey)
+	if masterKey == "" {
+		return errLocked
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(masterKey)
+	if err != nil || len(decoded) != 32 {
+		return errInvalidMasterKey
+	}
+	return nil
+}
+
+func defaultWrapperPath() string { return filepath.Join("data", "secretsbroker-wrapper.json") }
+
+func wrapperContextFor(osName string) wrapperContext {
+	ctx := wrapperContext{OS: strings.TrimSpace(osName), Supported: true}
+	if ctx.OS == "" {
+		ctx.OS = runtime.GOOS
+	}
+	switch ctx.OS {
+	case "windows":
+		ctx.Kind = "dpapi-user-scope"
+	case "darwin":
+		ctx.Kind = "keychain-service-item"
+	case "linux":
+		ctx.Kind = "protected-file-user-scope"
+	default:
+		ctx.Kind = "unsupported"
+		ctx.Supported = false
+		ctx.Unsupported = "No supported local wrapper provider for this OS. Use explicit portable-key unlock/import until provider support exists."
+	}
+	if current, err := user.Current(); err == nil && current != nil {
+		ctx.User = firstNonEmpty(current.Username, current.Uid)
+	}
+	if host, err := os.Hostname(); err == nil {
+		ctx.Machine = host
+	}
+	return ctx
+}
+
+func wrapperStatusResponse(path string, ctx wrapperContext) keyLifecycleResponse {
+	detail := wrapperStatus(path, ctx)
+	state := detail.State
+	outcome := state
+	if !detail.Supported {
+		outcome = "degraded"
+	} else if !detail.Available {
+		outcome = "locked"
+	}
+	return keyLifecycleResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: outcome, State: state, Ready: state == "ready", WrapperPath: path, Wrapper: &detail, NextAction: detail.NextAction, RecoveryGuidance: recoveryGuidanceForWrapper(detail)}
+}
+
+func wrapperStatus(path string, ctx wrapperContext) wrapperStatusDetail {
+	if !ctx.Supported {
+		return wrapperStatusDetail{Available: false, Supported: false, WrapperKind: ctx.Kind, OS: ctx.OS, State: "degraded", NextAction: "use_portable_key_unlock", FailureReason: ctx.Unsupported}
+	}
+	wrapper, err := readLocalKeyWrapper(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return wrapperStatusDetail{Available: false, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "locked", NextAction: "import_portable_key"}
+	}
+	if err != nil {
+		return wrapperStatusDetail{Available: true, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "degraded", NextAction: "import_portable_key", FailureReason: "wrapper metadata could not be read"}
+	}
+	return wrapper.detail(true, "ready", "")
+}
+
+func (w localKeyWrapper) detail(available bool, state string, failure string) wrapperStatusDetail {
+	next := "operate_normally"
+	if state == "degraded" || state == "locked" {
+		next = "import_portable_key"
+	}
+	return wrapperStatusDetail{Available: available, Supported: true, WrapperKind: w.WrapperKind, OS: w.OS, User: w.User, Machine: w.Machine, KeyID: w.KeyID, KeyVersion: w.KeyVersion, State: state, NextAction: next, FailureReason: failure}
+}
+
+func recoveryGuidanceForWrapper(detail wrapperStatusDetail) string {
+	if !detail.Supported {
+		return "Use a portable master-key file/env/flag on this OS until a supported wrapper provider is available."
+	}
+	if !detail.Available || detail.State == "locked" {
+		return "Import the matching portable master key to enroll this machine's local wrapper."
+	}
+	if detail.State == "degraded" {
+		return "Re-import the portable master key and re-wrap, or restore wrapper/store metadata from backup."
+	}
+	return "Local wrapper metadata is present. Keep the portable master key stored separately for recovery."
+}
+
+func wrapMasterKey(path, masterKey string, ctx wrapperContext, now time.Time) (localKeyWrapper, error) {
+	if !ctx.Supported {
+		return localKeyWrapper{}, errUnsupportedOSWrapper
+	}
+	block, err := aes.NewCipher(localWrapperKey(ctx))
+	if err != nil {
+		return localKeyWrapper{}, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return localKeyWrapper{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return localKeyWrapper{}, err
+	}
+	createdAt := now
+	if existing, err := readLocalKeyWrapper(path); err == nil && !existing.CreatedAt.IsZero() {
+		createdAt = existing.CreatedAt
+	}
+	wrapper := localKeyWrapper{Version: localWrapperVersion, ServiceID: serviceID, APIVersion: apiVersion, KeyID: masterKeyID(masterKey), KeyVersion: masterKeyVersion, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, Alg: localWrapperAlg, Nonce: base64.StdEncoding.EncodeToString(nonce), Ciphertext: base64.StdEncoding.EncodeToString(gcm.Seal(nil, nonce, []byte(strings.TrimSpace(masterKey)), nil)), CreatedAt: createdAt, UpdatedAt: now}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return localKeyWrapper{}, err
+	}
+	bytes, err := json.MarshalIndent(wrapper, "", "  ")
+	if err != nil {
+		return localKeyWrapper{}, err
+	}
+	if err := os.WriteFile(path, bytes, 0o600); err != nil {
+		return localKeyWrapper{}, err
+	}
+	return wrapper, nil
+}
+
+func readLocalKeyWrapper(path string) (localKeyWrapper, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return localKeyWrapper{}, err
+	}
+	var wrapper localKeyWrapper
+	if err := json.Unmarshal(bytes, &wrapper); err != nil {
+		return localKeyWrapper{}, errInvalidWrapper
+	}
+	if wrapper.Version != localWrapperVersion || wrapper.ServiceID != serviceID || wrapper.APIVersion != apiVersion || wrapper.Alg != localWrapperAlg || wrapper.Ciphertext == "" || wrapper.Nonce == "" || wrapper.KeyID == "" {
+		return localKeyWrapper{}, errInvalidWrapper
+	}
+	return wrapper, nil
+}
+
+func localWrapperKey(ctx wrapperContext) []byte {
+	sum := sha256.Sum256([]byte("service-lasso:@secretsbroker:local-wrapper:" + ctx.OS + ":" + ctx.Kind + ":" + ctx.User + ":" + ctx.Machine))
+	return sum[:]
+}

--- a/cmd/secretsbroker/key_lifecycle_test.go
+++ b/cmd/secretsbroker/key_lifecycle_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func lifecycleTestKey(seed byte) string {
+	bytes := make([]byte, 32)
+	for i := range bytes {
+		bytes[i] = seed
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes)
+}
+
+func lifecycleBackend(t *testing.T, masterKey string) *localBackend {
+	t.Helper()
+	b := newLocalBackend(filepath.Join(t.TempDir(), "store.json"), filepath.Join(t.TempDir(), "audit.jsonl"), masterKey)
+	b.now = func() time.Time { return time.Date(2026, 5, 8, 21, 0, 0, 0, time.UTC) }
+	return b
+}
+
+func TestInitializeUnlockImportAndRewrapMasterKeyLifecycle(t *testing.T) {
+	key := lifecycleTestKey(7)
+	backend := lifecycleBackend(t, key)
+
+	initialized, err := backend.initializeStore(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initialized.State != "ready" || initialized.KeyID != masterKeyID(key) || initialized.SecretCount != 0 || strings.Contains(initialized.RecoveryGuidance, key) {
+		t.Fatalf("initialize response = %#v", initialized)
+	}
+
+	unlocked, err := backend.unlockWithMasterKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked.Ready || unlocked.Outcome != "ready" || unlocked.KeyVersion != masterKeyVersion {
+		t.Fatalf("unlock response = %#v", unlocked)
+	}
+
+	wrapperPath := filepath.Join(t.TempDir(), "wrapper.json")
+	imported, err := backend.importOrRewrapMasterKey(wrapperPath, key, wrapperContextFor("linux"), "key_import")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported.Wrapper == nil || !imported.Wrapper.Available || imported.Wrapper.KeyID != masterKeyID(key) || imported.Wrapper.OS != "linux" {
+		t.Fatalf("import response = %#v", imported)
+	}
+	wrapperBytes, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(wrapperBytes), key) {
+		t.Fatalf("wrapper leaked portable key: %s", string(wrapperBytes))
+	}
+
+	rewrapped, err := backend.importOrRewrapMasterKey(wrapperPath, key, wrapperContextFor("linux"), "key_rewrap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewrapped.Outcome != "ready" || rewrapped.Wrapper == nil || rewrapped.Wrapper.State != "ready" {
+		t.Fatalf("rewrap response = %#v", rewrapped)
+	}
+}
+
+func TestUnlockFailureWrongKeyAndCorruptedCiphertext(t *testing.T) {
+	key := lifecycleTestKey(8)
+	wrong := lifecycleTestKey(9)
+	backend := lifecycleBackend(t, key)
+	if _, err := backend.initializeStore(key); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/TOKEN", Value: "secret-token"}); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongBackend := newLocalBackend(backend.storePath, filepath.Join(t.TempDir(), "wrong-audit.jsonl"), wrong)
+	if _, err := wrongBackend.unlockWithMasterKey(wrong); !errors.Is(err, errInvalidBackupKey) {
+		t.Fatalf("wrong-key unlock err = %v", err)
+	}
+
+	bytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var store localStoreFile
+	if err := json.Unmarshal(bytes, &store); err != nil {
+		t.Fatal(err)
+	}
+	entry := store.Secrets["services/api/TOKEN"]
+	entry.Payload.Ciphertext = "corrupted-ciphertext"
+	store.Secrets["services/api/TOKEN"] = entry
+	corrupted, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backend.storePath, corrupted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.unlockWithMasterKey(key); !errors.Is(err, errBackendDegraded) {
+		t.Fatalf("corrupted unlock err = %v", err)
+	}
+}
+
+func TestImportUnsupportedWrapperAndInvalidKeyFailClosed(t *testing.T) {
+	key := lifecycleTestKey(10)
+	backend := lifecycleBackend(t, key)
+	if _, err := backend.initializeStore(key); err != nil {
+		t.Fatal(err)
+	}
+	wrapperPath := filepath.Join(t.TempDir(), "wrapper.json")
+	if _, err := backend.importOrRewrapMasterKey(wrapperPath, key, wrapperContextFor("plan9"), "key_import"); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("unsupported wrapper err = %v", err)
+	}
+	if _, err := os.Stat(wrapperPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unsupported wrapper should not write file, stat err = %v", err)
+	}
+	if _, err := backend.importOrRewrapMasterKey(wrapperPath, "not-a-valid-portable-key", wrapperContextFor("linux"), "key_import"); !errors.Is(err, errInvalidMasterKey) {
+		t.Fatalf("invalid key err = %v", err)
+	}
+}
+
+func TestWrapperStatusReportsRecoveryGuidanceWithoutKeyMaterial(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing-wrapper.json")
+	missing := wrapperStatusResponse(missingPath, wrapperContextFor("linux"))
+	if missing.Outcome != "locked" || missing.Wrapper == nil || missing.Wrapper.NextAction != "import_portable_key" || !strings.Contains(missing.RecoveryGuidance, "Import") {
+		t.Fatalf("missing wrapper status = %#v", missing)
+	}
+
+	unsupported := wrapperStatusResponse(missingPath, wrapperContextFor("plan9"))
+	if unsupported.Outcome != "degraded" || unsupported.Wrapper == nil || unsupported.Wrapper.Supported || unsupported.Wrapper.NextAction != "use_portable_key_unlock" {
+		t.Fatalf("unsupported wrapper status = %#v", unsupported)
+	}
+}

--- a/cmd/secretsbroker/key_material.go
+++ b/cmd/secretsbroker/key_material.go
@@ -49,6 +49,16 @@ func runKey(args []string) error {
 		return printKeyStatus(args[1:])
 	case "generate":
 		return printGeneratedKey()
+	case "initialize":
+		return runKeyInitialize(args[1:])
+	case "unlock":
+		return runKeyUnlock(args[1:])
+	case "import":
+		return runKeyImport(args[1:])
+	case "rewrap":
+		return runKeyRewrap(args[1:])
+	case "wrapper-status":
+		return runKeyWrapperStatus(args[1:])
 	case "rotate":
 		return runKeyRotate(args[1:])
 	default:

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -142,7 +142,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
 	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
-	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key foundation")
+	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key lifecycle, local wrapper, and rotation")
 	fmt.Fprintln(os.Stderr, "  backup  Create or restore encrypted local-store backup artifacts")
 	fmt.Fprintln(os.Stderr, "  session Manage local API session/token foundation")
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
@@ -231,7 +231,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/reset/dry-run|apply",
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
-			"CLI secretsbroker key rotate",
+			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
 		},
 		Features: []string{
 			"liveness",
@@ -257,6 +257,8 @@ func defaultCapabilities() CapabilitiesResponse {
 			"write-back-policy",
 			"generated-secret-capture",
 			"encrypted-backup-restore",
+			"master-key-initialize-unlock-import-rewrap",
+			"os-wrapper-status",
 			"master-key-rotation",
 		},
 		FutureFeatures: []string{

--- a/docs/master-key-lifecycle.md
+++ b/docs/master-key-lifecycle.md
@@ -1,0 +1,103 @@
+# Master-Key Unlock, Import, and Local Re-Wrap Workflow
+
+Status: implemented contract slice  
+Issue: #39  
+Service id: `@secretsbroker`
+
+## Purpose
+
+Secrets Broker uses one portable master key to encrypt the local vault payloads. Each machine can additionally keep a local OS/user-scoped wrapper for that same portable key so the encrypted store remains portable without requiring the operator to paste the key on every start.
+
+Canonical model:
+
+```text
+portable master key -> encrypts vault payloads
+current OS/user wrapper -> protects a local copy of the portable master key
+```
+
+The portable key is sensitive secret material. API/CLI lifecycle responses expose only status, key id fingerprints, wrapper metadata, next actions, and recovery guidance. They never echo supplied key material or unwrapped key bytes.
+
+## Lifecycle states
+
+| State | Meaning | Typical next action |
+| --- | --- | --- |
+| `setup_needed` | No local encrypted store exists yet. | `initialize_store` |
+| `locked` | A store exists, but the current process cannot access matching master-key material. | `unlock_with_portable_key` or `import_portable_key` |
+| `ready` | Store exists and supplied/wrapped key material can decrypt current payloads. | operate normally |
+| `source_auth_required` | A configured source needs reconnect/auth before affected refs can resolve. | `reconnect_source` |
+| `degraded` | Store/source is partially unusable, including corrupted ciphertext or invalid wrapper payloads. | inspect diagnostics/recover from backup |
+
+## CLI contract
+
+### Initialize local encrypted store
+
+```powershell
+secretsbroker key initialize `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+Creates an empty encrypted local store if one does not already exist and validates the portable key format. The response includes `outcome`, `state`, `keyId`, `storePath`, and `nextAction`; it does not include the portable key.
+
+### Unlock with portable master key
+
+```powershell
+secretsbroker key unlock `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+Validates that the supplied key matches the existing store metadata and can decrypt every stored payload. Wrong keys and corrupted ciphertext fail closed with `locked` or `degraded` outcomes and no plaintext output.
+
+### Import existing vault on a new machine
+
+```powershell
+secretsbroker key import `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --wrapper .\data\secretsbroker-wrapper.json `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+Use after copying an encrypted store to a new machine. Import validates the portable key, verifies it against the copied store, then writes a local OS/user wrapper for future unlocks. The response exposes wrapper metadata only.
+
+### Re-wrap for current OS/user/machine
+
+```powershell
+secretsbroker key rewrap `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --wrapper .\data\secretsbroker-wrapper.json `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+Re-wraps the same portable key for the current OS/user/machine context. Re-wrap is auditable and fail-closed: unsupported wrapper providers, unreadable wrappers, wrong keys, corrupted ciphertext, or store verification failures do not write a new wrapper.
+
+### OS wrapper status
+
+```powershell
+secretsbroker key wrapper-status --wrapper .\data\secretsbroker-wrapper.json
+```
+
+Reports whether a local wrapper exists, whether the current OS wrapper provider is supported, the wrapper kind, OS, key id, and recovery guidance. It never unwraps or returns the portable key.
+
+## Recovery guidance
+
+- If the store is `setup_needed`, initialize it with a secure portable key.
+- If the store is `locked`, supply/import the matching portable key or restore a backup with the matching key.
+- If ciphertext or wrapper payloads are corrupted, restore the encrypted store and wrapper from backup, or import the portable key again and re-wrap.
+- If the OS wrapper provider is unsupported, keep using explicit portable-key file/env/flag unlock until a supported wrapper provider is available.
+
+## Audit rules
+
+Lifecycle operations emit audit events with operation, outcome, timestamp, and safe metadata only:
+
+- `key_initialize`
+- `key_unlock`
+- `key_import`
+- `key_rewrap`
+- `key_wrapper_status`
+
+Audit payloads must never contain the portable master key, plaintext secrets, wrapper plaintext, or submitted key material.

--- a/docs/portable-master-key.md
+++ b/docs/portable-master-key.md
@@ -87,35 +87,37 @@ Output:
 
 This command intentionally prints the generated key once. Operators should store it in a secure out-of-band location until OS-wrapper enrollment exists.
 
-## Planned local wrapper enrollment
+## Local wrapper enrollment
 
-Future implementation should add OS-backed local wrapper commands:
+Issue #39 adds the first implemented local wrapper lifecycle commands:
 
 ```text
+secretsbroker key initialize --master-key-file <file>
+secretsbroker key unlock --master-key-file <file>
 secretsbroker key import --master-key-file <file>
-secretsbroker key enroll-local
-secretsbroker key rewrap-local
-secretsbroker key lock
-secretsbroker key unlock
+secretsbroker key rewrap --master-key-file <file>
+secretsbroker key wrapper-status
 ```
 
-Recommended wrappers:
+The detailed contract is documented in `docs/master-key-lifecycle.md`.
 
-- Windows: DPAPI user/machine scope, with explicit scope metadata
-- macOS: Keychain item scoped to the service identity
-- Linux: protected file or secret-service/libsecret integration, with strict permissions
+Wrapper metadata records the intended provider:
 
-The OS wrapper stores/protects a local copy of the same portable master key. The ciphertext format remains platform-independent.
+- Windows: DPAPI user scope metadata
+- macOS: Keychain service item metadata
+- Linux: protected file user-scope metadata
+
+The local wrapper stores/protects a local copy of the same portable master key for the current OS/user/machine. The encrypted vault payload format remains platform-independent.
 
 ## Copied vault flow
 
 1. Copy encrypted store file to new machine.
 2. Start broker without local wrapper/key.
 3. Broker reports `locked`.
-4. Operator imports portable master key.
-5. Broker verifies key id against existing payload metadata.
-6. Operator enrolls/re-wraps local machine wrapper.
-7. Broker reports `ready`.
+4. Operator runs `secretsbroker key import --master-key-file <file>` with the portable master key.
+5. Broker validates the key format and verifies it against existing payload metadata/decryption.
+6. Broker writes or refreshes the local wrapper for the current OS/user/machine.
+7. Broker reports `ready` with status/metadata only.
 
 ## Recovery shares
 


### PR DESCRIPTION
## Summary
- add the implemented master-key lifecycle contract for initialize, unlock, import, local re-wrap, wrapper status, and recovery guidance
- add CLI/backend logic for store initialization, portable-key unlock validation, import/re-wrap local wrapper metadata, unsupported-wrapper failures, and safe wrapper status responses
- add tests for initialize, locked/wrong-key failure, unlock success, import, re-wrap, unsupported OS wrapper, corrupted ciphertext, and recovery guidance without key leakage

## Validation
- `go test ./...` ✅
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` ✅
- `pwsh -NoLogo -NoProfile -File .\scripts\verify.ps1` ⚠️ blocked locally: `service-lasso-harness binary not found. Set SERVICE_LASSO_HARNESS_BIN or add it to PATH.`

## Safety notes
- lifecycle responses and audit events expose status/metadata only; no portable key, wrapper plaintext, or secret values are returned
- unsupported wrapper providers and invalid/corrupted key/store states fail closed without writing wrappers

Closes #39