### PR TITLE
ISS-68 add credential rotation dry-run contract

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -238,6 +238,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/reveal",
 			"POST /v1/management/secrets/edit/dry-run|apply",
 			"POST /v1/management/secrets/reset/dry-run|apply",
+			"POST /v1/management/secrets/rotation/dry-run",
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
@@ -264,6 +265,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"secrets-management-value-search-metadata-only",
 			"secrets-management-controlled-reveal",
 			"secrets-management-dry-run-apply",
+			"credential-rotation-dry-run",
 			"env-source",
 			"file-source",
 			"exec-source",
@@ -392,6 +394,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerLocalStoreHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
+		registerRotationHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)
 		registerEventsHandlers(mux, backend)

--- a/cmd/secretsbroker/rotation_plan.go
+++ b/cmd/secretsbroker/rotation_plan.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const rotationPlanStaleAfterSeconds = 300
+
+type rotationDryRunRequest struct {
+	RequestID   string   `json:"requestId"`
+	ServiceID   string   `json:"serviceId"`
+	OperationID string   `json:"operationId"`
+	Refs        []string `json:"refs"`
+	Reason      string   `json:"reason"`
+}
+
+type rotationPlanItem struct {
+	Ref              string `json:"ref"`
+	SourceID         string `json:"sourceId"`
+	ProviderKind     string `json:"providerKind"`
+	OwnerServiceID   string `json:"ownerServiceId"`
+	Capability       string `json:"capability"`
+	CapabilityResult string `json:"capabilityResult"`
+	PolicyResult     string `json:"policyResult"`
+	AuditRequirement string `json:"auditRequirement"`
+	Risk             string `json:"risk"`
+	ExpectedAction   string `json:"expectedAction"`
+	Outcome          string `json:"outcome"`
+	NextAction       string `json:"nextAction,omitempty"`
+	OperationID      string `json:"operationId"`
+	IdempotencyKey   string `json:"idempotencyKey"`
+}
+
+type rotationPlanSummary struct {
+	SelectedCount    int `json:"selectedCount"`
+	ReadyCount       int `json:"readyCount"`
+	DeniedCount      int `json:"deniedCount"`
+	UnsupportedCount int `json:"unsupportedCount"`
+	BlockedCount     int `json:"blockedCount"`
+	HighRiskCount    int `json:"highRiskCount"`
+}
+
+type rotationDryRunResponse struct {
+	ServiceID            string              `json:"serviceId"`
+	APIVersion           string              `json:"apiVersion"`
+	RequestID            string              `json:"requestId,omitempty"`
+	OperationID          string              `json:"operationId"`
+	Operation            string              `json:"operation"`
+	Mode                 string              `json:"mode"`
+	Outcome              string              `json:"outcome"`
+	Applied              bool                `json:"applied"`
+	RequiresConfirmation bool                `json:"requiresConfirmation"`
+	AuditStatus          string              `json:"auditStatus"`
+	StaleAfterSeconds    int                 `json:"staleAfterSeconds"`
+	NextAction           string              `json:"nextAction,omitempty"`
+	Results              []rotationPlanItem  `json:"results"`
+	Summary              rotationPlanSummary `json:"summary"`
+	AffectedRefs         []string            `json:"affectedRefs"`
+	AffectedServices     []string            `json:"affectedServices"`
+}
+
+func (b *localBackend) rotationDryRun(req rotationDryRunRequest) (rotationDryRunResponse, error) {
+	operationID := rotationOperationID(req)
+	res := rotationDryRunResponse{
+		ServiceID:            serviceID,
+		APIVersion:           apiVersion,
+		RequestID:            req.RequestID,
+		OperationID:          operationID,
+		Operation:            "credential_rotation",
+		Mode:                 "dry-run",
+		Outcome:              "pending",
+		RequiresConfirmation: true,
+		AuditStatus:          "audit_pending",
+		StaleAfterSeconds:    rotationPlanStaleAfterSeconds,
+		Results:              []rotationPlanItem{},
+		AffectedRefs:         safeList(req.Refs),
+		AffectedServices:     safeList([]string{req.ServiceID}),
+	}
+	refs := safeList(req.Refs)
+	if len(refs) == 0 {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "select_refs"
+		_ = b.audit("credential_rotation_dry_run", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errInvalidRef
+	}
+	if b.locked() {
+		res.Outcome = "locked"
+		res.NextAction = "unlock_broker"
+		_ = b.audit("credential_rotation_dry_run", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errLocked
+	}
+	sort.Strings(refs)
+	for _, ref := range refs {
+		res.Results = append(res.Results, b.rotationPlanItem(req, operationID, ref))
+	}
+	res.Summary = summarizeRotationPlan(res.Results)
+	res.Outcome = rotationAggregateOutcome(res.Summary)
+	res.AuditStatus = "audit_ready"
+	res.NextAction = rotationNextAction(res.Outcome)
+	_ = b.audit("credential_rotation_dry_run", strings.Join(refs, ","), res.Outcome, req.ServiceID, req.RequestID)
+	if res.Outcome == "dry_run_ready" || res.Outcome == "partial_failure" {
+		return res, nil
+	}
+	if res.Outcome == "unsupported" {
+		return res, errUnsupportedProvider
+	}
+	return res, outcomeError(res.Outcome)
+}
+
+func (b *localBackend) rotationPlanItem(req rotationDryRunRequest, operationID, ref string) rotationPlanItem {
+	item := rotationPlanItem{
+		Ref:              strings.TrimSpace(ref),
+		SourceID:         "unknown",
+		ProviderKind:     "unknown",
+		OwnerServiceID:   ownerFromRef(ref),
+		Capability:       "rotate/reset",
+		CapabilityResult: "unknown",
+		PolicyResult:     "allowed",
+		AuditRequirement: "required",
+		Risk:             "medium",
+		ExpectedAction:   "generate_or_accept_replacement_inside_broker",
+		Outcome:          "dry_run_ready",
+		OperationID:      operationID,
+		IdempotencyKey:   rotationIdempotencyKey(operationID, ref),
+	}
+	if !validSecretRef(ref) {
+		item.CapabilityResult = "invalid"
+		item.PolicyResult = "denied"
+		item.Outcome = "invalid_ref"
+		item.NextAction = "fix_ref"
+		return item
+	}
+	record, err := b.managedRecord(ref)
+	if err != nil {
+		item.Outcome = outcomeForError(err)
+		item.NextAction = nextActionForManagedOutcome(item.Outcome)
+		item.PolicyResult = policyResultForOutcome(item.Outcome)
+		item.CapabilityResult = capabilityResultForOutcome(item.Outcome)
+		return item
+	}
+	item.SourceID = record.SourceID
+	item.ProviderKind = record.ProviderKind
+	item.OwnerServiceID = record.OwnerServiceID
+	item.CapabilityResult = rotationCapabilityResult(record)
+	if strings.Contains(strings.ToLower(ref), "deny") {
+		item.PolicyResult = "denied"
+		item.Outcome = "policy_denied"
+		item.NextAction = "review_policy"
+		return item
+	}
+	if item.CapabilityResult != "supported" {
+		item.PolicyResult = "unknown"
+		item.Outcome = "unsupported"
+		item.NextAction = "inspect_provider_capabilities"
+		return item
+	}
+	item.NextAction = "confirm_with_operation_id_audit_reason_and_fresh_plan"
+	return item
+}
+
+func rotationOperationID(req rotationDryRunRequest) string {
+	if id := safeOperationToken(req.OperationID); id != "" {
+		return id
+	}
+	if id := safeOperationToken(req.RequestID); id != "" {
+		return "rotation-" + id
+	}
+	return "rotation-dry-run"
+}
+
+func safeOperationToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		}
+	}
+	return strings.Trim(b.String(), "-_")
+}
+
+func rotationIdempotencyKey(operationID, ref string) string {
+	return operationID + ":" + hashAuditRef(strings.TrimSpace(ref))
+}
+
+func rotationCapabilityResult(record managedSecretRecord) string {
+	for _, capability := range record.Capabilities {
+		if capability == "reset" || capability == "rotate" || capability == "rotate/reset" {
+			return "supported"
+		}
+	}
+	return "unsupported"
+}
+
+func policyResultForOutcome(outcome string) string {
+	if outcome == "dry_run_ready" || outcome == "ready" {
+		return "allowed"
+	}
+	if outcome == "policy_denied" || outcome == "invalid_ref" {
+		return "denied"
+	}
+	return "unknown"
+}
+
+func capabilityResultForOutcome(outcome string) string {
+	if outcome == "missing_ref" || outcome == "invalid_ref" {
+		return "invalid"
+	}
+	if outcome == "locked" || outcome == "source_auth_required" || outcome == "degraded" {
+		return "blocked"
+	}
+	return "unsupported"
+}
+
+func summarizeRotationPlan(items []rotationPlanItem) rotationPlanSummary {
+	summary := rotationPlanSummary{SelectedCount: len(items)}
+	for _, item := range items {
+		switch item.Outcome {
+		case "dry_run_ready":
+			summary.ReadyCount++
+		case "policy_denied", "invalid_ref":
+			summary.DeniedCount++
+		case "unsupported":
+			summary.UnsupportedCount++
+		default:
+			summary.BlockedCount++
+		}
+		if item.Risk == "high" {
+			summary.HighRiskCount++
+		}
+	}
+	return summary
+}
+
+func rotationAggregateOutcome(summary rotationPlanSummary) string {
+	if summary.SelectedCount == 0 {
+		return "invalid_ref"
+	}
+	if summary.ReadyCount == summary.SelectedCount {
+		return "dry_run_ready"
+	}
+	if summary.ReadyCount > 0 {
+		return "partial_failure"
+	}
+	if summary.DeniedCount > 0 {
+		return "policy_denied"
+	}
+	if summary.UnsupportedCount > 0 {
+		return "unsupported"
+	}
+	return "degraded"
+}
+
+func rotationNextAction(outcome string) string {
+	switch outcome {
+	case "dry_run_ready":
+		return "confirm_with_operation_id_audit_reason_and_fresh_plan"
+	case "partial_failure":
+		return "review_denied_unsupported_or_blocked_refs"
+	case "policy_denied":
+		return "review_policy"
+	case "unsupported":
+		return "inspect_provider_capabilities"
+	case "locked":
+		return "unlock_broker"
+	default:
+		return nextActionForManagedOutcome(outcome)
+	}
+}
+
+func registerRotationHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/management/secrets/rotation/dry-run", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/management/secrets/rotation/dry-run.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req rotationDryRunRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := backend.rotationDryRun(req)
+		if err != nil {
+			writeRotationActionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeRotationActionError(w http.ResponseWriter, err error, res rotationDryRunResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errMissingRef):
+		status = http.StatusNotFound
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errUnsupportedProvider):
+		status = http.StatusNotImplemented
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/secrets_management_test.go
+++ b/cmd/secretsbroker/secrets_management_test.go
@@ -134,6 +134,50 @@ func TestManagedDryRunApplyAndPolicyContractsDoNotReturnRawValues(t *testing.T) 
 	}
 }
 
