### PR TITLE
ISS-40 add Secrets Broker headless admin CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,17 @@ The first bootstrap slice provides:
   - `secretsbroker key rotate`
   - `secretsbroker backup create`
   - `secretsbroker backup restore`
+  - `secretsbroker admin status`
+  - `secretsbroker admin secrets list|search|value-search|reveal`
+  - `secretsbroker admin providers capabilities|status|validate`
+  - `secretsbroker admin migration dry-run|apply`
+  - `secretsbroker admin audit export`
   - `secretsbroker session status`
   - `secretsbroker session generate`
   - `secretsbroker version`
 - package/test/verify scripts following the service-template contract
 
-The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; the implemented initialize/unlock/import/re-wrap lifecycle is documented in `docs/master-key-lifecycle.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`. Cross-language Node/Go compatibility expectations and reusable fixture format are documented in `docs/parity-contract.md`, with baseline fixtures under `conformance/fixtures/`.
+The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; the implemented initialize/unlock/import/re-wrap lifecycle is documented in `docs/master-key-lifecycle.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`. Local API token/session security is documented in `docs/local-api-security.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`. The headless admin CLI is documented in `docs/headless-admin-cli.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`. Cross-language Node/Go compatibility expectations and reusable fixture format are documented in `docs/parity-contract.md`, with baseline fixtures under `conformance/fixtures/`.
 
 ## Local development
 

