### PR TITLE
ISS-62 enforce service secret policy slice

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -95,18 +95,19 @@ type writebackIdentity struct {
 }
 
 type generatedSecretCaptureRequest struct {
-	RequestID          string            `json:"requestId"`
-	Identity           writebackIdentity `json:"identity"`
-	Policy             writebackPolicy   `json:"policy"`
-	Operation          string            `json:"operation"`
-	Namespace          string            `json:"namespace"`
-	Ref                string            `json:"ref"`
-	Value              string            `json:"value"`
-	Metadata           map[string]string `json:"metadata"`
-	RefreshRequired    bool              `json:"refreshRequired"`
-	ReconnectRequired  bool              `json:"reconnectRequired"`
-	InvalidateRefs     []string          `json:"invalidateRefs"`
-	SourceAuthRequired bool              `json:"sourceAuthRequired"`
+	RequestID          string                `json:"requestId"`
+	Identity           writebackIdentity     `json:"identity"`
+	Policy             writebackPolicy       `json:"policy"`
+	Secrets            *serviceSecretsPolicy `json:"secrets,omitempty"`
+	Operation          string                `json:"operation"`
+	Namespace          string                `json:"namespace"`
+	Ref                string                `json:"ref"`
+	Value              string                `json:"value"`
+	Metadata           map[string]string     `json:"metadata"`
+	RefreshRequired    bool                  `json:"refreshRequired"`
+	ReconnectRequired  bool                  `json:"reconnectRequired"`
+	InvalidateRefs     []string              `json:"invalidateRefs"`
+	SourceAuthRequired bool                  `json:"sourceAuthRequired"`
 }
 
 type generatedSecretCaptureResponse struct {
@@ -125,11 +126,12 @@ type generatedSecretCaptureResponse struct {
 }
 
 type resolveRequest struct {
-	RequestID   string   `json:"requestId"`
-	WorkspaceID string   `json:"workspaceId"`
-	ServiceID   string   `json:"serviceId"`
-	Purpose     string   `json:"purpose"`
-	Refs        []string `json:"refs"`
+	RequestID   string                `json:"requestId"`
+	WorkspaceID string                `json:"workspaceId"`
+	ServiceID   string                `json:"serviceId"`
+	Purpose     string                `json:"purpose"`
+	Secrets     *serviceSecretsPolicy `json:"secrets,omitempty"`
+	Refs        []string              `json:"refs"`
 }
 
 type resolveResponse struct {
@@ -296,6 +298,15 @@ func (b *localBackend) captureGeneratedSecret(req generatedSecretCaptureRequest)
 			return response, errIdentityExpired
 		}
 	}
