### PR TITLE
Ignore agent scratch workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 output/
 verify/service-harness.ci.json
+.work-agent/


### PR DESCRIPTION
Adds .work-agent/ to .gitignore so local agent evidence and scratch logs do not show as untracked product files.