### PR TITLE
ISS-65 add bounded operational events

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -7,7 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -17,6 +19,7 @@ type adminCommonOptions struct {
 	MasterKey     string
 	MasterKeyFile string
 	SourcesPath   string
+	EventsPath    string
 }
 
 type adminStatusResponse struct {
@@ -61,6 +64,8 @@ func executeAdmin(args []string, out io.Writer) error {
 		return runAdminAudit(args[1:], out)
 	case "telemetry":
 		return runAdminTelemetry(args[1:], out)
+	case "events":
+		return runAdminEvents(args[1:], out)
 	default:
 		return fmt.Errorf("unknown admin command %q", args[0])
 	}
@@ -269,11 +274,76 @@ func runAdminTelemetry(args []string, out io.Writer) error {
 	return encodeAdminJSON(out, res)
 }
 
+func runAdminEvents(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin events command %q", "")
+	}
+	if args[0] != "list" {
+		return fmt.Errorf("unknown admin events command %q", args[0])
+	}
+	fs, opts := newAdminFlagSet("admin events list")
+	since := fs.String("since", "", "RFC3339 lower time bound")
+	until := fs.String("until", "", "RFC3339 upper time bound")
+	serviceID := fs.String("service-id", "", "service id filter")
+	providerID := fs.String("provider-id", "", "provider id filter")
+	operation := fs.String("operation", "", "operation filter")
+	outcome := fs.String("outcome", "", "outcome filter")
+	severity := fs.String("severity", "", "severity filter")
+	family := fs.String("family", "", "event family filter")
+	refPrefix := fs.String("ref-prefix", "", "safe ref prefix filter")
+	refHash := fs.String("ref-hash", "", "ref hash filter")
+	limit := fs.Int("limit", defaultOperationalEventLimit, "event page size")
+	cursor := fs.Int("cursor", 0, "event page cursor")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	finalizeAdminEventPath(opts)
+	values := url.Values{}
+	values.Set("limit", strconv.Itoa(*limit))
+	values.Set("cursor", strconv.Itoa(*cursor))
+	for key, value := range map[string]string{
+		"since":      *since,
+		"until":      *until,
+		"serviceId":  *serviceID,
+		"providerId": *providerID,
+		"operation":  *operation,
+		"outcome":    *outcome,
+		"severity":   *severity,
+		"family":     *family,
+		"refPrefix":  *refPrefix,
+		"refHash":    *refHash,
+	} {
+		if strings.TrimSpace(value) != "" {
+			values.Set(key, value)
+		}
+	}
+	filters, err := parseEventFilters(values)
+	if err != nil {
+		return err
+	}
+	res, err := buildEventsResponse(opts.EventsPath, filters)
+	if err != nil {
+		_ = encodeAdminJSON(out, res)
+		return err
+	}
+	return encodeAdminJSON(out, res)
+}
+
+func finalizeAdminEventPath(opts *adminCommonOptions) {
+	if strings.TrimSpace(os.Getenv("SECRETSBROKER_EVENTS_PATH")) != "" {
+		return
+	}
+	if opts.EventsPath == defaultEventsPath(defaultAuditPath()) {
+		opts.EventsPath = defaultEventsPath(opts.AuditPath)
+	}
+}
+
 func newAdminFlagSet(name string) (*flag.FlagSet, *adminCommonOptions) {
 	opts := &adminCommonOptions{}
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.StringVar(&opts.StorePath, "store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
 	fs.StringVar(&opts.AuditPath, "audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	fs.StringVar(&opts.EventsPath, "events", getenvDefault("SECRETSBROKER_EVENTS_PATH", defaultEventsPath(opts.AuditPath)), "operational events JSONL path")
 	fs.StringVar(&opts.MasterKey, "master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
 	fs.StringVar(&opts.MasterKeyFile, "master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
 	fs.StringVar(&opts.SourcesPath, "sources", getenvDefault("SECRETSBROKER_SOURCES_PATH", ""), "source adapter config path")
@@ -281,11 +351,13 @@ func newAdminFlagSet(name string) (*flag.FlagSet, *adminCommonOptions) {
 }
 
 func backendFromAdminOptions(opts *adminCommonOptions) (*localBackend, keyMaterial, error) {
+	finalizeAdminEventPath(opts)
 	material, err := loadKeyMaterial(opts.MasterKey, opts.MasterKeyFile)
 	if err != nil && !errors.Is(err, errLocked) {
 		return nil, material, err
 	}
 	backend := newLocalBackend(opts.StorePath, opts.AuditPath, material.Value)
+	backend.eventPath = opts.EventsPath
 	sources, sourceErr := loadSourceConfig(opts.SourcesPath)
 	if sourceErr != nil {
 		return nil, material, sourceErr

--- a/cmd/secretsbroker/events.go
+++ b/cmd/secretsbroker/events.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultOperationalEventLimit = 50
+	maxOperationalEventLimit     = 200
+)
+
+var errInvalidEventFilter = errors.New("invalid event filter")
+
+type operationalEvent struct {
+	ID         string    `json:"id"`
+	TS         time.Time `json:"ts"`
+	Family     string    `json:"family"`
+	Severity   string    `json:"severity"`
+	Operation  string    `json:"operation"`
+	ServiceID  string    `json:"serviceId,omitempty"`
+	ProviderID string    `json:"providerId,omitempty"`
+	SourceID   string    `json:"sourceId,omitempty"`
+	RefPrefix  string    `json:"refPrefix,omitempty"`
+	RefHash    string    `json:"refHash,omitempty"`
+	Outcome    string    `json:"outcome"`
+	RequestID  string    `json:"requestId,omitempty"`
+}
+
+type eventSafety struct {
+	MetadataOnly          bool `json:"metadataOnly"`
+	RawRefIncluded        bool `json:"rawRefIncluded"`
+	ValueMaterialIncluded bool `json:"valueMaterialIncluded"`
+}
+
+type eventsResponse struct {
+	ServiceID   string             `json:"serviceId"`
+	APIVersion  string             `json:"apiVersion"`
+	Outcome     string             `json:"outcome"`
+	GeneratedAt time.Time          `json:"generatedAt"`
+	Limit       int                `json:"limit"`
+	NextCursor  string             `json:"nextCursor,omitempty"`
+	Events      []operationalEvent `json:"events"`
+	Safety      eventSafety        `json:"safety"`
+}
+
+type eventFilters struct {
+	Since      *time.Time
+	Until      *time.Time
+	ServiceID  string
+	ProviderID string
+	Operation  string
+	Outcome    string
+	Severity   string
+	Family     string
+	RefPrefix  string
+	RefHash    string
+	Limit      int
+	Cursor     int
+}
+
+type eventFilterError struct {
+	Field   string
+	Message string
+}
+
+func (e eventFilterError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+func (b *localBackend) writeOperationalEvent(audit auditEvent) error {
+	if strings.TrimSpace(b.eventPath) == "" {
+		return nil
+	}
+	event := operationalEventFromAudit(audit)
+	events, err := loadOperationalEvents(b.eventPath)
+	if err != nil {
+		return err
+	}
+	events = append(events, event)
+	if len(events) > maxOperationalEventLimit {
+		events = events[len(events)-maxOperationalEventLimit:]
+	}
+	return saveOperationalEvents(b.eventPath, events)
+}
+
+func operationalEventFromAudit(audit auditEvent) operationalEvent {
+	audit = normalizeAuditEvent(audit)
+	event := operationalEvent{
+		TS:         audit.TS,
+		Family:     eventFamily(audit),
+		Severity:   eventSeverity(audit.Outcome),
+		Operation:  audit.Operation,
+		ServiceID:  audit.ServiceID,
+		ProviderID: audit.ProviderID,
+		SourceID:   audit.SourceID,
+		RefPrefix:  safeRefPrefix(audit.Ref),
+		RefHash:    audit.RefHash,
+		Outcome:    audit.Outcome,
+		RequestID:  audit.RequestID,
+	}
+	event.ID = strings.Join([]string{event.TS.Format(time.RFC3339Nano), event.Family, event.Operation, event.Outcome, event.RefHash}, ":")
+	return event
+}
+
+func eventFamily(audit auditEvent) string {
+	if audit.AuditStatus != "" && audit.AuditStatus != "audit_recorded" {
+		return "audit_unavailable"
+	}
+	switch {
+	case audit.Operation == "policy_decision":
+		return "policy_decision"
+	case audit.Operation == "source_lifecycle" && audit.Outcome == "ready":
+		return "source_recovered"
+	case audit.Operation == "source_lifecycle":
+		return "source_auth_required"
+	case strings.HasPrefix(audit.Operation, "provider_") && audit.Outcome == "ready":
+		return "provider_recovered"
+	case strings.HasPrefix(audit.Operation, "provider_"):
+		return "provider_unavailable"
+	case audit.Operation == "management_reveal":
+		return "management_reveal"
+	case strings.HasPrefix(audit.Operation, "management_"):
+		return "management_apply"
+	case strings.HasPrefix(audit.Operation, "key_"):
+		return "key_lifecycle"
+	case strings.HasPrefix(audit.Operation, "backup_"):
+		return "backup_restore"
+	default:
+		return "audit_recorded"
+	}
+}
+
+func eventSeverity(outcome string) string {
+	switch outcome {
+	case "ready", "allowed":
+		return "info"
+	case "degraded", "invalid_ref", "identity_expired":
+		return "error"
+	default:
+		return "warning"
+	}
+}
+
+func safeRefPrefix(ref string) string {
+	ref = strings.Trim(strings.TrimSpace(ref), "/")
+	if ref == "" {
+		return ""
+	}
+	parts := strings.Split(ref, "/")
+	if len(parts) <= 2 {
+		return strings.Join(parts, "/")
+	}
+	return strings.Join(parts[:2], "/")
+}
+
+func loadOperationalEvents(path string) ([]operationalEvent, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []operationalEvent{}, nil
+	}
+	if err != nil {
+		return nil, errBackendDegraded
+	}
+	defer file.Close()
+	events := []operationalEvent{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var event operationalEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			return nil, errBackendDegraded
+		}
+		events = append(events, normalizeOperationalEvent(event))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errBackendDegraded
+	}
+	return events, nil
+}
+
+func saveOperationalEvents(path string, events []operationalEvent) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	var builder strings.Builder
+	enc := json.NewEncoder(&builder)
+	for _, event := range events {
+		if err := enc.Encode(normalizeOperationalEvent(event)); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, []byte(builder.String()), 0o600)
+}
+
+func normalizeOperationalEvent(event operationalEvent) operationalEvent {
+	event.Family = scrubAuditField(event.Family)
+	event.Severity = scrubAuditField(event.Severity)
+	event.Operation = scrubAuditField(event.Operation)
+	event.ServiceID = scrubAuditField(event.ServiceID)
+	event.ProviderID = scrubAuditField(event.ProviderID)
+	event.SourceID = scrubAuditField(event.SourceID)
+	event.RefPrefix = scrubAuditField(event.RefPrefix)
+	event.RefHash = scrubAuditField(event.RefHash)
+	event.Outcome = scrubAuditField(event.Outcome)
+	event.RequestID = scrubAuditField(event.RequestID)
+	event.ID = scrubAuditField(event.ID)
+	if event.Family == "" {
+		event.Family = "audit_recorded"
+	}
+	if event.Severity == "" {
+		event.Severity = eventSeverity(event.Outcome)
+	}
+	if event.Outcome == "" {
+		event.Outcome = "degraded"
+	}
+	return event
+}
+
+func parseEventFilters(values url.Values) (eventFilters, error) {
+	filters := eventFilters{Limit: defaultOperationalEventLimit}
+	var err error
+	if filters.Since, err = parseEventTime(values.Get("since"), "since"); err != nil {
+		return filters, err
+	}
+	if filters.Until, err = parseEventTime(values.Get("until"), "until"); err != nil {
+		return filters, err
+	}
+	if filters.Since != nil && filters.Until != nil && filters.Since.After(*filters.Until) {
+		return filters, eventFilterError{Field: "since", Message: "must be before until"}
+	}
+	filters.ServiceID = scrubAuditField(values.Get("serviceId"))
+	filters.ProviderID = scrubAuditField(values.Get("providerId"))
+	filters.Operation = scrubAuditField(values.Get("operation"))
+	filters.Outcome = scrubAuditField(values.Get("outcome"))
+	filters.Severity = scrubAuditField(values.Get("severity"))
+	filters.Family = scrubAuditField(values.Get("family"))
+	filters.RefPrefix = scrubAuditField(values.Get("refPrefix"))
+	filters.RefHash = scrubAuditField(values.Get("refHash"))
+	if raw := strings.TrimSpace(values.Get("limit")); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit < 1 || limit > maxOperationalEventLimit {
+			return filters, eventFilterError{Field: "limit", Message: "must be an integer from 1 to 200"}
+		}
+		filters.Limit = limit
+	}
+	if raw := strings.TrimSpace(values.Get("cursor")); raw != "" {
+		cursor, err := strconv.Atoi(raw)
+		if err != nil || cursor < 0 {
+			return filters, eventFilterError{Field: "cursor", Message: "must be a non-negative integer"}
+		}
+		filters.Cursor = cursor
+	}
+	return filters, nil
+}
+
+func parseEventTime(value, field string) (*time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, eventFilterError{Field: field, Message: "must be RFC3339"}
+	}
+	parsed = parsed.UTC()
+	return &parsed, nil
+}
+
+func buildEventsResponse(path string, filters eventFilters) (eventsResponse, error) {
+	res := eventsResponse{
+		ServiceID:   serviceID,
+		APIVersion:  apiVersion,
+		Outcome:     "ready",
+		GeneratedAt: time.Now().UTC(),
+		Limit:       filters.Limit,
+		Events:      []operationalEvent{},
+		Safety:      eventSafety{MetadataOnly: true, RawRefIncluded: false, ValueMaterialIncluded: false},
+	}
+	events, err := loadOperationalEvents(path)
+	if err != nil {
+		res.Outcome = "degraded"
+		return res, err
+	}
+	filtered := make([]operationalEvent, 0, len(events))
+	for _, event := range events {
+		if eventMatchesFilters(event, filters) {
+			filtered = append(filtered, event)
+		}
+	}
+	if filters.Cursor > len(filtered) {
+		return res, eventFilterError{Field: "cursor", Message: "is beyond the filtered event set"}
+	}
+	end := filters.Cursor + filters.Limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	res.Events = append(res.Events, filtered[filters.Cursor:end]...)
+	if end < len(filtered) {
+		res.NextCursor = strconv.Itoa(end)
+	}
+	return res, nil
+}
+
+func eventMatchesFilters(event operationalEvent, filters eventFilters) bool {
+	if filters.Since != nil && event.TS.Before(*filters.Since) {
+		return false
+	}
+	if filters.Until != nil && event.TS.After(*filters.Until) {
+		return false
+	}
+	if filters.ServiceID != "" && event.ServiceID != filters.ServiceID {
+		return false
+	}
+	if filters.ProviderID != "" && event.ProviderID != filters.ProviderID {
+		return false
+	}
+	if filters.Operation != "" && event.Operation != filters.Operation {
+		return false
+	}
+	if filters.Outcome != "" && event.Outcome != filters.Outcome {
+		return false
+	}
+	if filters.Severity != "" && event.Severity != filters.Severity {
+		return false
+	}
+	if filters.Family != "" && event.Family != filters.Family {
+		return false
+	}
+	if filters.RefHash != "" && event.RefHash != filters.RefHash {
+		return false
+	}
+	if filters.RefPrefix != "" && !strings.HasPrefix(event.RefPrefix, filters.RefPrefix) {
+		return false
+	}
+	return true
+}
+
+func registerEventsHandlers(mux *http.ServeMux, backend *localBackend) {
+	mux.HandleFunc("/v1/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/events.", "invalid_ref", "")
+			return
+		}
+		filters, err := parseEventFilters(r.URL.Query())
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_event_filter", err.Error(), "invalid_ref", "adjust_event_filter")
+			return
+		}
+		res, err := buildEventsResponse(backend.eventPath, filters)
+		if err != nil {
+			writeJSON(w, http.StatusServiceUnavailable, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}

--- a/cmd/secretsbroker/events_test.go
+++ b/cmd/secretsbroker/events_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const operationalEventSecretValue = "fixture-operational-event-secret-value"
+
+func TestOperationalEventsRetainFilterAndStayMetadataOnly(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: operationalEventSecretValue}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < maxOperationalEventLimit+5; i++ {
+		backend.now = func() time.Time {
+			return time.Date(2026, 5, 7, 0, 0, i, 0, time.UTC)
+		}
+		_ = backend.writeAuditEvent(auditEvent{
+			TS:        backend.now(),
+			Operation: "policy_decision",
+			ServiceID: "api-" + strconv.Itoa(i),
+			Ref:       ref,
+			Outcome:   "denied",
+			RequestID: "req-" + strconv.Itoa(i),
+		})
+	}
+
+	res, err := buildEventsResponse(backend.eventPath, eventFilters{Limit: maxOperationalEventLimit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Events) != maxOperationalEventLimit {
+		t.Fatalf("event count = %d, want %d", len(res.Events), maxOperationalEventLimit)
+	}
+	if res.Events[0].RequestID != "req-5" {
+		t.Fatalf("retention did not drop oldest events first: %#v", res.Events[0])
+	}
+	filtered, err := buildEventsResponse(backend.eventPath, eventFilters{Limit: 10, ServiceID: "api-204", Family: "policy_decision", RefPrefix: "services/api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Events) != 1 || filtered.Events[0].Outcome != "denied" || filtered.Events[0].Severity != "warning" {
+		t.Fatalf("filtered events = %#v", filtered.Events)
+	}
+	encoded, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, operationalEventSecretValue, "test-master-key", ref)
+	if strings.Contains(string(encoded), ref) {
+		t.Fatalf("events exposed raw ref: %s", string(encoded))
+	}
+	if !res.Safety.MetadataOnly || res.Safety.RawRefIncluded || res.Safety.ValueMaterialIncluded {
+		t.Fatalf("unsafe event safety flags: %#v", res.Safety)
+	}
+}
+
+func TestOperationalEventsEndpointPaginationAndInvalidFilters(t *testing.T) {
+	backend := testBackend(t)
+	for i := 0; i < 3; i++ {
+		_ = backend.writeAuditEvent(auditEvent{TS: backend.now().Add(time.Duration(i) * time.Second), Operation: "provider_status", ProviderID: "vault", Outcome: "degraded"})
+	}
+	server := httptest.NewServer(newHandler(runtimeState{}, backend, localAPISecurity{}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/v1/events?family=provider_unavailable&limit=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("events status = %d", resp.StatusCode)
+	}
+	var page eventsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 2 || page.NextCursor != "2" {
+		t.Fatalf("first page = %#v", page)
+	}
+
+	bad, err := http.Get(server.URL + "/v1/events?limit=0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bad.Body.Close()
+	if bad.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad filter status = %d", bad.StatusCode)
+	}
+	var envelope ErrorEnvelope
+	if err := json.NewDecoder(bad.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Error.Code != "invalid_event_filter" {
+		t.Fatalf("bad filter error = %#v", envelope.Error)
+	}
+}
+
+func TestAdminEventsCLIReadsMetadataOnlyEvents(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: operationalEventSecretValue}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := executeAdmin([]string{"events", "list", "--events", backend.eventPath, "--family", "audit_recorded", "--limit", "1"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, out.Bytes(), operationalEventSecretValue, "test-master-key", ref)
+	if !strings.Contains(out.String(), "events") || !strings.Contains(out.String(), "audit_recorded") {
+		t.Fatalf("events CLI output missing expected metadata: %s", out.String())
+	}
+}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -37,6 +37,7 @@ var (
 type localBackend struct {
 	storePath string
 	auditPath string
+	eventPath string
 	masterKey string
 	sources   sourceConfigFile
 	now       func() time.Time
@@ -167,11 +168,25 @@ type auditEvent struct {
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
-	return &localBackend{storePath: storePath, auditPath: auditPath, masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
+	return &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
 }
 
 func defaultStorePath() string { return filepath.Join("data", "secretsbroker-store.json") }
 func defaultAuditPath() string { return filepath.Join("data", "secretsbroker-audit.jsonl") }
+func defaultEventsPath(auditPath string) string {
+	auditPath = strings.TrimSpace(auditPath)
+	if auditPath == "" {
+		return ""
+	}
+	if filepath.Clean(auditPath) == filepath.Clean(defaultAuditPath()) {
+		return filepath.Join("data", "secretsbroker-events.jsonl")
+	}
+	ext := filepath.Ext(auditPath)
+	if ext == "" {
+		return auditPath + "-events"
+	}
+	return strings.TrimSuffix(auditPath, ext) + "-events" + ext
+}
 
 func (b *localBackend) locked() bool { return strings.TrimSpace(b.masterKey) == "" }
 
@@ -484,7 +499,10 @@ func (b *localBackend) writeAuditEvent(event auditEvent) error {
 		return err
 	}
 	defer file.Close()
-	return json.NewEncoder(file).Encode(event)
+	if err := json.NewEncoder(file).Encode(event); err != nil {
+		return err
+	}
+	return b.writeOperationalEvent(event)
 }
 
 func normalizeAuditEvent(event auditEvent) auditEvent {

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -226,6 +226,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /v1/providers/capabilities",
 			"GET /v1/providers/config/status",
 			"GET /v1/telemetry",
+			"GET /v1/events",
 			"POST /v1/providers/config/validate|apply",
 			"POST /v1/providers/migration/dry-run|apply",
 			"GET /v1/management/secrets",
@@ -236,7 +237,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
-			"CLI secretsbroker admin status|secrets|providers|migration|audit",
+			"CLI secretsbroker admin status|secrets|providers|migration|audit|events",
 		},
 		Features: []string{
 			"liveness",
@@ -252,6 +253,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"provider-config-status",
 			"provider-config-validation",
 			"redacted-telemetry",
+			"bounded-operational-events",
 			"provider-migration-dry-run-apply",
 			"secrets-management-metadata-search",
 			"secrets-management-value-search-metadata-only",
@@ -293,6 +295,7 @@ func serve(args []string) error {
 	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
 	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
 	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	eventsPath := fs.String("events", getenvDefault("SECRETSBROKER_EVENTS_PATH", defaultEventsPath(*auditPath)), "operational events JSONL path")
 	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "local development master key; empty means locked")
 	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
 	apiToken := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "local API token for secret-bearing endpoints")
@@ -304,6 +307,16 @@ func serve(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	eventsPathValue := *eventsPath
+	eventsPathExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "events" {
+			eventsPathExplicit = true
+		}
+	})
+	if !eventsPathExplicit && strings.TrimSpace(os.Getenv("SECRETSBROKER_EVENTS_PATH")) == "" {
+		eventsPathValue = defaultEventsPath(*auditPath)
+	}
 
 	refs := []string(affectedRefs)
 	services := []string(affectedServices)
@@ -313,6 +326,7 @@ func serve(args []string) error {
 		return err
 	}
 	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	backend.eventPath = eventsPathValue
 	sources, err := loadSourceConfig(*sourcesPath)
 	if err != nil {
 		return err
@@ -369,6 +383,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)
+		registerEventsHandlers(mux, backend)
 	}
 	return mux
 }

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -150,6 +150,14 @@ Filtering requirements:
 - Invalid filters fail safely with typed errors.
 - Value search and credential search are not event-filter features.
 
+Implemented first slice:
+
+- Audit metadata now feeds a bounded local operational event store with deterministic retention of the most recent 200 events.
+- GET /v1/events returns metadata-only events with filters for since, until, serviceId, providerId, operation, outcome, severity, family, refPrefix, and refHash.
+- secretsbroker admin events list exposes the same bounded event reader for headless administration.
+- Event responses expose safe ref prefixes and refHash; they do not include raw refs, raw values, provider credentials, tokens, private keys, cookies, passwords, environment values, provider response bodies, or credential search results.
+- Event filters use bounded page sizes with cursor pagination, and invalid filters return typed invalid_event_filter errors.
+
 ## Lockout model
 
 Lockout scopes should be narrow enough to avoid turning one bad caller into a whole-broker outage.


### PR DESCRIPTION
## Issue
Closes #65

## Summary
- Added a bounded operational event store fed from normalized audit metadata.
- Added GET /v1/events with bounded filters and cursor pagination.
- Added secretsbroker admin events list for the same metadata-only event view.
- Documented the first implemented event/filtering slice in the operational-controls baseline.

## Scope
- In scope: local metadata-only event persistence, filtering, pagination, endpoint, CLI, and tests.
- Out of scope: streaming webhooks, external event buses, lockout behavior, and provider-specific event sinks.

## Spec / contract / fixture impact
- Updated: docs/operational-controls-baseline.md
- Contract added: event responses expose safe ref prefixes and refHash, not raw refs or secret material.

## Service Lasso invariant impact
- Invariant: @secretsbroker remains local-first and Service Lasso-facing.
- Preservation proof: events are local JSONL metadata derived from existing audit normalization; no Vault/OpenBao dependency or raw secret-value payload is introduced.

## Validation
- PASS go test ./cmd/secretsbroker -run 'TestOperationalEvents|TestAdminEvents|TestTelemetry'
- PASS pwsh -NoLogo -NoProfile -File .\scripts\test.ps1
- PASS go test ./...
- PASS git diff --check

## Approval trail
- Required: no known special approval for this implementation slice.
- Evidence: issue #65 is Project #1 Ready target-repo work.

## Cleanup
- Branch contains commit 1e9d5a2bc8e339cd119078f20909d1083908c26f.
- Local checkout will stay on the issue branch until PR state is recorded, with only .work-agent/ evidence logs untracked.