### PR TITLE
ISS-64 add redacted telemetry metrics

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -59,6 +59,8 @@ func executeAdmin(args []string, out io.Writer) error {
 		return runAdminMigration(args[1:], out)
 	case "audit":
 		return runAdminAudit(args[1:], out)
+	case "telemetry":
+		return runAdminTelemetry(args[1:], out)
 	default:
 		return fmt.Errorf("unknown admin command %q", args[0])
 	}
@@ -243,6 +245,23 @@ func runAdminAudit(args []string, out io.Writer) error {
 		return err
 	}
 	res, err := exportAuditEvents(opts.AuditPath, *operation, *ref, *refHashOnly)
+	if err != nil {
+		_ = encodeAdminJSON(out, res)
+		return err
+	}
+	return encodeAdminJSON(out, res)
+}
+
+func runAdminTelemetry(args []string, out io.Writer) error {
+	fs, opts := newAdminFlagSet("admin telemetry")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	res, err := buildTelemetryResponse(backend)
 	if err != nil {
 		_ = encodeAdminJSON(out, res)
 		return err

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -225,6 +225,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /v1/sources/status",
 			"GET /v1/providers/capabilities",
 			"GET /v1/providers/config/status",
+			"GET /v1/telemetry",
 			"POST /v1/providers/config/validate|apply",
 			"POST /v1/providers/migration/dry-run|apply",
 			"GET /v1/management/secrets",
@@ -250,6 +251,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"source-status",
 			"provider-config-status",
 			"provider-config-validation",
+			"redacted-telemetry",
 			"provider-migration-dry-run-apply",
 			"secrets-management-metadata-search",
 			"secrets-management-value-search-metadata-only",
@@ -366,6 +368,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
+		registerTelemetryHandlers(mux, backend)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/telemetry.go
+++ b/cmd/secretsbroker/telemetry.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"time"
+)
+
+type telemetryResponse struct {
+	ServiceID          string                       `json:"serviceId"`
+	APIVersion         string                       `json:"apiVersion"`
+	Outcome            string                       `json:"outcome"`
+	GeneratedAt        time.Time                    `json:"generatedAt"`
+	Counters           telemetryCounters            `json:"counters"`
+	DurationHistograms []telemetryDurationHistogram `json:"durationHistograms"`
+	Safety             telemetrySafety              `json:"safety"`
+}
+
+type telemetryCounters struct {
+	Operations           []telemetryOperationCounter `json:"operations"`
+	PolicyDecisions      []telemetryOutcomeCounter   `json:"policyDecisions"`
+	LocalAPIAuthFailures int                         `json:"localApiAuthFailures"`
+	ActiveLockouts       int                         `json:"activeLockouts"`
+	ProviderStates       []telemetryStateCounter     `json:"providerStates"`
+	SourceStates         []telemetryStateCounter     `json:"sourceStates"`
+	AuditRecords         []telemetryAuditCounter     `json:"auditRecords"`
+}
+
+type telemetryOperationCounter struct {
+	Operation string `json:"operation"`
+	Outcome   string `json:"outcome"`
+	Count     int    `json:"count"`
+}
+
+type telemetryOutcomeCounter struct {
+	Outcome string `json:"outcome"`
+	Count   int    `json:"count"`
+}
+
+type telemetryStateCounter struct {
+	ID      string `json:"id"`
+	State   string `json:"state"`
+	Outcome string `json:"outcome"`
+	Count   int    `json:"count"`
+}
+
+type telemetryAuditCounter struct {
+	AuditStatus string `json:"auditStatus"`
+	Outcome     string `json:"outcome"`
+	Count       int    `json:"count"`
+}
+
+type telemetryDurationHistogram struct {
+	Operation string         `json:"operation"`
+	Outcome   string         `json:"outcome,omitempty"`
+	Buckets   map[string]int `json:"buckets"`
+}
+
+type telemetrySafety struct {
+	LowCardinalityLabels  bool `json:"lowCardinalityLabels"`
+	ValueMaterialIncluded bool `json:"valueMaterialIncluded"`
+}
+
+func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
+	res := telemetryResponse{
+		ServiceID:          serviceID,
+		APIVersion:         apiVersion,
+		Outcome:            "ready",
+		GeneratedAt:        time.Now().UTC(),
+		DurationHistograms: []telemetryDurationHistogram{},
+		Safety:             telemetrySafety{LowCardinalityLabels: true, ValueMaterialIncluded: false},
+	}
+	if backend == nil {
+		res.Outcome = "degraded"
+		return res, errBackendDegraded
+	}
+
+	audit, err := exportAuditEvents(backend.auditPath, "", "", true)
+	if err != nil {
+		res.Outcome = "degraded"
+		return res, err
+	}
+	res.Counters.Operations = auditOperationCounters(audit.Events)
+	res.Counters.PolicyDecisions = policyDecisionCounters(audit.Events)
+	res.Counters.LocalAPIAuthFailures = localAPIAuthFailureCount(audit.Events)
+	res.Counters.ActiveLockouts = 0
+	res.Counters.AuditRecords = auditRecordCounters(audit.Events)
+	res.Counters.SourceStates = sourceStateCounters(defaultSourceRegistry(backend).Sources)
+	res.Counters.ProviderStates = providerStateCounters(backend.providerConfigStatusResponse().Providers)
+	return res, nil
+}
+
+func registerTelemetryHandlers(mux *http.ServeMux, backend *localBackend) {
+	mux.HandleFunc("/v1/telemetry", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/telemetry.", "invalid_ref", "")
+			return
+		}
+		res, err := buildTelemetryResponse(backend)
+		if err != nil {
+			status := http.StatusServiceUnavailable
+			if errors.Is(err, errBackendDegraded) {
+				status = http.StatusServiceUnavailable
+			}
+			writeJSON(w, status, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func auditOperationCounters(events []auditEvent) []telemetryOperationCounter {
+	counts := map[string]int{}
+	for _, event := range events {
+		event = normalizeAuditEvent(event)
+		counts[event.Operation+"\x00"+event.Outcome]++
+	}
+	keys := sortedKeys(counts)
+	out := make([]telemetryOperationCounter, 0, len(keys))
+	for _, key := range keys {
+		operation, outcome := splitCounterKey(key)
+		out = append(out, telemetryOperationCounter{Operation: operation, Outcome: outcome, Count: counts[key]})
+	}
+	return out
+}
+
+func policyDecisionCounters(events []auditEvent) []telemetryOutcomeCounter {
+	counts := map[string]int{}
+	for _, event := range events {
+		event = normalizeAuditEvent(event)
+		if event.Operation == "policy_decision" {
+			counts[event.Outcome]++
+		}
+	}
+	keys := sortedKeys(counts)
+	out := make([]telemetryOutcomeCounter, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, telemetryOutcomeCounter{Outcome: key, Count: counts[key]})
+	}
+	return out
+}
+
+func localAPIAuthFailureCount(events []auditEvent) int {
+	count := 0
+	for _, event := range events {
+		event = normalizeAuditEvent(event)
+		if event.Operation == "local_api_auth" && event.Outcome != "ready" {
+			count++
+		}
+	}
+	return count
+}
+
+func auditRecordCounters(events []auditEvent) []telemetryAuditCounter {
+	counts := map[string]int{}
+	for _, event := range events {
+		event = normalizeAuditEvent(event)
+		counts[event.AuditStatus+"\x00"+event.Outcome]++
+	}
+	keys := sortedKeys(counts)
+	out := make([]telemetryAuditCounter, 0, len(keys))
+	for _, key := range keys {
+		status, outcome := splitCounterKey(key)
+		out = append(out, telemetryAuditCounter{AuditStatus: status, Outcome: outcome, Count: counts[key]})
+	}
+	return out
+}
+
+func sourceStateCounters(sources []SourceStatus) []telemetryStateCounter {
+	out := make([]telemetryStateCounter, 0, len(sources))
+	for _, source := range sources {
+		out = append(out, telemetryStateCounter{ID: source.SourceID, State: source.State, Outcome: source.Outcome, Count: 1})
+	}
+	sort.Slice(out, func(i, j int) bool { return stateCounterLess(out[i], out[j]) })
+	return out
+}
+
+func providerStateCounters(providers []providerConfigStatus) []telemetryStateCounter {
+	out := make([]telemetryStateCounter, 0, len(providers))
+	for _, provider := range providers {
+		out = append(out, telemetryStateCounter{ID: provider.ProviderID, State: provider.State, Outcome: provider.Outcome, Count: 1})
+	}
+	sort.Slice(out, func(i, j int) bool { return stateCounterLess(out[i], out[j]) })
+	return out
+}
+
+func sortedKeys(counts map[string]int) []string {
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func splitCounterKey(key string) (string, string) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == 0 {
+			return key[:i], key[i+1:]
+		}
+	}
+	return key, ""
+}
+
+func stateCounterLess(a, b telemetryStateCounter) bool {
+	if a.ID != b.ID {
+		return a.ID < b.ID
+	}
+	if a.State != b.State {
+		return a.State < b.State
+	}
+	return a.Outcome < b.Outcome
+}

--- a/cmd/secretsbroker/telemetry_test.go
+++ b/cmd/secretsbroker/telemetry_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const telemetrySecretValue = "fixture-telemetry-secret-value"
+
+func TestTelemetryCountsOperationalMetadataWithoutSecretMaterial(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: telemetrySecretValue}); err != nil {
+		t.Fatal(err)
+	}
+	_ = backend.audit("local_api_auth", "", "unauthorized", "@operator", "req-auth")
+	backend.resolve(resolveRequest{
+		RequestID: "req-policy-denied",
+		ServiceID: "api",
+		Secrets:   &serviceSecretsPolicy{Resolve: []string{"services/api/other/*"}},
+		Refs:      []string{ref},
+	})
+
+	res, err := buildTelemetryResponse(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, telemetrySecretValue, "test-master-key", ref)
+	if res.Outcome != "ready" || res.Safety.ValueMaterialIncluded {
+		t.Fatalf("unsafe telemetry response: %#v", res)
+	}
+	if !hasOperationCount(res.Counters.Operations, "write", "ready", 1) {
+		t.Fatalf("missing write ready counter: %#v", res.Counters.Operations)
+	}
+	if !hasOperationCount(res.Counters.Operations, "resolve", "policy_denied", 1) {
+		t.Fatalf("missing resolve policy_denied counter: %#v", res.Counters.Operations)
+	}
+	if !hasOutcomeCount(res.Counters.PolicyDecisions, "denied", 1) {
+		t.Fatalf("missing policy denied counter: %#v", res.Counters.PolicyDecisions)
+	}
+	if res.Counters.LocalAPIAuthFailures != 1 {
+		t.Fatalf("auth failure count = %d", res.Counters.LocalAPIAuthFailures)
+	}
+	if len(res.Counters.SourceStates) == 0 || len(res.Counters.ProviderStates) == 0 {
+		t.Fatalf("missing source/provider state counters: %#v", res.Counters)
+	}
+}
+
+func TestTelemetryEndpointAndAdminCLIAreMetadataOnly(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: telemetrySecretValue}); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(runtimeState{}, backend, localAPISecurity{token: "local-token"}))
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/v1/telemetry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("telemetry status = %d", resp.StatusCode)
+	}
+	var apiBody telemetryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiBody); err != nil {
+		t.Fatal(err)
+	}
+	apiEncoded, err := json.Marshal(apiBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, apiEncoded, telemetrySecretValue, ref)
+
+	var cli bytes.Buffer
+	if err := executeAdmin([]string{"telemetry", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &cli); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, cli.Bytes(), telemetrySecretValue, "test-master-key", ref)
+	if !strings.Contains(cli.String(), "operations") || !strings.Contains(cli.String(), "providerStates") {
+		t.Fatalf("telemetry CLI missing counters: %s", cli.String())
+	}
+}
+
+func hasOperationCount(counters []telemetryOperationCounter, operation, outcome string, count int) bool {
+	for _, counter := range counters {
+		if counter.Operation == operation && counter.Outcome == outcome && counter.Count == count {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOutcomeCount(counters []telemetryOutcomeCounter, outcome string, count int) bool {
+	for _, counter := range counters {
+		if counter.Outcome == outcome && counter.Count == count {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -120,6 +120,13 @@ Baseline metrics:
 
 Telemetry labels must be low-cardinality and safe. Use service ids, provider ids, operation names, outcomes, and state names. Use ref prefix groups or hashes only when necessary; do not label with raw values or unbounded refs.
 
+Implemented first slice:
+
+- `GET /v1/telemetry` returns read-only metadata counters for operation/outcome pairs, policy decisions, local API auth failures recorded in audit metadata, source states, provider states, and audit-record status/outcome pairs.
+- `secretsbroker admin telemetry` prints the same metadata-only telemetry shape for headless consumers.
+- The first slice intentionally reports duration histograms as an empty array until operation-duration timing is recorded by the broker paths.
+- Telemetry uses `refHash`-only audit reads internally and does not serialize raw refs, secret values, provider credentials, bearer tokens, private keys, cookies, passwords, environment values, or provider response bodies.
+
 ## Events and filtering
 
 Events represent operator-relevant state transitions and decisions. The broker should maintain a bounded recent event store and expose filtered reads.


### PR DESCRIPTION
## Issue
Closes #64

## Summary
- Adds a read-only `GET /v1/telemetry` endpoint for redacted operational counters.
- Adds `secretsbroker admin telemetry` for headless metadata-only metrics output.
- Documents the first telemetry slice in the operational controls baseline and tests that telemetry omits secret values, raw refs, and key material.

## Scope
- In scope: operation/outcome counters from audit metadata, policy decision counters, local API auth failure counts from audit metadata, provider/source state counters, audit status counters, endpoint/CLI contract, and redaction tests.
- Out of scope: recording operation duration timings and lockout state transitions before those runtime paths exist; the response carries empty duration histograms and zero active lockouts for this slice.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md`.
- API/CLI contract added through Go response structs and tests.

## Service Lasso invariant impact
- Invariant: keep Secrets Broker local-first and do not expose raw secret material.
- Preservation proof: telemetry is built from `refHash`-only audit reads and low-cardinality source/provider metadata; tests assert secret value, raw ref, and master-key material are absent.

## Validation
- PASS `gofmt -w cmd/secretsbroker/telemetry.go cmd/secretsbroker/telemetry_test.go cmd/secretsbroker/main.go cmd/secretsbroker/admin_cli.go`
- PASS `go test ./cmd/secretsbroker -run 'TestTelemetry|TestAdminCLIStatusProvidersAndMetadataOutputAreScrubbed|TestCapabilities' -count=1`
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`
- PASS `git diff --check`

## Approval trail
- Required: no
- Evidence: issue is marked Ready on Project #1 and implementation is bounded to #64.

## Cleanup
- Branch: `issue-64-redacted-telemetry`
- Local cleanup after merge: switch back to `main`, pull, delete local branch when safe.

