### PR TITLE
ISS-63 harden audit export redaction

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -31,12 +31,13 @@ type adminStatusResponse struct {
 }
 
 type adminAuditExportResponse struct {
-	ServiceID  string       `json:"serviceId"`
-	APIVersion string       `json:"apiVersion"`
-	Outcome    string       `json:"outcome"`
-	Operation  string       `json:"operation,omitempty"`
-	Ref        string       `json:"ref,omitempty"`
-	Events     []auditEvent `json:"events"`
+	ServiceID   string       `json:"serviceId"`
+	APIVersion  string       `json:"apiVersion"`
+	Outcome     string       `json:"outcome"`
+	Operation   string       `json:"operation,omitempty"`
+	Ref         string       `json:"ref,omitempty"`
+	RefHashOnly bool         `json:"refHashOnly,omitempty"`
+	Events      []auditEvent `json:"events"`
 }
 
 func runAdmin(args []string) error {
@@ -237,10 +238,11 @@ func runAdminAudit(args []string, out io.Writer) error {
 	fs, opts := newAdminFlagSet("admin audit export")
 	operation := fs.String("operation", "", "operation filter")
 	ref := fs.String("ref", "", "ref filter")
+	refHashOnly := fs.Bool("ref-hash-only", false, "omit raw refs from exported audit events and keep refHash only")
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
 	}
-	res, err := exportAuditEvents(opts.AuditPath, *operation, *ref)
+	res, err := exportAuditEvents(opts.AuditPath, *operation, *ref, *refHashOnly)
 	if err != nil {
 		_ = encodeAdminJSON(out, res)
 		return err
@@ -289,8 +291,8 @@ func normalizeAdminState(state string, backend *localBackend, material keyMateri
 	return "ready"
 }
 
-func exportAuditEvents(path, operation, ref string) (adminAuditExportResponse, error) {
-	res := adminAuditExportResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Operation: strings.TrimSpace(operation), Ref: strings.TrimSpace(ref), Events: []auditEvent{}}
+func exportAuditEvents(path, operation, ref string, refHashOnly bool) (adminAuditExportResponse, error) {
+	res := adminAuditExportResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", Operation: strings.TrimSpace(operation), Ref: strings.TrimSpace(ref), RefHashOnly: refHashOnly, Events: []auditEvent{}}
 	file, err := os.Open(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return res, nil
@@ -312,6 +314,10 @@ func exportAuditEvents(path, operation, ref string) (adminAuditExportResponse, e
 		}
 		if res.Ref != "" && event.Ref != res.Ref {
 			continue
+		}
+		event = normalizeAuditEvent(event)
+		if refHashOnly {
+			event.Ref = ""
 		}
 		res.Events = append(res.Events, event)
 	}

--- a/cmd/secretsbroker/admin_cli_test.go
+++ b/cmd/secretsbroker/admin_cli_test.go
@@ -126,6 +126,25 @@ func TestAdminCLIProviderValidationMigrationAndAuditAreScrubbed(t *testing.T) {
 	if len(exported.Events) == 0 || exported.Events[0].Operation != "management_reveal" {
 		t.Fatalf("audit export = %#v", exported)
 	}
+	if exported.Events[0].RefHash == "" || exported.Events[0].ReasonCode != "ready" || exported.Events[0].ActorKind != "operator" || exported.Events[0].AuditStatus != "audit_recorded" {
+		t.Fatalf("audit event missing normalized metadata: %#v", exported.Events[0])
+	}
+
+	var hashOnly bytes.Buffer
+	if err := executeAdmin([]string{"audit", "export", "--operation", "management_reveal", "--ref-hash-only", "--audit", backend.auditPath}, &hashOnly); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, hashOnly.Bytes(), adminCLISecretValue, "test-master-key")
+	if bytes.Contains(hashOnly.Bytes(), []byte(ref)) {
+		t.Fatalf("hash-only audit export exposed raw ref: %s", hashOnly.String())
+	}
+	var hashOnlyExport adminAuditExportResponse
+	if err := json.Unmarshal(hashOnly.Bytes(), &hashOnlyExport); err != nil {
+		t.Fatal(err)
+	}
+	if len(hashOnlyExport.Events) == 0 || hashOnlyExport.Events[0].Ref != "" || hashOnlyExport.Events[0].RefHash == "" {
+		t.Fatalf("hash-only audit export = %#v", hashOnlyExport)
+	}
 }
 
 func TestAdminCLILockedListFailsClosed(t *testing.T) {

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -150,14 +151,19 @@ type resolveResult struct {
 }
 
 type auditEvent struct {
-	TS        time.Time `json:"ts"`
-	Operation string    `json:"operation"`
-	Ref       string    `json:"ref,omitempty"`
-	Outcome   string    `json:"outcome"`
-	State     string    `json:"state,omitempty"`
-	SourceID  string    `json:"sourceId,omitempty"`
-	ServiceID string    `json:"serviceId,omitempty"`
-	RequestID string    `json:"requestId,omitempty"`
+	TS          time.Time `json:"ts"`
+	RequestID   string    `json:"requestId,omitempty"`
+	Operation   string    `json:"operation"`
+	ServiceID   string    `json:"serviceId,omitempty"`
+	ActorKind   string    `json:"actorKind"`
+	Ref         string    `json:"ref,omitempty"`
+	RefHash     string    `json:"refHash,omitempty"`
+	ProviderID  string    `json:"providerId,omitempty"`
+	SourceID    string    `json:"sourceId,omitempty"`
+	Outcome     string    `json:"outcome"`
+	ReasonCode  string    `json:"reasonCode"`
+	State       string    `json:"state,omitempty"`
+	AuditStatus string    `json:"auditStatus"`
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
@@ -469,6 +475,7 @@ func (b *localBackend) writeAuditEvent(event auditEvent) error {
 	if strings.TrimSpace(b.auditPath) == "" {
 		return nil
 	}
+	event = normalizeAuditEvent(event)
 	if err := os.MkdirAll(filepath.Dir(b.auditPath), 0o700); err != nil {
 		return err
 	}
@@ -478,6 +485,76 @@ func (b *localBackend) writeAuditEvent(event auditEvent) error {
 	}
 	defer file.Close()
 	return json.NewEncoder(file).Encode(event)
+}
+
+func normalizeAuditEvent(event auditEvent) auditEvent {
+	event.Operation = scrubAuditField(event.Operation)
+	event.Ref = scrubAuditField(event.Ref)
+	event.Outcome = scrubAuditField(event.Outcome)
+	event.State = scrubAuditField(event.State)
+	event.SourceID = scrubAuditField(event.SourceID)
+	event.ServiceID = scrubAuditField(event.ServiceID)
+	event.RequestID = scrubAuditField(event.RequestID)
+	event.ProviderID = scrubAuditField(event.ProviderID)
+	event.ReasonCode = scrubAuditField(event.ReasonCode)
+	event.ActorKind = scrubAuditField(event.ActorKind)
+	event.AuditStatus = scrubAuditField(event.AuditStatus)
+	if event.Operation == "" {
+		event.Operation = "unknown"
+	}
+	if event.Outcome == "" {
+		event.Outcome = "degraded"
+	}
+	if event.ReasonCode == "" {
+		event.ReasonCode = event.Outcome
+	}
+	if event.ActorKind == "" {
+		event.ActorKind = actorKindForAudit(event.ServiceID)
+	}
+	if event.AuditStatus == "" {
+		event.AuditStatus = "audit_recorded"
+	}
+	if event.Ref != "" && event.RefHash == "" {
+		event.RefHash = hashAuditRef(event.Ref)
+	}
+	if event.ProviderID == "" && strings.HasPrefix(event.Operation, "provider_") && event.Ref != "" {
+		event.ProviderID = event.Ref
+	}
+	return event
+}
+
+func scrubAuditField(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, value)
+	if len(value) > 256 {
+		return value[:256]
+	}
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func hashAuditRef(ref string) string {
+	sum := sha256.Sum256([]byte(ref))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func actorKindForAudit(serviceID string) string {
+	switch strings.TrimSpace(serviceID) {
+	case "":
+		return "system"
+	case "@operator":
+		return "operator"
+	default:
+		return "service"
+	}
 }
 
 func (b *localBackend) encrypt(value string) (secretPayload, error) {

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -97,6 +97,13 @@ Required redaction:
 - No event may include raw `value`, credential payloads, auth headers, bearer tokens, private keys, cookies, environment dumps, or provider response bodies.
 - Audit failure blocks reveal/apply unless the operation is explicitly marked non-secret-bearing and safe to continue.
 
+Implemented first slice:
+
+- Local audit JSONL records are normalized with `requestId`, `operation`, `serviceId`, `actorKind`, `ref`, `refHash`, `providerId` where applicable, `outcome`, `reasonCode`, and `auditStatus`.
+- Audit fields are trimmed, control characters are stripped, and long metadata fields are bounded before persistence.
+- `secretsbroker admin audit export --ref-hash-only` omits raw refs from exported events while preserving `refHash` for correlation.
+- Tests cover metadata-only audit export and prove secret payload values/master-key material are not serialized.
+
 ## Telemetry model
 
 Telemetry is operational health data, not audit evidence. It should be safe to expose to Service Lasso and Service Admin without elevated secret access.


### PR DESCRIPTION
## Issue
Closes #63

## Summary
- Normalizes local audit JSONL records with actor kind, reason code, audit status, provider id where applicable, and deterministic ref hashes.
- Adds `secretsbroker admin audit export --ref-hash-only` so exports can correlate refs without returning raw refs.
- Documents the implemented audit hardening slice in the operational controls baseline.

## Scope
- In scope: local audit record normalization, metadata bounding/control-character scrubbing, hash-only audit export, and focused test coverage.
- Out of scope: tamper-evident audit chains, remote audit sinks, telemetry/events/lockout implementation, and broader policy enforcement.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md` for the implemented first audit slice.
- API/CLI contract: `admin audit export --ref-hash-only` omits event `ref` while preserving `refHash`.

## Service Lasso invariant impact
- Invariant: secrets, provider credentials, tokens, private keys, cookies, passwords, environment values, and provider response bodies stay out of audit exports.
- Preservation proof: tests assert audit export does not serialize the fixture secret value or master key, and hash-only export removes raw refs.

## Validation
- PASS `go test ./cmd/secretsbroker`
- PASS `git diff --check`
- PASS `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`

## Approval trail
- Required: normal PR review/checks.
- Evidence: local validation logs under `.work-agent/logs/issue-63-2026-05-22T07-43-40-248Z/`.

## Cleanup
- Branch remains for PR review. Local checkout will be returned to `main` after handoff; only `.work-agent/` evidence logs should remain untracked.

