### PR TITLE
ISS-66 add scoped local API lockout

### DIFF
--- a/cmd/secretsbroker/lockout.go
+++ b/cmd/secretsbroker/lockout.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	localAPILockoutThreshold = 3
+	localAPILockoutCooldown  = 5 * time.Minute
+)
+
+type lockoutStore struct {
+	mu        sync.Mutex
+	entries   map[string]lockoutEntry
+	now       func() time.Time
+	threshold int
+	cooldown  time.Duration
+}
+
+type lockoutEntry struct {
+	Failures    int
+	ActiveUntil time.Time
+	LastFailure time.Time
+}
+
+type lockoutDecision struct {
+	Active            bool
+	Scope             string
+	RetryAfterSeconds int
+}
+
+func newLockoutStore(now func() time.Time) *lockoutStore {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &lockoutStore{
+		entries:   map[string]lockoutEntry{},
+		now:       now,
+		threshold: localAPILockoutThreshold,
+		cooldown:  localAPILockoutCooldown,
+	}
+}
+
+func localAPILockoutScope(r *http.Request) string {
+	host := strings.TrimSpace(r.RemoteAddr)
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	if host == "" {
+		host = "local"
+	}
+	return "local_api:" + host
+}
+
+func (s *lockoutStore) active(scope string) lockoutDecision {
+	if s == nil {
+		return lockoutDecision{Scope: scope}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.activeLocked(scope, s.now())
+}
+
+func (s *lockoutStore) recordFailure(scope string) (lockoutDecision, bool) {
+	if s == nil {
+		return lockoutDecision{Scope: scope}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	if decision := s.activeLocked(scope, now); decision.Active {
+		return decision, false
+	}
+
+	entry := s.entries[scope]
+	if !entry.ActiveUntil.IsZero() && !entry.ActiveUntil.After(now) {
+		entry = lockoutEntry{}
+	}
+	entry.Failures++
+	entry.LastFailure = now
+	started := false
+	if entry.Failures >= s.threshold {
+		entry.Failures = s.threshold
+		entry.ActiveUntil = now.Add(s.cooldown)
+		started = true
+	}
+	s.entries[scope] = entry
+	return s.decision(scope, entry, now), started
+}
+
+func (s *lockoutStore) recordSuccess(scope string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, scope)
+}
+
+func (s *lockoutStore) activeLocked(scope string, now time.Time) lockoutDecision {
+	entry, ok := s.entries[scope]
+	if !ok {
+		return lockoutDecision{Scope: scope}
+	}
+	if entry.ActiveUntil.After(now) {
+		return s.decision(scope, entry, now)
+	}
+	if !entry.ActiveUntil.IsZero() {
+		delete(s.entries, scope)
+	}
+	return lockoutDecision{Scope: scope}
+}
+
+func (s *lockoutStore) decision(scope string, entry lockoutEntry, now time.Time) lockoutDecision {
+	decision := lockoutDecision{Scope: scope}
+	if entry.ActiveUntil.After(now) {
+		decision.Active = true
+		decision.RetryAfterSeconds = int(time.Until(entry.ActiveUntil).Seconds())
+		if s.now != nil {
+			decision.RetryAfterSeconds = int(entry.ActiveUntil.Sub(now).Seconds())
+		}
+		if decision.RetryAfterSeconds < 1 {
+			decision.RetryAfterSeconds = 1
+		}
+	}
+	return decision
+}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -42,6 +42,7 @@ var typedOutcomes = []string{
 	"invalid_ref",
 	"source_unavailable",
 	"identity_expired",
+	"lockout_active",
 	"disabled",
 }
 
@@ -92,13 +93,16 @@ type ErrorEnvelope struct {
 }
 
 type APIError struct {
-	Code             string   `json:"code"`
-	Message          string   `json:"message"`
-	Outcome          string   `json:"outcome"`
-	RequestID        string   `json:"requestId,omitempty"`
-	NextAction       string   `json:"nextAction,omitempty"`
-	AffectedRefs     []string `json:"affectedRefs"`
-	AffectedServices []string `json:"affectedServices"`
+	Code              string   `json:"code"`
+	Message           string   `json:"message"`
+	Outcome           string   `json:"outcome"`
+	RequestID         string   `json:"requestId,omitempty"`
+	NextAction        string   `json:"nextAction,omitempty"`
+	AffectedRefs      []string `json:"affectedRefs"`
+	AffectedServices  []string `json:"affectedServices"`
+	LockoutActive     bool     `json:"lockoutActive,omitempty"`
+	LockoutScope      string   `json:"lockoutScope,omitempty"`
+	RetryAfterSeconds int      `json:"retryAfterSeconds,omitempty"`
 }
 
 func main() {
@@ -254,6 +258,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"provider-config-validation",
 			"redacted-telemetry",
 			"bounded-operational-events",
+			"scoped-local-api-lockout",
 			"provider-migration-dry-run-apply",
 			"secrets-management-metadata-search",
 			"secrets-management-value-search-metadata-only",
@@ -378,6 +383,12 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		writeJSON(w, http.StatusOK, defaultCapabilities())
 	})
 	if backend != nil {
+		if security.lockouts == nil {
+			security.lockouts = newLockoutStore(nil)
+		}
+		if security.audit == nil {
+			security.audit = backend.audit
+		}
 		registerLocalStoreHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)