--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type adminCommonOptions struct {
+	StorePath     string
+	AuditPath     string
+	MasterKey     string
+	MasterKeyFile string
+	SourcesPath   string
+}
+
+type adminStatusResponse struct {
+	ServiceID  string                       `json:"serviceId"`
+	APIVersion string                       `json:"apiVersion"`
+	Outcome    string                       `json:"outcome"`
+	Health     HealthResponse               `json:"health"`
+	Status     Status                       `json:"status"`
+	State      StateResponse                `json:"state"`
+	Key        keyStatusResponse            `json:"key"`
+	Providers  providerConfigStatusResponse `json:"providers"`
+}
+
+type adminAuditExportResponse struct {
+	ServiceID  string       `json:"serviceId"`
+	APIVersion string       `json:"apiVersion"`
+	Outcome    string       `json:"outcome"`
+	Operation  string       `json:"operation,omitempty"`
+	Ref        string       `json:"ref,omitempty"`
+	Events     []auditEvent `json:"events"`
+}
+
+func runAdmin(args []string) error {
+	return executeAdmin(args, os.Stdout)
+}
+
+func executeAdmin(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin command %q", "")
+	}
+	switch args[0] {
+	case "status":
+		return runAdminStatus(args[1:], out)
+	case "secrets":
+		return runAdminSecrets(args[1:], out)
+	case "providers":
+		return runAdminProviders(args[1:], out)
+	case "migration":
+		return runAdminMigration(args[1:], out)
+	case "audit":
+		return runAdminAudit(args[1:], out)
+	default:
+		return fmt.Errorf("unknown admin command %q", args[0])
+	}
+}
+
+func runAdminStatus(args []string, out io.Writer) error {
+	fs, opts := newAdminFlagSet("admin status")
+	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", ""), "state override for diagnostics")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	backend, material, err := backendFromAdminOptions(opts)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	statusState := normalizeAdminState(*state, backend, material)
+	res := adminStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: statusState, Health: defaultHealth(statusState), Status: defaultStatus(statusState), State: defaultState(statusState), Key: keyStatus(material), Providers: backend.providerConfigStatusResponse()}
+	return encodeAdminJSON(out, res)
+}
+
+func runAdminSecrets(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin secrets command %q", "")
+	}
+	sub := args[0]
+	fs, opts := newAdminFlagSet("admin secrets " + sub)
+	query := fs.String("query", "", "metadata/value search query")
+	ref := fs.String("ref", "", "secret ref")
+	reason := fs.String("reason", "", "audit reason")
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	confirm := fs.Bool("confirm", false, "explicitly confirm reveal")
+	noEcho := fs.Bool("no-echo", false, "suppress revealed value while recording outcome")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	switch sub {
+	case "list":
+		res, err := backend.listManagedSecrets("", false)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "search":
+		res, err := backend.listManagedSecrets(*query, false)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "value-search":
+		res, err := backend.listManagedSecrets(*query, true)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "reveal":
+		if !*confirm {
+			res := baseManagedActionResponse(managedSecretActionRequest{RequestID: *requestID, ServiceID: *service, Ref: *ref, Reason: *reason}, "reveal", "apply")
+			res.Outcome = "policy_denied"
+			res.RequiresConfirmation = true
+			res.NextAction = "rerun_with_confirm_and_audit_reason"
+			_ = backend.audit("management_reveal", *ref, res.Outcome, *service, *requestID)
+			_ = encodeAdminJSON(out, res)
+			return errPolicyDenied
+		}
+		res, err := backend.revealManagedSecret(managedSecretActionRequest{RequestID: *requestID, ServiceID: *service, Ref: *ref, Reason: *reason, Confirm: *confirm})
+		if *noEcho {
+			res.Value = ""
+			res.NextAction = "value_suppressed_by_no_echo"
+		}
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	default:
+		return fmt.Errorf("unknown admin secrets command %q", sub)
+	}
+}
+
+func runAdminProviders(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin providers command %q", "")
+	}
+	sub := args[0]
+	fs, opts := newAdminFlagSet("admin providers " + sub)
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	providerID := fs.String("provider-id", "", "provider id")
+	providerKind := fs.String("provider-kind", "", "provider kind")
+	displayName := fs.String("display-name", "", "display name")
+	address := fs.String("address", "", "provider address")
+	credentialRef := fs.String("credential-ref", "", "credential ref/handle")
+	credentialValue := fs.String("credential-value", "", "plaintext credential value; rejected")
+	namespaces := fs.String("namespaces", "", "comma-separated namespaces")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	switch sub {
+	case "capabilities":
+		return encodeAdminJSON(out, backend.providerCapabilitiesResponse())
+	case "status":
+		return encodeAdminJSON(out, backend.providerConfigStatusResponse())
+	case "validate":
+		res, err := backend.validateProviderConfig(providerConfigRequest{RequestID: *requestID, ServiceID: *service, ProviderID: *providerID, ProviderKind: *providerKind, DisplayName: *displayName, Address: *address, CredentialRef: *credentialRef, CredentialValue: *credentialValue, Namespaces: splitCSV(*namespaces)})
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	default:
+		return fmt.Errorf("unknown admin providers command %q", sub)
+	}
+}
+
+func runAdminMigration(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin migration command %q", "")
+	}
+	sub := args[0]
+	fs, opts := newAdminFlagSet("admin migration " + sub)
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	operationID := fs.String("operation-id", "", "operation id")
+	sourceProvider := fs.String("source-provider", "local", "source provider id")
+	targetProvider := fs.String("target-provider", "local", "target provider id")
+	reason := fs.String("reason", "", "audit reason")
+	confirm := fs.Bool("confirm", false, "confirm apply")
+	refs := multiFlag{}
+	fs.Var(&refs, "ref", "secret ref; repeatable")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil {
+		return err
+	}
+	req := migrationPlanRequest{RequestID: *requestID, ServiceID: *service, OperationID: *operationID, SourceProviderID: *sourceProvider, TargetProviderID: *targetProvider, Refs: []string(refs), Reason: *reason, Confirm: *confirm}
+	switch sub {
+	case "dry-run":
+		res, err := backend.migrationDryRun(req)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "apply":
+		res, err := backend.migrationApply(req)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	default:
+		return fmt.Errorf("unknown admin migration command %q", sub)
+	}
+}
+
+func runAdminAudit(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin audit command %q", "")
+	}
+	if args[0] != "export" {
+		return fmt.Errorf("unknown admin audit command %q", args[0])
+	}
+	fs, opts := newAdminFlagSet("admin audit export")
+	operation := fs.String("operation", "", "operation filter")
+	ref := fs.String("ref", "", "ref filter")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	res, err := exportAuditEvents(opts.AuditPath, *operation, *ref)
+	if err != nil {
+		_ = encodeAdminJSON(out, res)
+		return err
+	}
+	return encodeAdminJSON(out, res)
+}
+
+func newAdminFlagSet(name string) (*flag.FlagSet, *adminCommonOptions) {
+	opts := &adminCommonOptions{}
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.StringVar(&opts.StorePath, "store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	fs.StringVar(&opts.AuditPath, "audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	fs.StringVar(&opts.MasterKey, "master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	fs.StringVar(&opts.MasterKeyFile, "master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	fs.StringVar(&opts.SourcesPath, "sources", getenvDefault("SECRETSBROKER_SOURCES_PATH", ""), "source adapter config path")
+	return fs, opts
+}
+
+func backendFromAdminOptions(opts *adminCommonOptions) (*localBackend, keyMaterial, error) {
+	material, err := loadKeyMaterial(opts.MasterKey, opts.MasterKeyFile)
+	if err != nil && !errors.Is(err, errLocked) {
+		return nil, material, err
+	}
+	backend := newLocalBackend(opts.StorePath, opts.AuditPath, material.Value)
+	sources, sourceErr := loadSourceConfig(opts.SourcesPath)
+	if sourceErr != nil {
+		return nil, material, sourceErr
+	}
+	backend.sources = sources
+	return backend, material, err
+}
+
+func normalizeAdminState(state string, backend *localBackend, material keyMaterial) string {
+	if strings.TrimSpace(state) != "" {
+		return normalizeState(state)
+	}
+	if strings.TrimSpace(material.Value) == "" {
+		if _, err := os.Stat(backend.storePath); errors.Is(err, os.ErrNotExist) {
+			return "setup_needed"
+		}
+		return "locked"
+	}
+	if _, _, err := backend.validateStoreForKey(); err != nil {
+		return outcomeForError(err)
+	}
+	return "ready"
+}
+
+func exportAuditEvents(path, operation, ref string) (adminAuditExportResponse, error) {
+	res := adminAuditExportResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Operation: strings.TrimSpace(operation), Ref: strings.TrimSpace(ref), Events: []auditEvent{}}
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return res, nil
+	}
+	if err != nil {
+		res.Outcome = "degraded"
+		return res, errBackendDegraded
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var event auditEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			res.Outcome = "degraded"
+			return res, errBackendDegraded
+		}
+		if res.Operation != "" && event.Operation != res.Operation {
+			continue
+		}
+		if res.Ref != "" && event.Ref != res.Ref {
+			continue
+		}
+		res.Events = append(res.Events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		res.Outcome = "degraded"
+		return res, errBackendDegraded
+	}
+	return res, nil
+}
+
+func encodeAdminJSON(out io.Writer, value any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}