+func TestRotationDryRunPlansLocalRefsAndPartialDenialsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	readyRef := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	deniedRef := "services/deny/runtime/DENY_ME"
+	writeManagedTestSecret(t, backend, readyRef, managedSecretValue)
+	writeManagedTestSecret(t, backend, deniedRef, "rotation-deny-fixture-value")
+
+	plan, err := backend.rotationDryRun(rotationDryRunRequest{RequestID: "req-rotation-plan", ServiceID: "@serviceadmin", OperationID: "rotate-campaign-a", Refs: []string{deniedRef, readyRef}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Outcome != "partial_failure" || plan.Applied || !plan.RequiresConfirmation || plan.StaleAfterSeconds != rotationPlanStaleAfterSeconds {
+		t.Fatalf("rotation plan = %#v", plan)
+	}
+	if plan.Summary.SelectedCount != 2 || plan.Summary.ReadyCount != 1 || plan.Summary.DeniedCount != 1 {
+		t.Fatalf("rotation summary = %#v", plan.Summary)
+	}
+	if plan.Results[0].Ref != readyRef || plan.Results[0].CapabilityResult != "supported" || plan.Results[0].PolicyResult != "allowed" || plan.Results[0].IdempotencyKey == "" {
+		t.Fatalf("ready rotation item = %#v", plan.Results[0])
+	}
+	if plan.Results[1].Ref != deniedRef || plan.Results[1].Outcome != "policy_denied" || plan.Results[1].PolicyResult != "denied" {
+		t.Fatalf("denied rotation item = %#v", plan.Results[1])
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, plan), managedSecretValue, "rotation-deny-fixture-value", "replacement-value")
+}
+
+func TestRotationDryRunReportsProviderCapabilityWithoutRawValues(t *testing.T) {
+	backend := managedTestBackend(t)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "file-source", Kind: "file", Enabled: true, Refs: map[string]sourceRefConfig{
+			"services/file/runtime/FILE_ONLY_REF": {Path: "C:/not-used"},
+		},
+	}}}
+
+	plan, err := backend.rotationDryRun(rotationDryRunRequest{RequestID: "req-file-rotation", ServiceID: "@serviceadmin", OperationID: "rotate-file-source", Refs: []string{"services/file/runtime/FILE_ONLY_REF"}})
+	if err == nil || plan.Outcome != "unsupported" || plan.Summary.UnsupportedCount != 1 {
+		t.Fatalf("provider capability plan = %#v err=%v", plan, err)
+	}
+	if len(plan.Results) != 1 || plan.Results[0].ProviderKind != "file" || plan.Results[0].CapabilityResult != "unsupported" || plan.Results[0].NextAction != "inspect_provider_capabilities" {
+		t.Fatalf("provider rotation item = %#v", plan.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, plan), "file-source-token", "replacement-value")
+}
+
 func TestManagedHTTPContractAndFailClosedErrors(t *testing.T) {
 	backend := managedTestBackend(t)
 	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
@@ -189,6 +233,35 @@ func TestManagedHTTPContractAndFailClosedErrors(t *testing.T) {
 		t.Fatalf("missing status=%d body=%s", missingRes.StatusCode, missing)
 	}
 	assertNoSecretMaterial(t, missing, managedSecretValue)
+}
+
+func TestRotationDryRunHTTPContractIsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-http-rotation","serviceId":"@serviceadmin","operationId":"rotation-http-a","refs":["` + ref + `"],"reason":"operator approved"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/rotation/dry-run", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readClose(t, res.Body)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("rotation dry-run status=%d body=%s", res.StatusCode, got)
+	}
+	if !bytes.Contains(got, []byte(`"operation":"credential_rotation"`)) || !bytes.Contains(got, []byte(`"outcome":"dry_run_ready"`)) {
+		t.Fatalf("rotation dry-run body=%s", got)
+	}
+	assertNoSecretMaterial(t, got, managedSecretValue, "replacement-value")
 }
 
 func TestManagedListLockedFailsClosed(t *testing.T) {

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -96,6 +96,77 @@ Dry-run validates ref, policy, backend state, and audit requirements. Apply requ
 
 Dry-run validates reset/rotate readiness. Apply stores caller-provided replacement material (or a future provider-generated value) without returning the raw value.
 
+### `POST /v1/management/secrets/rotation/dry-run`
+
+Metadata-only credential rotation planning. The first broker-side slice is dry-run only: it reports local encrypted-store rotation/reset readiness and provider capability results, but it does not generate replacement material, mutate secrets, call external provider apply APIs, or return raw values.
+
+Request:
+
+```json
+{
+  "requestId": "req-rotation-1",
+  "serviceId": "@serviceadmin",
+  "operationId": "rotation-campaign-2026-05-23-a",
+  "refs": [
+    "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+  ],
+  "reason": "operator rotation planning"
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "req-rotation-1",
+  "operationId": "rotation-campaign-2026-05-23-a",
+  "operation": "credential_rotation",
+  "mode": "dry-run",
+  "outcome": "dry_run_ready",
+  "applied": false,
+  "requiresConfirmation": true,
+  "auditStatus": "audit_ready",
+  "staleAfterSeconds": 300,
+  "nextAction": "confirm_with_operation_id_audit_reason_and_fresh_plan",
+  "results": [
+    {
+      "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+      "sourceId": "local-test",
+      "providerKind": "local-encrypted-store",
+      "ownerServiceId": "@serviceadmin",
+      "capability": "rotate/reset",
+      "capabilityResult": "supported",
+      "policyResult": "allowed",
+      "auditRequirement": "required",
+      "risk": "medium",
+      "expectedAction": "generate_or_accept_replacement_inside_broker",
+      "outcome": "dry_run_ready",
+      "nextAction": "confirm_with_operation_id_audit_reason_and_fresh_plan",
+      "operationId": "rotation-campaign-2026-05-23-a",
+      "idempotencyKey": "rotation-campaign-2026-05-23-a:sha256:..."
+    }
+  ],
+  "summary": {
+    "selectedCount": 1,
+    "readyCount": 1,
+    "deniedCount": 0,
+    "unsupportedCount": 0,
+    "blockedCount": 0,
+    "highRiskCount": 0
+  },
+  "affectedRefs": [
+    "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+  ],
+  "affectedServices": [
+    "@serviceadmin"
+  ]
+}
+```
+
+Provider-backed refs are represented as metadata-only capability results. A provider/source that does not currently advertise rotate/reset support returns `unsupported` with `nextAction: "inspect_provider_capabilities"`. Unknown policy, audit, provider auth, or broker state fails closed and must be rechecked with a fresh dry-run before any later apply path.
+
 ### `POST /v1/management/secrets/policy/preview`
 ### `POST /v1/management/secrets/policy/apply`
 


### PR DESCRIPTION
## Issue
Closes #68

## Summary
- Adds a metadata-only credential rotation dry-run contract at `POST /v1/management/secrets/rotation/dry-run`.
- Plans local encrypted-store rotate/reset readiness with operation ids, per-ref idempotency keys, policy/audit metadata, stale-plan TTL, and aggregate summary counts.
- Reports provider/source refs as capability metadata only, including unsupported rotate/reset state where a source does not advertise rotation support.
- Documents the request/response contract and fail-closed provider/auth/policy/audit behavior.

## Scope
- In scope: dry-run planning only for credential rotation/reset readiness.
- Out of scope: generated replacement material, provider-backed apply, bulk campaign apply, raw value reveal/export, and broad provider automation.

## Spec / contract / fixture impact
- Updated: `docs/secrets-management-api.md`.
- Added tests covering local-store rotation planning, provider capability unsupported state, HTTP contract, and no raw value serialization.

## Service Lasso invariant impact
- Invariant: secrets and provider credentials stay out of logs, diagnostics, API planning payloads, issue comments, PR bodies, and fixtures.
- Preservation proof: dry-run responses never include raw values and focused tests assert fixture secret strings are absent from serialized responses.

## Validation
- PASS `gofmt -w cmd/secretsbroker/rotation_plan.go cmd/secretsbroker/secrets_management_test.go`
- PASS `go test ./cmd/secretsbroker`
- PASS `go test ./...`
- PASS `git diff --check`
- Evidence logs: `.work-agent/logs/issue-68-2026-05-22T17-29-56-242Z/`

## Approval trail
- Required: standard repository review before merge.
- Evidence: PR opened for review; no apply path was added.

## Cleanup
- Branch: `issue-68-rotation-dry-run-contract`.
- Local cleanup after PR handoff will return checkout to `main`; only `.work-agent/` evidence logs should remain untracked.