--- a/cmd/secretsbroker/session.go
+++ b/cmd/secretsbroker/session.go
@@ -83,7 +83,11 @@ func generateSessionToken() (string, error) {
 	return "sbk_" + base64.RawURLEncoding.EncodeToString(bytes), nil
 }
 
-type localAPISecurity struct{ token string }
+type localAPISecurity struct {
+	token    string
+	lockouts *lockoutStore
+	audit    func(operation, ref, outcome, requestServiceID, requestID string) error
+}
 
 func (s localAPISecurity) require(w http.ResponseWriter, r *http.Request) bool {
 	expected := strings.TrimSpace(s.token)
@@ -91,15 +95,49 @@ func (s localAPISecurity) require(w http.ResponseWriter, r *http.Request) bool {
 		writeAPIError(w, http.StatusServiceUnavailable, "security_not_configured", "Secret-bearing endpoints require SECRETSBROKER_API_TOKEN or --api-token.", "policy_denied", "configure_api_token")
 		return false
 	}
+	scope := localAPILockoutScope(r)
+	if decision := s.lockouts.active(scope); decision.Active {
+		s.auditOutcome("local_api_lockout", "lockout_active")
+		writeLockoutAPIError(w, decision)
+		return false
+	}
 	got := bearerToken(r.Header.Get("Authorization"))
 	if got == "" {
 		got = strings.TrimSpace(r.Header.Get("X-SecretsBroker-Token"))
 	}
 	if got == "" || !constantTimeTokenEqual(got, expected) {
+		s.auditOutcome("local_api_auth", "unauthorized")
+		decision, started := s.lockouts.recordFailure(scope)
+		if started {
+			s.auditOutcome("local_api_lockout", "lockout_active")
+			writeLockoutAPIError(w, decision)
+			return false
+		}
 		writeAPIError(w, http.StatusUnauthorized, "unauthorized", "A valid local API token is required.", "policy_denied", "authenticate_local_session")
 		return false
 	}
+	s.lockouts.recordSuccess(scope)
 	return true
+}
+
+func (s localAPISecurity) auditOutcome(operation, outcome string) {
+	if s.audit != nil {
+		_ = s.audit(operation, "", outcome, "@operator", "")
+	}
+}
+
+func writeLockoutAPIError(w http.ResponseWriter, decision lockoutDecision) {
+	writeJSON(w, http.StatusLocked, ErrorEnvelope{Error: APIError{
+		Code:              "lockout_active",
+		Message:           "Local API authentication is temporarily locked for this scope.",
+		Outcome:           "policy_denied",
+		NextAction:        "wait_or_clear_lockout",
+		AffectedRefs:      []string{},
+		AffectedServices:  []string{},
+		LockoutActive:     true,
+		LockoutScope:      decision.Scope,
+		RetryAfterSeconds: decision.RetryAfterSeconds,
+	}})
 }
 
 func constantTimeTokenEqual(got, expected string) bool {

--- a/cmd/secretsbroker/session_test.go
+++ b/cmd/secretsbroker/session_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSessionStatusAndGenerate(t *testing.T) {
@@ -66,5 +70,80 @@ func TestLocalAPISecurityAcceptsBearerAndRejectsWrongToken(t *testing.T) {
 	goodRes := httptest.NewRecorder()
 	if !sec.require(goodRes, goodReq) {
 		t.Fatalf("good bearer token should pass")
+	}
+}
+
+func TestLocalAPISecurityLocksOutRepeatedInvalidTokens(t *testing.T) {
+	dir := t.TempDir()
+	auditPath := filepath.Join(dir, "audit.jsonl")
+	backend := newLocalBackend(filepath.Join(dir, "store.json"), auditPath, "test-master-key")
+	now := time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)
+	lockouts := newLockoutStore(func() time.Time { return now })
+	sec := localAPISecurity{token: "secret-token", lockouts: lockouts, audit: backend.audit}
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+		req.RemoteAddr = "127.0.0.1:5000"
+		req.Header.Set("Authorization", "Bearer wrong-token")
+		res := httptest.NewRecorder()
+		if sec.require(res, req) {
+			t.Fatalf("invalid token attempt %d should reject", i)
+		}
+		if i < localAPILockoutThreshold && res.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d status = %d", i, res.Code)
+		}
+		if i == localAPILockoutThreshold {
+			if res.Code != http.StatusLocked {
+				t.Fatalf("lockout status = %d", res.Code)
+			}
+			var body ErrorEnvelope
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.Error.Code != "lockout_active" || !body.Error.LockoutActive || body.Error.LockoutScope != "local_api:127.0.0.1" {
+				t.Fatalf("lockout body = %#v", body.Error)
+			}
+			if body.Error.RetryAfterSeconds <= 0 {
+				t.Fatalf("retryAfterSeconds = %d", body.Error.RetryAfterSeconds)
+			}
+			encoded := res.Body.String()
+			if strings.Contains(encoded, "wrong-token") || strings.Contains(encoded, "secret-token") {
+				t.Fatalf("lockout response leaked token material: %s", encoded)
+			}
+		}
+	}
+
+	auditBytes, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditText := string(auditBytes)
+	for _, want := range []string{"local_api_auth", "unauthorized", "local_api_lockout", "lockout_active"} {
+		if !strings.Contains(auditText, want) {
+			t.Fatalf("audit missing %q: %s", want, auditText)
+		}
+	}
+	if strings.Contains(auditText, "wrong-token") || strings.Contains(auditText, "secret-token") {
+		t.Fatalf("audit leaked token material: %s", auditText)
+	}
+
+	lockedReq := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+	lockedReq.RemoteAddr = "127.0.0.1:5000"
+	lockedReq.Header.Set("Authorization", "Bearer secret-token")
+	lockedRes := httptest.NewRecorder()
+	if sec.require(lockedRes, lockedReq) {
+		t.Fatalf("active lockout should reject even a valid token until cooldown expires")
+	}
+	if lockedRes.Code != http.StatusLocked {
+		t.Fatalf("active lockout status = %d", lockedRes.Code)
+	}
+
+	now = now.Add(localAPILockoutCooldown + time.Second)
+	goodReq := httptest.NewRequest(http.MethodPost, "/v1/resolve", nil)
+	goodReq.RemoteAddr = "127.0.0.1:5000"
+	goodReq.Header.Set("Authorization", "Bearer secret-token")
+	goodRes := httptest.NewRecorder()
+	if !sec.require(goodRes, goodReq) {
+		t.Fatalf("valid token should pass after cooldown")
 	}
 }

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -55,6 +55,8 @@ If no token is configured, secret-bearing endpoints return `503 security_not_con
 
 Token checks trim whitespace, hash both presented and expected tokens, and then compare fixed-size digests in constant time. This avoids length-dependent token comparison behavior while keeping responses generic.
 
+Repeated invalid local API tokens are tracked by local API client scope. Three invalid attempts for the same scope start a five-minute cooldown for secret-bearing endpoints. The lockout response includes safe metadata only and does not echo the presented token or expected token.
+
 Secret-bearing endpoints cap request bodies at 1 MiB before JSON decode. Oversized requests return `413 request_too_large` with a safe fixed message; request content and bearer tokens are not echoed.
 
 ## CLI helpers
@@ -84,6 +86,24 @@ Missing/invalid token:
     "nextAction": "authenticate_local_session",
     "affectedRefs": [],
     "affectedServices": []
+  }
+}
+```
+
+Active lockout:
+
+```json
+{
+  "error": {
+    "code": "lockout_active",
+    "message": "Local API authentication is temporarily locked for this scope.",
+    "outcome": "policy_denied",
+    "nextAction": "wait_or_clear_lockout",
+    "affectedRefs": [],
+    "affectedServices": [],
+    "lockoutActive": true,
+    "lockoutScope": "local_api:127.0.0.1",
+    "retryAfterSeconds": 300
   }
 }
 ```