--- a/cmd/secretsbroker/admin_cli_test.go
+++ b/cmd/secretsbroker/admin_cli_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const adminCLISecretValue = "fixture-admin-cli-secret-value"
+
+func TestAdminCLIStatusProvidersAndMetadataOutputAreScrubbed(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", adminCLISecretValue)
+	keyPath := filepath.Join(t.TempDir(), "key.txt")
+	if err := os.WriteFile(keyPath, []byte("test-master-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var status bytes.Buffer
+	if err := executeAdmin([]string{"status", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key-file", keyPath}, &status); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, status.Bytes(), adminCLISecretValue, "test-master-key")
+	if !bytes.Contains(status.Bytes(), []byte("providerKind")) || !bytes.Contains(status.Bytes(), []byte("local-encrypted-store")) {
+		t.Fatalf("status missing provider summary: %s", status.String())
+	}
+
+	var providers bytes.Buffer
+	if err := executeAdmin([]string{"providers", "status", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &providers); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, providers.Bytes(), adminCLISecretValue, "test-master-key")
+
+	var list bytes.Buffer
+	if err := executeAdmin([]string{"secrets", "list", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &list); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, list.Bytes(), adminCLISecretValue, "test-master-key")
+	if !bytes.Contains(list.Bytes(), []byte("SESSION_SIGNING_KEY")) {
+		t.Fatalf("list missing metadata ref: %s", list.String())
+	}
+
+	var search bytes.Buffer
+	if err := executeAdmin([]string{"secrets", "value-search", "--query", "admin-cli-secret", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &search); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, search.Bytes(), adminCLISecretValue, "test-master-key")
+}
+
+func TestAdminCLIRevealRequiresConfirmReasonAndSupportsNoEcho(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, adminCLISecretValue)
+
+	var denied bytes.Buffer
+	err := executeAdmin([]string{"secrets", "reveal", "--ref", ref, "--reason", "operator check", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &denied)
+	if !errors.Is(err, errPolicyDenied) {
+		t.Fatalf("expected policy denied without confirm, got %v body=%s", err, denied.String())
+	}
+	assertNoSecretMaterial(t, denied.Bytes(), adminCLISecretValue)
+
+	var noEcho bytes.Buffer
+	if err := executeAdmin([]string{"secrets", "reveal", "--ref", ref, "--reason", "operator check", "--confirm", "--no-echo", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &noEcho); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, noEcho.Bytes(), adminCLISecretValue)
+	if !bytes.Contains(noEcho.Bytes(), []byte("value_suppressed_by_no_echo")) {
+		t.Fatalf("no-echo response missing guidance: %s", noEcho.String())
+	}
+
+	var reveal bytes.Buffer
+	if err := executeAdmin([]string{"secrets", "reveal", "--ref", ref, "--reason", "operator check", "--confirm", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &reveal); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(reveal.Bytes(), []byte(adminCLISecretValue)) {
+		t.Fatalf("explicit reveal did not include value: %s", reveal.String())
+	}
+}
+
+func TestAdminCLIProviderValidationMigrationAndAuditAreScrubbed(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, adminCLISecretValue)
+
+	var validate bytes.Buffer
+	if err := executeAdmin([]string{"providers", "validate", "--provider-id", "vault-dev", "--provider-kind", "vault", "--address", "https://vault.example.invalid", "--credential-ref", "secret://local/provider/vault-dev/token", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &validate); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, validate.Bytes(), adminCLISecretValue, "raw-token-value")
+	if bytes.Contains(validate.Bytes(), []byte("credentialValue")) {
+		t.Fatalf("provider validation exposed credential value field: %s", validate.String())
+	}
+
+	var rejected bytes.Buffer
+	err := executeAdmin([]string{"providers", "validate", "--provider-id", "vault-dev", "--provider-kind", "vault", "--address", "https://vault.example.invalid", "--credential-value", "raw-token-value", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &rejected)
+	if !errors.Is(err, errPolicyDenied) {
+		t.Fatalf("plaintext credential should be denied, got %v body=%s", err, rejected.String())
+	}
+	assertNoSecretMaterial(t, rejected.Bytes(), "raw-token-value", adminCLISecretValue)
+
+	var migration bytes.Buffer
+	if err := executeAdmin([]string{"migration", "dry-run", "--source-provider", "local", "--target-provider", "local", "--ref", ref, "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &migration); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, migration.Bytes(), adminCLISecretValue, "test-master-key")
+	if !bytes.Contains(migration.Bytes(), []byte("dry_run_ready")) {
+		t.Fatalf("migration dry run missing outcome: %s", migration.String())
+	}
+
+	if err := backend.audit("management_reveal", ref, "ready", "@operator", "req-1"); err != nil {
+		t.Fatal(err)
+	}
+	var audit bytes.Buffer
+	if err := executeAdmin([]string{"audit", "export", "--operation", "management_reveal", "--audit", backend.auditPath}, &audit); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, audit.Bytes(), adminCLISecretValue, "test-master-key")
+	var exported adminAuditExportResponse
+	if err := json.Unmarshal(audit.Bytes(), &exported); err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Events) == 0 || exported.Events[0].Operation != "management_reveal" {
+		t.Fatalf("audit export = %#v", exported)
+	}
+}
+
+func TestAdminCLILockedListFailsClosed(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "store.json")
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	var out bytes.Buffer
+	err := executeAdmin([]string{"secrets", "list", "--store", storePath, "--audit", auditPath}, &out)
+	if !errors.Is(err, errLocked) {
+		t.Fatalf("locked list err=%v body=%s", err, out.String())
+	}
+	assertNoSecretMaterial(t, out.Bytes(), adminCLISecretValue)
+	if !strings.Contains(out.String(), "locked") {
+		t.Fatalf("locked response missing outcome: %s", out.String())
+	}
+}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -122,6 +122,8 @@ func run(args []string) error {
 		return runKey(args[1:])
 	case "backup":
 		return runBackup(args[1:])
+	case "admin":
+		return runAdmin(args[1:])
 	case "session":
 		return runSession(args[1:])
 	case "version":
@@ -137,13 +139,14 @@ func run(args []string) error {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|backup|session|version>")
+	fmt.Fprintln(os.Stderr, "Usage: secretsbroker <serve|status|key|backup|admin|session|version>")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Commands:")
 	fmt.Fprintln(os.Stderr, "  serve   Start the local-first @secretsbroker daemon")
 	fmt.Fprintln(os.Stderr, "  status  Print current broker state JSON")
 	fmt.Fprintln(os.Stderr, "  key     Manage portable master-key lifecycle, local wrapper, and rotation")
 	fmt.Fprintln(os.Stderr, "  backup  Create or restore encrypted local-store backup artifacts")
+	fmt.Fprintln(os.Stderr, "  admin   Headless admin CLI for status, metadata search, reveal, provider, migration, and audit workflows")
 	fmt.Fprintln(os.Stderr, "  session Manage local API session/token foundation")
 	fmt.Fprintln(os.Stderr, "  version Print broker version")
 }
@@ -232,6 +235,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
+			"CLI secretsbroker admin status|secrets|providers|migration|audit",
 		},
 		Features: []string{
 			"liveness",
@@ -260,6 +264,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"master-key-initialize-unlock-import-rewrap",
 			"os-wrapper-status",
 			"master-key-rotation",
+			"headless-admin-cli",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",

--- a/docs/headless-admin-cli.md
+++ b/docs/headless-admin-cli.md
@@ -1,0 +1,117 @@
+# Secrets Broker Headless Admin CLI
+
+Status: implemented contract slice  
+Issue: #40  
+Service id: `@secretsbroker`
+
+## Purpose
+
+Headless/server operators need a safe CLI surface for Secrets Broker when Service Admin is unavailable or intentionally not installed. The CLI mirrors existing local API/admin contracts and stays metadata-first by default.
+
+## Safety defaults
+
+- Status, list, search, provider status, migration dry-run, and audit export output metadata only.
+- Provider credentials, portable master keys, wrapper plaintext, raw env values, tokens, passwords, cookies, private keys, and secret values are never printed by default.
+- Raw secret values are printed only by `admin secrets reveal` when all of these are present:
+  - a valid ref
+  - `--reason <audit reason>`
+  - `--confirm`
+  - not `--no-echo`
+- `--no-echo` performs the reveal/audit check but suppresses the value and returns reveal metadata/guidance only.
+- Failure states fail closed with typed outcomes such as `locked`, `missing_ref`, `invalid_ref`, `policy_denied`, `source_auth_required`, `unsupported`, and `degraded`.
+
+## Commands
+
+All commands support the existing local store flags where applicable:
+
+```text
+--store <path>
+--audit <path>
+--master-key <key>
+--master-key-file <path>
+--sources <path>
+```
+
+### Status / health summary
+
+```powershell
+secretsbroker admin status --master-key-file .\secure\portable-master-key.txt
+```
+
+Returns service status, health, lifecycle state, capabilities, and provider config summary. Output contains status metadata only.
+
+### List/search secret metadata
+
+```powershell
+secretsbroker admin secrets list --master-key-file .\secure\portable-master-key.txt
+secretsbroker admin secrets search --query SESSION --master-key-file .\secure\portable-master-key.txt
+secretsbroker admin secrets value-search --query signing --master-key-file .\secure\portable-master-key.txt
+```
+
+List and search never return raw values. Value-search may inspect broker-held values internally, but output remains refs/status/metadata only.
+
+### Controlled reveal
+
+```powershell
+secretsbroker admin secrets reveal `
+  --ref services/@serviceadmin/runtime/SESSION_SIGNING_KEY `
+  --reason "operator troubleshooting" `
+  --confirm `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+This is the only CLI path that may print a raw value. Prefer `--no-echo` when the operator only needs to verify access and create an audit record:
+
+```powershell
+secretsbroker admin secrets reveal `
+  --ref services/@serviceadmin/runtime/SESSION_SIGNING_KEY `
+  --reason "verify access without printing" `
+  --confirm `
+  --no-echo `
+  --master-key-file .\secure\portable-master-key.txt
+```
+
+### Provider status and config validation
+
+```powershell
+secretsbroker admin providers capabilities
+secretsbroker admin providers status --master-key-file .\secure\portable-master-key.txt
+secretsbroker admin providers validate `
+  --provider-id vault-dev `
+  --provider-kind vault `
+  --address https://vault.example.invalid `
+  --credential-ref secret://local/provider/vault-dev/token
+```
+
+Validation rejects plaintext credential payloads and reports credential refs/handles only.
+
+### Migration dry-run/apply status
+
+```powershell
+secretsbroker admin migration dry-run `
+  --source-provider local `
+  --target-provider local `
+  --ref services/@serviceadmin/runtime/SESSION_SIGNING_KEY
+```
+
+Migration dry-run is metadata-only. Apply requires `--confirm`, `--operation-id`, and `--reason` and still does not print raw values.
+
+### Audit export
+
+```powershell
+secretsbroker admin audit export --audit .\data\secretsbroker-audit.jsonl --operation management_reveal
+```
+
+Audit export returns operation/ref/outcome/timestamp/request metadata only. Audit events must not contain raw values.
+
+### Unlock/import/re-wrap
+
+Master-key lifecycle commands are part of the same headless operator workflow and are documented in `docs/master-key-lifecycle.md`:
+
+```text
+secretsbroker key initialize
+secretsbroker key unlock
+secretsbroker key import
+secretsbroker key rewrap
+secretsbroker key wrapper-status
+```


### PR DESCRIPTION
## Summary
- add `secretsbroker admin` headless CLI commands for status, secret metadata list/search/value-search, controlled reveal/no-echo, provider capabilities/status/validate, migration dry-run/apply, and scrubbed audit export
- add `docs/headless-admin-cli.md` with safe-by-default operator contract and command examples
- update README/capabilities/usage to advertise the headless admin surface
- add tests proving default CLI output is scrubbed and raw values only appear on explicit reveal with `--confirm` + audit reason

## Validation
- `go test ./...` ✅
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` ✅
- `pwsh -NoLogo -NoProfile -File .\scripts\verify.ps1` ⚠️ blocked locally: `service-lasso-harness binary not found. Set SERVICE_LASSO_HARNESS_BIN or add it to PATH.`

## Safety notes
- list/search/provider/migration/audit/status commands return metadata only
- plaintext provider credential input is rejected and not echoed
- reveal requires explicit `--confirm` plus `--reason`; `--no-echo` suppresses the value while preserving audit/status output

Closes #40