+	if req.Secrets != nil {
+		decision := evaluateServiceSecretsPolicy(service, "writeback", fullRef, req.Secrets)
+		_ = b.audit("policy_decision", fullRef, decision.Outcome, service, req.RequestID)
+		if decision.Outcome != "allowed" {
+			_ = b.audit("writeback_capture", fullRef, "policy_denied", service, req.RequestID)
+			response.Outcome = "policy_denied"
+			return response, errPolicyDenied
+		}
+	}
 	if !namespaceAllowed(namespace, req.Policy.AllowedNamespaces) || !operationAllowed(operation, req.Policy.AllowedOperations) {
 		_ = b.audit("writeback_capture", fullRef, "policy_denied", service, req.RequestID)
 		response.Outcome = "policy_denied"
@@ -370,6 +381,11 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 		case !validSecretRef(ref):
 			result.Outcome = "invalid_ref"
 			result.Message = "Secret ref is invalid."
+		case req.Secrets != nil && evaluateServiceSecretsPolicy(req.ServiceID, "resolve", ref, req.Secrets).Outcome != "allowed":
+			decision := evaluateServiceSecretsPolicy(req.ServiceID, "resolve", ref, req.Secrets)
+			_ = b.audit("policy_decision", ref, decision.Outcome, req.ServiceID, req.RequestID)
+			result.Outcome = "policy_denied"
+			result.Message = "Service secret policy denied resolve."
 		case b.locked():
 			result.Outcome = "locked"
 			result.Message = "Secrets Broker local store is locked."

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -258,6 +258,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"env-source",
 			"file-source",
 			"exec-source",
+			"service-json-secret-policy",
 			"write-back-policy",
 			"generated-secret-capture",
 			"encrypted-backup-restore",

--- a/cmd/secretsbroker/policy.go
+++ b/cmd/secretsbroker/policy.go
@@ -1,0 +1,106 @@
+package main
+
+import "strings"
+
+type serviceSecretsPolicy struct {
+	Resolve   []string `json:"resolve,omitempty"`
+	Writeback []string `json:"writeback,omitempty"`
+	Manage    []string `json:"manage,omitempty"`
+}
+
+type secretPolicyDecision struct {
+	ServiceID  string `json:"serviceId"`
+	Operation  string `json:"operation"`
+	Ref        string `json:"ref"`
+	Outcome    string `json:"outcome"`
+	NextAction string `json:"nextAction"`
+	ReasonCode string `json:"reasonCode"`
+}
+
+func evaluateServiceSecretsPolicy(serviceID, operation, ref string, policy *serviceSecretsPolicy) secretPolicyDecision {
+	serviceID = strings.TrimSpace(serviceID)
+	operation = strings.TrimSpace(operation)
+	ref = strings.Trim(strings.TrimSpace(ref), "/")
+	decision := secretPolicyDecision{
+		ServiceID:  serviceID,
+		Operation:  operation,
+		Ref:        ref,
+		Outcome:    "unknown",
+		NextAction: "provide_service_secret_policy",
+		ReasonCode: "policy_missing",
+	}
+	if serviceID == "" || operation == "" || !validSecretRef(ref) {
+		decision.Outcome = "denied"
+		decision.NextAction = "provide_valid_service_identity_and_ref"
+		decision.ReasonCode = "invalid_policy_subject"
+		return decision
+	}
+	if policy == nil {
+		return decision
+	}
+	if (operation == "resolve" || operation == "writeback") && serviceRefOwnerMismatch(serviceID, ref) {
+		decision.Outcome = "denied"
+		decision.NextAction = "use_matching_service_identity"
+		decision.ReasonCode = "service_id_mismatch"
+		return decision
+	}
+	patterns, known := policyPatternsForOperation(operation, *policy)
+	if !known {
+		decision.Outcome = "unknown"
+		decision.NextAction = "use_supported_policy_operation"
+		decision.ReasonCode = "policy_operation_unknown"
+		return decision
+	}
+	if len(patterns) == 0 {
+		decision.Outcome = "denied"
+		decision.NextAction = "add_service_secret_policy_assignment"
+		decision.ReasonCode = "policy_empty"
+		return decision
+	}
+	for _, pattern := range patterns {
+		if secretPolicyPatternMatches(ref, pattern) {
+			decision.Outcome = "allowed"
+			decision.NextAction = ""
+			decision.ReasonCode = "policy_match"
+			return decision
+		}
+	}
+	decision.Outcome = "denied"
+	decision.NextAction = "add_service_secret_policy_assignment"
+	decision.ReasonCode = "policy_no_match"
+	return decision
+}
+
+func policyPatternsForOperation(operation string, policy serviceSecretsPolicy) ([]string, bool) {
+	switch operation {
+	case "resolve":
+		return safeList(policy.Resolve), true
+	case "writeback":
+		return safeList(policy.Writeback), true
+	case "reveal", "edit", "reset", "migration", "policy_apply", "manage":
+		return safeList(policy.Manage), true
+	default:
+		return nil, false
+	}
+}
+
+func secretPolicyPatternMatches(ref, pattern string) bool {
+	ref = strings.Trim(strings.TrimSpace(ref), "/")
+	pattern = strings.Trim(strings.TrimSpace(pattern), "/")
+	if ref == "" || pattern == "" || strings.Contains(pattern, "..") || strings.ContainsAny(pattern, " \t\r\n") {
+		return false
+	}
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasSuffix(pattern, "/*") {
+		prefix := strings.TrimSuffix(pattern, "/*")
+		return ref == prefix || strings.HasPrefix(ref, prefix+"/")
+	}
+	return ref == pattern
+}
+
+func serviceRefOwnerMismatch(serviceID, ref string) bool {
+	owner := ownerFromRef(ref)
+	return owner != "" && owner != "unknown" && owner != serviceID
+}

--- a/cmd/secretsbroker/policy_test.go
+++ b/cmd/secretsbroker/policy_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateServiceSecretsPolicyDecisions(t *testing.T) {
+	policy := &serviceSecretsPolicy{
+		Resolve:   []string{"services/api/runtime/*"},
+		Writeback: []string{"services/api/generated/*"},
+		Manage:    []string{"services/api/runtime/*"},
+	}
+	tests := []struct {
+		name       string
+		serviceID  string
+		operation  string
+		ref        string
+		policy     *serviceSecretsPolicy
+		want       string
+		reasonCode string
+	}{
+		{name: "resolve allowed by prefix", serviceID: "api", operation: "resolve", ref: "services/api/runtime/API_TOKEN", policy: policy, want: "allowed", reasonCode: "policy_match"},
+		{name: "writeback denied by namespace", serviceID: "api", operation: "writeback", ref: "services/api/runtime/API_TOKEN", policy: policy, want: "denied", reasonCode: "policy_no_match"},
+		{name: "manage uses management assignment", serviceID: "@serviceadmin", operation: "reveal", ref: "services/api/runtime/API_TOKEN", policy: policy, want: "allowed", reasonCode: "policy_match"},
+		{name: "missing policy is unknown", serviceID: "api", operation: "resolve", ref: "services/api/runtime/API_TOKEN", policy: nil, want: "unknown", reasonCode: "policy_missing"},
+		{name: "unknown operation is unknown", serviceID: "api", operation: "rotate", ref: "services/api/runtime/API_TOKEN", policy: policy, want: "unknown", reasonCode: "policy_operation_unknown"},
+		{name: "malformed ref is denied", serviceID: "api", operation: "resolve", ref: "services/api/../API_TOKEN", policy: policy, want: "denied", reasonCode: "invalid_policy_subject"},
+		{name: "service id mismatch is denied", serviceID: "worker", operation: "resolve", ref: "services/api/runtime/API_TOKEN", policy: policy, want: "denied", reasonCode: "service_id_mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := evaluateServiceSecretsPolicy(tt.serviceID, tt.operation, tt.ref, tt.policy)
+			if decision.Outcome != tt.want || decision.ReasonCode != tt.reasonCode {
+				t.Fatalf("decision = %#v, want outcome %q reason %q", decision, tt.want, tt.reasonCode)
+			}
+		})
+	}
+}
+
+func TestResolveHonorsManifestPolicyWithoutLeakingValue(t *testing.T) {
+	backend := testBackend(t)
+	allowedRef := "services/api/runtime/API_TOKEN"
+	deniedRef := "services/api/private/ROOT_TOKEN"
+	allowedValue := "allowed-secret-value"
+	deniedValue := "denied-secret-value"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: allowedRef, Value: allowedValue}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: deniedRef, Value: deniedValue}); err != nil {
+		t.Fatal(err)
+	}
+
+	res := backend.resolve(resolveRequest{
+		RequestID: "req-policy-resolve",
+		ServiceID: "api",
+		Secrets:   &serviceSecretsPolicy{Resolve: []string{"services/api/runtime/*"}},
+		Refs:      []string{allowedRef, deniedRef},
+	})
+	if len(res.Results) != 2 {
+		t.Fatalf("results = %#v", res.Results)
+	}
+	if res.Results[0].Outcome != "ready" || res.Results[0].Value != allowedValue {
+		t.Fatalf("allowed result = %#v", res.Results[0])
+	}
+	if res.Results[1].Outcome != "policy_denied" || res.Results[1].Value != "" {
+		t.Fatalf("denied result = %#v", res.Results[1])
+	}
+	encoded, err := json.Marshal(res.Results[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, deniedValue)
+}
+
+func TestWritebackHonorsManifestPolicyWithoutLeakingValue(t *testing.T) {
+	backend := testBackend(t)
+	value := "generated-secret-value"
+	allowed := generatedSecretCaptureRequest{
+		RequestID: "req-writeback-allowed",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}},
+		Secrets:   &serviceSecretsPolicy{Writeback: []string{"services/api/generated/*"}},
+		Operation: "create",
+		Namespace: "services/api",
+		Ref:       "generated/API_TOKEN",
+		Value:     value,
+	}
+	res, err := backend.captureGeneratedSecret(allowed)
+	if err != nil || res.Outcome != "ready" {
+		t.Fatalf("allowed writeback = %#v err=%v", res, err)
+	}
+
+	denied := allowed
+	denied.RequestID = "req-writeback-denied"
+	denied.Ref = "runtime/API_TOKEN"
+	res, err = backend.captureGeneratedSecret(denied)
+	if !errors.Is(err, errPolicyDenied) || res.Outcome != "policy_denied" {
+		t.Fatalf("denied writeback = %#v err=%v", res, err)
+	}
+	encoded, marshalErr := json.Marshal(res)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if strings.Contains(string(encoded), value) {
+		t.Fatalf("policy-denied writeback leaked value: %s", encoded)
+	}
+}

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -60,6 +60,16 @@ Baseline semantics:
 - Policy evaluation returns `allowed`, `denied`, or `unknown`; `unknown` is denied.
 - Policy denial responses include safe metadata: service id, operation, outcome, and next action. They do not include the requested value or credential material.
 
