### PR TITLE
ISS-40 remove headless admin doc trailing whitespace

### DIFF
--- a/docs/headless-admin-cli.md
+++ b/docs/headless-admin-cli.md
@@ -1,7 +1,7 @@
 # Secrets Broker Headless Admin CLI
 
-Status: implemented contract slice  
-Issue: #40  
+Status: implemented contract slice
+Issue: #40
 Service id: `@secretsbroker`
 
 ## Purpose


### PR DESCRIPTION
## Summary
- cleanup follow-up for #40 after delayed validation caught trailing whitespace in `docs/headless-admin-cli.md`
- removes trailing whitespace from the headless admin CLI doc status/issue metadata lines

## Validation
- `git diff --check HEAD` ✅
- `go test ./...` ✅

Follow-up to PR #43 / issue #40.