### PR TITLE
#66 add management denial lockout

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -29,6 +29,7 @@ var (
 	errMissingRef         = errors.New("secret ref was not found")
 	errInvalidRef         = errors.New("invalid secret ref")
 	errPolicyDenied       = errors.New("write-back policy denied")
+	errLockoutActive      = errors.New("lockout active")
 	errIdentityExpired    = errors.New("launch identity expired")
 	errSourceAuthRequired = errors.New("source authentication required")
 	errBackendDegraded    = errors.New("backend degraded")
@@ -41,6 +42,7 @@ type localBackend struct {
 	masterKey string
 	sources   sourceConfigFile
 	now       func() time.Time
+	lockouts  *lockoutStore
 }
 
 type localStoreFile struct {
@@ -168,7 +170,14 @@ type auditEvent struct {
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
-	return &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
+	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
+	backend.lockouts = newLockoutStore(func() time.Time {
+		if backend.now == nil {
+			return time.Now().UTC()
+		}
+		return backend.now()
+	})
+	return backend
 }
 
 func defaultStorePath() string { return filepath.Join("data", "secretsbroker-store.json") }

--- a/cmd/secretsbroker/secrets_management.go
+++ b/cmd/secretsbroker/secrets_management.go
@@ -65,6 +65,9 @@ type managedSecretActionResponse struct {
 	AffectedRefs          []string             `json:"affectedRefs"`
 	AffectedServices      []string             `json:"affectedServices"`
 	UnsupportedCapability string               `json:"unsupportedCapability,omitempty"`
+	LockoutActive         bool                 `json:"lockoutActive,omitempty"`
+	LockoutScope          string               `json:"lockoutScope,omitempty"`
+	RetryAfterSeconds     int                  `json:"retryAfterSeconds,omitempty"`
 }
 
 func (b *localBackend) listManagedSecrets(query string, valueSearch bool) (managedSecretsResponse, error) {
@@ -204,9 +207,18 @@ func workspaceFromRef(ref string) string {
 
 func (b *localBackend) revealManagedSecret(req managedSecretActionRequest) (managedSecretActionResponse, error) {
 	res := baseManagedActionResponse(req, "reveal", "apply")
+	if b.managementLockoutActive(req, "reveal", &res) {
+		return res, errLockoutActive
+	}
 	if err := validateManagedAction(req, true); err != nil {
-		res.Outcome = "invalid_ref"
-		res.NextAction = "provide_ref_and_reason"
+		res.Outcome = outcomeForError(err)
+		res.NextAction = nextActionForManagedOutcome(res.Outcome)
+		if errors.Is(err, errPolicyDenied) {
+			b.recordManagementPolicyDenied(req, "reveal", &res)
+			if res.LockoutActive {
+				return res, errLockoutActive
+			}
+		}
 		_ = b.audit("management_reveal", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
 		return res, err
 	}
@@ -218,6 +230,12 @@ func (b *localBackend) revealManagedSecret(req managedSecretActionRequest) (mana
 		}
 		res.Outcome = outcome
 		res.NextAction = nextActionForManagedOutcome(outcome)
+		if outcome == "policy_denied" {
+			b.recordManagementPolicyDenied(req, "reveal", &res)
+			if res.LockoutActive {
+				return res, errLockoutActive
+			}
+		}
 		_ = b.audit("management_reveal", req.Ref, outcome, req.ServiceID, req.RequestID)
 		return res, outcomeError(outcome)
 	}
@@ -227,6 +245,7 @@ func (b *localBackend) revealManagedSecret(req managedSecretActionRequest) (mana
 	res.TTLSeconds = revealTTLSeconds
 	res.AuditStatus = "audit_recorded"
 	res.Metadata = result.Metadata
+	b.recordManagementSuccess(req, "reveal")
 	_ = b.audit("management_reveal", req.Ref, "ready", req.ServiceID, req.RequestID)
 	return res, nil
 }
@@ -277,10 +296,17 @@ func (b *localBackend) managedResetApply(req managedSecretActionRequest) (manage
 
 func (b *localBackend) managedWriteApply(req managedSecretActionRequest, operation string) (managedSecretActionResponse, error) {
 	res := baseManagedActionResponse(req, operation, "apply")
+	if b.managementLockoutActive(req, operation, &res) {
+		return res, errLockoutActive
+	}
 	if err := validateManagedAction(req, true); err != nil || !req.Confirm || strings.TrimSpace(req.Value) == "" {
 		res.Outcome = "policy_denied"
 		res.NextAction = "run_dry_run_confirm_reason_and_value"
+		b.recordManagementPolicyDenied(req, operation, &res)
 		_ = b.audit("management_"+operation+"_apply", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		if res.LockoutActive {
+			return res, errLockoutActive
+		}
 		return res, errPolicyDenied
 	}
 	written, err := b.writeSecret(writeSecretRequest{Ref: req.Ref, Value: req.Value, Metadata: map[string]string{"sourceId": "management:" + operation}})
@@ -295,16 +321,24 @@ func (b *localBackend) managedWriteApply(req managedSecretActionRequest, operati
 	res.AuditStatus = "audit_recorded"
 	res.Metadata = &written.Metadata
 	res.Record = &record
+	b.recordManagementSuccess(req, operation)
 	_ = b.audit("management_"+operation+"_apply", req.Ref, "applied", req.ServiceID, req.RequestID)
 	return res, nil
 }
 
 func (b *localBackend) managedPolicyApply(req managedSecretActionRequest) (managedSecretActionResponse, error) {
 	res := baseManagedActionResponse(req, "policy", "apply")
+	if b.managementLockoutActive(req, "policy", &res) {
+		return res, errLockoutActive
+	}
 	if err := validateManagedAction(req, true); err != nil || !req.Confirm || strings.TrimSpace(req.Policy) == "" {
 		res.Outcome = "policy_denied"
 		res.NextAction = "preview_confirm_reason_and_policy"
+		b.recordManagementPolicyDenied(req, "policy", &res)
 		_ = b.audit("management_policy_apply", req.Ref, res.Outcome, req.ServiceID, req.RequestID)
+		if res.LockoutActive {
+			return res, errLockoutActive
+		}
 		return res, errPolicyDenied
 	}
 	record, err := b.managedRecord(req.Ref)
@@ -318,6 +352,7 @@ func (b *localBackend) managedPolicyApply(req managedSecretActionRequest) (manag
 	res.Applied = true
 	res.AuditStatus = "audit_recorded"
 	res.Record = &record
+	b.recordManagementSuccess(req, "policy")
 	_ = b.audit("management_policy_apply", req.Ref, "applied", req.ServiceID, req.RequestID)
 	return res, nil
 }
@@ -346,6 +381,59 @@ func (b *localBackend) managedRecord(ref string) (managedSecretRecord, error) {
 
 func baseManagedActionResponse(req managedSecretActionRequest, operation, mode string) managedSecretActionResponse {
 	return managedSecretActionResponse{ServiceID: serviceID, APIVersion: apiVersion, RequestID: req.RequestID, Ref: strings.TrimSpace(req.Ref), Operation: operation, Mode: mode, Outcome: "pending", AuditStatus: "audit_pending", AffectedRefs: safeList([]string{req.Ref}), AffectedServices: safeList([]string{req.ServiceID})}
+}
+
+func (b *localBackend) managementLockoutActive(req managedSecretActionRequest, operation string, res *managedSecretActionResponse) bool {
+	if b == nil || res == nil || b.lockouts == nil {
+		return false
+	}
+	decision := b.lockouts.active(managementLockoutScope(req, operation))
+	if !decision.Active {
+		return false
+	}
+	applyManagementLockout(res, decision)
+	_ = b.audit("management_lockout", req.Ref, "lockout_active", req.ServiceID, req.RequestID)
+	return true
+}
+
+func (b *localBackend) recordManagementPolicyDenied(req managedSecretActionRequest, operation string, res *managedSecretActionResponse) {
+	if b == nil || res == nil || b.lockouts == nil {
+		return
+	}
+	decision, started := b.lockouts.recordFailure(managementLockoutScope(req, operation))
+	if started {
+		applyManagementLockout(res, decision)
+		_ = b.audit("management_lockout", req.Ref, "lockout_active", req.ServiceID, req.RequestID)
+	}
+}
+
+func (b *localBackend) recordManagementSuccess(req managedSecretActionRequest, operation string) {
+	if b == nil || b.lockouts == nil {
+		return
+	}
+	b.lockouts.recordSuccess(managementLockoutScope(req, operation))
+}
+
+func applyManagementLockout(res *managedSecretActionResponse, decision lockoutDecision) {
+	res.Outcome = "lockout_active"
+	res.NextAction = "wait_or_clear_lockout"
+	res.Value = ""
+	res.Applied = false
+	res.LockoutActive = true
+	res.LockoutScope = decision.Scope
+	res.RetryAfterSeconds = decision.RetryAfterSeconds
+}
+
+func managementLockoutScope(req managedSecretActionRequest, operation string) string {
+	service := strings.TrimSpace(req.ServiceID)
+	if service == "" {
+		service = "@operator"
+	}
+	ref := strings.TrimSpace(req.Ref)
+	if ref == "" || !validSecretRef(ref) {
+		ref = "unknown"
+	}
+	return strings.Join([]string{"management", strings.TrimSpace(operation), service, ref}, ":")
 }
 
 func dryRunMode(operation string) string {
@@ -502,6 +590,8 @@ func writeManagementActionError(w http.ResponseWriter, err error, res managedSec
 		status = http.StatusNotFound
 	case errors.Is(err, errPolicyDenied):
 		status = http.StatusForbidden
+	case errors.Is(err, errLockoutActive):
+		status = http.StatusLocked
 	case errors.Is(err, errSourceAuthRequired):
 		status = http.StatusFailedDependency
 	}

--- a/cmd/secretsbroker/secrets_management_test.go
+++ b/cmd/secretsbroker/secrets_management_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 const managedSecretValue = "fixture-managed-secret-value"
@@ -131,6 +133,82 @@ func TestManagedDryRunApplyAndPolicyContractsDoNotReturnRawValues(t *testing.T) 
 	policy, err := backend.managedPolicyApply(managedSecretActionRequest{RequestID: "req-policy-apply", ServiceID: "@serviceadmin", Ref: ref, Reason: "approved", Confirm: true, Policy: "policy/serviceadmin/reveal"})
 	if err != nil || !policy.Applied || policy.Value != "" || policy.Record.Policy != "policy/serviceadmin/reveal" {
 		t.Fatalf("policy apply = %#v err=%v", policy, err)
+	}
+}
+
+func TestManagedPolicyDeniedAttemptsStartScopedLockout(t *testing.T) {
+	backend := managedTestBackend(t)
+	now := time.Date(2026, 6, 6, 1, 45, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-denied", ServiceID: "@serviceadmin", Ref: ref, Value: "replacement-value"})
+		if !errors.Is(err, errPolicyDenied) && !errors.Is(err, errLockoutActive) {
+			t.Fatalf("denied edit apply err=%v res=%#v", err, res)
+		}
+		if i < localAPILockoutThreshold && res.LockoutActive {
+			t.Fatalf("lockout started too early on attempt %d: %#v", i, res)
+		}
+		if i == localAPILockoutThreshold {
+			if res.Outcome != "lockout_active" || !res.LockoutActive || res.LockoutScope != "management:edit:@serviceadmin:"+ref || res.RetryAfterSeconds < 1 || res.Value != "" || res.Applied {
+				t.Fatalf("lockout response = %#v", res)
+			}
+			assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "replacement-value")
+		}
+	}
+
+	otherRef := "services/@serviceadmin/runtime/OTHER_KEY"
+	writeManagedTestSecret(t, backend, otherRef, "other-managed-value")
+	other, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-other", ServiceID: "@serviceadmin", Ref: otherRef, Reason: "approved", Confirm: true, Value: "other-replacement"})
+	if err != nil || !other.Applied {
+		t.Fatalf("lockout should not block unrelated ref: %#v err=%v", other, err)
+	}
+
+	locked, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-active", ServiceID: "@serviceadmin", Ref: ref, Reason: "approved", Confirm: true, Value: "replacement-value"})
+	if !errors.Is(err, errLockoutActive) || locked.Outcome != "lockout_active" || locked.Applied || locked.Value != "" {
+		t.Fatalf("active lockout should block valid apply until cooldown: %#v err=%v", locked, err)
+	}
+
+	now = now.Add(localAPILockoutCooldown + time.Second)
+	applied, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-after-cooldown", ServiceID: "@serviceadmin", Ref: ref, Reason: "approved", Confirm: true, Value: "replacement-value"})
+	if err != nil || !applied.Applied || applied.Outcome != "applied" {
+		t.Fatalf("apply after cooldown = %#v err=%v", applied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "replacement-value")
+}
+
+func TestManagedRevealLockoutHTTPResponseIsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		body := []byte(`{"requestId":"req-http-denied","serviceId":"@serviceadmin","ref":"` + ref + `"}`)
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/reveal", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer test-token")
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := readClose(t, res.Body)
+		if i < localAPILockoutThreshold && res.StatusCode != http.StatusForbidden {
+			t.Fatalf("attempt %d status=%d body=%s", i, res.StatusCode, payload)
+		}
+		if i == localAPILockoutThreshold {
+			if res.StatusCode != http.StatusLocked || !bytes.Contains(payload, []byte(`"lockoutActive":true`)) || !bytes.Contains(payload, []byte(`"outcome":"lockout_active"`)) {
+				t.Fatalf("lockout status=%d body=%s", res.StatusCode, payload)
+			}
+			assertNoSecretMaterial(t, payload, managedSecretValue, "test-token")
+		}
 	}
 }
 

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -57,6 +57,15 @@ Token checks trim whitespace, hash both presented and expected tokens, and then 
 
 Repeated invalid local API tokens are tracked by local API client scope. Three invalid attempts for the same scope start a five-minute cooldown for secret-bearing endpoints. The lockout response includes safe metadata only and does not echo the presented token or expected token.
 
+Repeated policy-denied management reveal/apply attempts are also tracked with narrow scopes:
+
+- `management:reveal:<serviceId>:<ref>`
+- `management:edit:<serviceId>:<ref>`
+- `management:reset:<serviceId>:<ref>`
+- `management:policy:<serviceId>:<ref>`
+
+Three denied attempts for the same management operation/ref/service start the same five-minute cooldown. The cooldown blocks that exact reveal/apply scope while unrelated refs, unrelated operations, and read-only status/list/dry-run surfaces remain available.
+
 Secret-bearing endpoints cap request bodies at 1 MiB before JSON decode. Oversized requests return `413 request_too_large` with a safe fixed message; request content and bearer tokens are not echoed.
 
 ## CLI helpers
@@ -107,6 +116,31 @@ Active lockout:
   }
 }
 ```
+
+Management reveal/apply lockout response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "req-edit",
+  "ref": "services/@serviceadmin/runtime/API_TOKEN",
+  "operation": "edit",
+  "mode": "apply",
+  "outcome": "lockout_active",
+  "applied": false,
+  "requiresConfirmation": false,
+  "auditStatus": "audit_pending",
+  "nextAction": "wait_or_clear_lockout",
+  "affectedRefs": ["services/@serviceadmin/runtime/API_TOKEN"],
+  "affectedServices": ["@serviceadmin"],
+  "lockoutActive": true,
+  "lockoutScope": "management:edit:@serviceadmin:services/@serviceadmin/runtime/API_TOKEN",
+  "retryAfterSeconds": 300
+}
+```
+
+The management lockout response never includes raw secret values, submitted replacement values, provider credentials, local API tokens, auth headers, private keys, cookies, passwords, or environment values.
 
 No server token configured:
 

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -191,7 +191,14 @@ Implemented first slice:
 - Active lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
 - Lockout and auth-failure audit/events use operation/outcome metadata only and do not persist presented tokens, expected tokens, request bodies, or secret values.
 - Safe read-only status, readiness, capabilities, telemetry, and event endpoints remain available during local API lockout.
-- Provider/source, service-identity, management apply/reveal denial, and audited admin-clear persistence are follow-up slices under #66.
+
+Implemented management-denial slice:
+
+- Policy-denied management reveal/edit/reset/policy apply attempts are tracked in memory by operation, requesting service id, and safe ref handle.
+- Three denied attempts for the same management scope start a five-minute cooldown for that exact reveal/apply operation.
+- Active management lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
+- Unrelated refs, unrelated management operations, and safe read-only status/list/dry-run surfaces remain available during the cooldown.
+- Provider/source, service-identity, and audited admin-clear persistence are follow-up slices under #66.
 
 ## API/backend mapping
 


### PR DESCRIPTION
## Summary
- add scoped management-denial lockout tracking for repeated policy-denied reveal/edit/reset/policy-apply attempts
- scope lockouts by operation, requesting service id, and safe ref handle so unrelated refs/operations remain available
- return metadata-only lockout fields and update docs for local API/security and operational controls

## Validation
- PASS `go test ./cmd/secretsbroker`
- PASS `go test ./...`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- PASS `git diff --check`

Refs #66