+Implemented first slice:
+
+- The broker has a service-manifest policy evaluator for the optional `secrets` section.
+- Supported operation families are `resolve`, `writeback`, and management operations mapped to `manage`.
+- Patterns support exact refs, `*`, and prefix wildcards ending in `/*`.
+- Runtime `resolve` and `writeback` decisions deny `services/<id>/...` refs when the presented service identity does not match `<id>`.
+- `POST /v1/resolve` and `POST /v1/writeback` enforce the supplied manifest policy when the request includes `secrets`.
+- Existing launch-time write-back grants remain enforced; a supplied manifest policy is an additional fail-closed gate.
+- Denied resolve/write-back responses do not echo raw secret values or generated replacement material.
+
 ## Audit model
 
 Audit events are append-only JSONL records in local mode and provider-backed records in enterprise/provider mode when available. Records should use a stable schema:

--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -346,6 +346,34 @@ Sample:
 
 ## Other important manifest aspects
 
+### `secrets`
+
+`secrets` declares the secret refs a service is allowed to use. The broker treats this section as desired policy input and still requires the caller's runtime identity to match the service.
+
+Example:
+
+```json
+"secrets": {
+  "resolve": [
+    "services/echo-service/runtime/*"
+  ],
+  "writeback": [
+    "services/echo-service/generated/*"
+  ],
+  "manage": []
+}
+```
+
+Current broker semantics:
+
+- `resolve` gates runtime secret resolution.
+- `writeback` gates generated secret capture in addition to launch-time write-back grants.
+- `manage` gates reveal/edit/reset/migration/policy operations and remains subject to local API auth, audit reason, and operation-specific checks.
+- Patterns are metadata matchers: exact refs, `*`, or prefix wildcards ending in `/*`.
+- Runtime `resolve` and `writeback` decisions deny `services/<id>/...` refs when the presented service identity does not match `<id>`.
+- Missing or malformed policy evaluates to `unknown` or `denied` and must fail closed when policy enforcement is requested.
+- Policy decisions and denial responses are metadata-only; they must not include raw values, provider credentials, tokens, environment dumps, or generated replacement material.
+
 ### Environment generation
 Current broader Service Lasso direction includes:
 - explicit service-local env via `env`