@@ -133,6 +153,7 @@ Planned session model:
 - per-service/ref policy checks before resolve/write-back
 - lease/renew/revoke for runtime identities where applicable
 - audit events for allow/deny/resolve/write-back without plaintext values
+- durable audited lockout clear workflow for management clients
 
 ## Non-goals for this slice
 

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -184,6 +184,15 @@ Baseline behavior:
 - emit audit and event records for lockout start and clear
 - provide an admin clear command that requires local API auth and audit reason
 
+Implemented first slice:
+
+- Secret-bearing local API token failures are tracked in memory by narrow local API client scope.
+- Three invalid token attempts for the same local API scope start a five-minute cooldown.
+- Active lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
+- Lockout and auth-failure audit/events use operation/outcome metadata only and do not persist presented tokens, expected tokens, request bodies, or secret values.
+- Safe read-only status, readiness, capabilities, telemetry, and event endpoints remain available during local API lockout.
+- Provider/source, service-identity, management apply/reveal denial, and audited admin-clear persistence are follow-up slices under #66.
+
 ## API/backend mapping
 
 | Control | API/backend requirement |


### PR DESCRIPTION
## Issue
Refs #66

## Summary
- Add scoped in-memory local API lockout for repeated invalid local API token attempts.
- Return metadata-only lockout errors with scope and retry timing, without echoing presented or expected token material.
- Record auth failure and lockout audit/event metadata and document the first #66 lockout slice.

## Scope
- In scope: local API token failure lockout for secret-bearing endpoints, capabilities/error contract, docs, and tests.
- Out of scope: provider/source credential lockouts, service-identity lockouts, management apply/reveal denial lockouts, durable lockout persistence, and audited admin-clear workflow.

## Spec / contract / fixture impact
- Updated: docs/local-api-security.md and docs/operational-controls-baseline.md.
- API error contract now includes optional lockout metadata fields.

## Service Lasso invariant impact
- Invariant: keep secrets and credentials out of logs, diagnostics, issue comments, PR bodies, and audit payload values.
- Preservation proof: tests assert lockout responses and audit records do not include presented or expected token material.

## Validation
- PASS `go test ./cmd/secretsbroker`
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1`
- PASS `git diff --check`
- PASS GitHub validate-template checks on macOS, Linux, and Windows
- Evidence logs: `.work-agent/logs/issue-66-2026-05-22T13-29-18-548Z/`

## Approval trail
- Required: no
- Evidence: target-repo issue #66 is Project #1 Ready and labeled for agent execution.

## Cleanup
- Branch: `issue-66-scoped-lockout` (remote deleted after merge; local branch deleted)
- Local checkout returned to `main`; untracked `.work-agent/` evidence logs remain local only.