### PR DESCRIPTION
## Issue
Closes #62

## Summary
- Added a service-manifest `secrets` policy evaluator for resolve/writeback/manage operation families.
- Enforced supplied manifest policy on `POST /v1/resolve` and `POST /v1/writeback` without changing existing callers that do not supply manifest policy.
- Documented the `secrets` manifest policy contract and the first implemented enforcement slice.

## Scope
- In scope: exact/prefix/`*` ref matching, allowed/denied/unknown decisions, service-id mismatch denial for runtime resolve/writeback, metadata-only denied responses.
- Out of scope: full external identity/session leases, UI surfaces, advanced policy inheritance, and audit schema expansion beyond existing safe metadata audit calls.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md`
- Updated: `docs/service-json-reference.md`
- No fixture changes required.

## Service Lasso invariant impact
- Invariant: keep `@secretsbroker` local-first and Service Lasso-facing.
- Preservation proof: implementation is local broker policy evaluation only; no Vault/OpenBao dependency or secret value exposure was added.

## Validation
- PASS `go test ./cmd/secretsbroker -run "TestEvaluateServiceSecretsPolicyDecisions|TestResolveHonorsManifestPolicyWithoutLeakingValue|TestWritebackHonorsManifestPolicyWithoutLeakingValue"`
- PASS `go test ./cmd/secretsbroker`
- PASS `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`
- PASS `git diff --check`

## Approval trail
- Required: no special operator approval for this bounded target-repo issue slice.
- Evidence: Project #1 Ready item, issue #62.

## Cleanup
- Branch: `issue-62-policy-assignments`
- Local checkout should return to `main` after PR handoff/merge.
