### PR TITLE
66: add write-back scoped lockouts

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -127,6 +127,9 @@ type generatedSecretCaptureResponse struct {
 	ReconnectRequired bool           `json:"reconnectRequired"`
 	InvalidatedRefs   []string       `json:"invalidatedRefs"`
 	Metadata          SecretMetadata `json:"metadata,omitempty"`
+	LockoutActive     bool           `json:"lockoutActive,omitempty"`
+	LockoutScope      string         `json:"lockoutScope,omitempty"`
+	RetryAfterSeconds int            `json:"retryAfterSeconds,omitempty"`
 }
 
 type resolveRequest struct {
@@ -315,8 +318,20 @@ func (b *localBackend) captureGeneratedSecret(req generatedSecretCaptureRequest)
 		response.Outcome = "invalid_ref"
 		return response, errInvalidRef
 	}
+	if decision := b.activeWritebackLockout(writebackLockoutScope("identity", service, operation, fullRef)); decision.Active {
+		_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+		response.Outcome = "lockout_active"
+		applyWritebackLockout(&response, decision)
+		return response, errLockoutActive
+	}
 	if service == "" {
 		_ = b.audit("writeback_capture", fullRef, "identity_expired", service, req.RequestID)
+		if decision, started := b.recordWritebackLockoutFailure(writebackLockoutScope("identity", service, operation, fullRef)); started {
+			_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+			response.Outcome = "lockout_active"
+			applyWritebackLockout(&response, decision)
+			return response, errLockoutActive
+		}
 		response.Outcome = "identity_expired"
 		return response, errIdentityExpired
 	}
@@ -324,26 +339,77 @@ func (b *localBackend) captureGeneratedSecret(req generatedSecretCaptureRequest)
 		expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(req.Identity.ExpiresAt))
 		if err != nil || !expiresAt.After(b.now()) {
 			_ = b.audit("writeback_capture", fullRef, "identity_expired", service, req.RequestID)
+			if decision, started := b.recordWritebackLockoutFailure(writebackLockoutScope("identity", service, operation, fullRef)); started {
+				_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+				response.Outcome = "lockout_active"
+				applyWritebackLockout(&response, decision)
+				return response, errLockoutActive
+			}
 			response.Outcome = "identity_expired"
 			return response, errIdentityExpired
 		}
+	}
+	if decision := b.activeWritebackLockout(writebackLockoutScope("policy", service, operation, fullRef)); decision.Active {
+		_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+		response.Outcome = "lockout_active"
+		applyWritebackLockout(&response, decision)
+		return response, errLockoutActive
 	}
 	if req.Secrets != nil {
 		decision := evaluateServiceSecretsPolicy(service, "writeback", fullRef, req.Secrets)
 		_ = b.audit("policy_decision", fullRef, decision.Outcome, service, req.RequestID)
 		if decision.Outcome != "allowed" {
 			_ = b.audit("writeback_capture", fullRef, "policy_denied", service, req.RequestID)
+			if decision, started := b.recordWritebackLockoutFailure(writebackLockoutScope("policy", service, operation, fullRef)); started {
+				_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+				response.Outcome = "lockout_active"
+				applyWritebackLockout(&response, decision)
+				return response, errLockoutActive
+			} else if decision.Active {
+				_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+				response.Outcome = "lockout_active"
+				applyWritebackLockout(&response, decision)
+				return response, errLockoutActive
+			}
 			response.Outcome = "policy_denied"
 			return response, errPolicyDenied
 		}
 	}
 	if !namespaceAllowed(namespace, req.Policy.AllowedNamespaces) || !operationAllowed(operation, req.Policy.AllowedOperations) {
 		_ = b.audit("writeback_capture", fullRef, "policy_denied", service, req.RequestID)
+		if decision, started := b.recordWritebackLockoutFailure(writebackLockoutScope("policy", service, operation, fullRef)); started {
+			_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+			response.Outcome = "lockout_active"
+			applyWritebackLockout(&response, decision)
+			return response, errLockoutActive
+		} else if decision.Active {
+			_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+			response.Outcome = "lockout_active"
+			applyWritebackLockout(&response, decision)
+			return response, errLockoutActive
+		}
 		response.Outcome = "policy_denied"
 		return response, errPolicyDenied
 	}
+	if decision := b.activeWritebackLockout(writebackLockoutScope("source_auth", service, operation, fullRef)); decision.Active {
+		_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+		response.Outcome = "lockout_active"
+		applyWritebackLockout(&response, decision)
+		return response, errLockoutActive
+	}
 	if req.SourceAuthRequired {
 		_ = b.audit("writeback_capture", fullRef, "source_auth_required", service, req.RequestID)
+		if decision, started := b.recordWritebackLockoutFailure(writebackLockoutScope("source_auth", service, operation, fullRef)); started {
+			_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+			response.Outcome = "lockout_active"
+			applyWritebackLockout(&response, decision)
+			return response, errLockoutActive
+		} else if decision.Active {
+			_ = b.audit("writeback_lockout", fullRef, "lockout_active", service, req.RequestID)
+			response.Outcome = "lockout_active"
+			applyWritebackLockout(&response, decision)
+			return response, errLockoutActive
+		}
 		response.Outcome = "source_auth_required"
 		return response, errSourceAuthRequired
 	}
@@ -389,7 +455,45 @@ func (b *localBackend) captureGeneratedSecret(req generatedSecretCaptureRequest)
 	_ = b.audit("writeback_capture", fullRef, "ready", service, req.RequestID)
 	response.Outcome = "ready"
 	response.Metadata = written.Metadata
+	b.recordWritebackLockoutSuccess(writebackLockoutScope("identity", service, operation, fullRef))
+	b.recordWritebackLockoutSuccess(writebackLockoutScope("policy", service, operation, fullRef))
+	b.recordWritebackLockoutSuccess(writebackLockoutScope("source_auth", service, operation, fullRef))
 	return response, nil
+}
+
+func writebackLockoutScope(family, service, operation, ref string) string {
+	service = strings.TrimSpace(service)
+	if service == "" {
+		service = "unknown"
+	}
+	return strings.Join([]string{"writeback", strings.TrimSpace(family), strings.TrimSpace(operation), service, strings.Trim(strings.TrimSpace(ref), "/")}, ":")
+}
+
+func (b *localBackend) activeWritebackLockout(scope string) lockoutDecision {
+	if b == nil || b.lockouts == nil {
+		return lockoutDecision{Scope: scope}
+	}
+	return b.lockouts.active(scope)
+}
+
+func (b *localBackend) recordWritebackLockoutFailure(scope string) (lockoutDecision, bool) {
+	if b == nil || b.lockouts == nil {
+		return lockoutDecision{Scope: scope}, false
+	}
+	return b.lockouts.recordFailure(scope)
+}
+
+func (b *localBackend) recordWritebackLockoutSuccess(scope string) {
+	if b == nil || b.lockouts == nil {
+		return
+	}
+	b.lockouts.recordSuccess(scope)
+}
+
+func applyWritebackLockout(res *generatedSecretCaptureResponse, decision lockoutDecision) {
+	res.LockoutActive = true
+	res.LockoutScope = decision.Scope
+	res.RetryAfterSeconds = decision.RetryAfterSeconds
 }
 
 func (b *localBackend) resolve(req resolveRequest) resolveResponse {
@@ -692,6 +796,8 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			writeAPIError(w, http.StatusForbidden, "policy_denied", "Write-back policy denied this generated secret capture.", "policy_denied", "review_policy")
 		case errors.Is(err, errSourceAuthRequired):
 			writeAPIError(w, http.StatusFailedDependency, "source_auth_required", "Source authentication is required before write-back can proceed.", "source_auth_required", "reconnect_source")
+		case errors.Is(err, errLockoutActive):
+			writeScopedLockoutAPIError(w, res.LockoutScope, res.RetryAfterSeconds, "Write-back is temporarily locked for this scope.")
 		case errors.Is(err, errLocked):
 			writeAPIError(w, http.StatusServiceUnavailable, "locked", "Secrets Broker local store is locked.", "locked", "unlock_broker")
 		default:

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -40,6 +40,44 @@ func TestHTTPGeneratedSecretWritebackCapture(t *testing.T) {
 	}
 }
 
+func TestHTTPGeneratedSecretWritebackLockoutResponseIsMetadataOnly(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-writeback-http-lockout","identity":{"serviceId":"api-service","expiresAt":"2026-05-07T00:05:00Z"},"policy":{"allowedNamespaces":["services/api-service"],"allowedOperations":["create"]},"operation":"create","namespace":"services/api-service","ref":"runtime/API_TOKEN","value":"generated-http-secret","sourceAuthRequired":true}`)
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/writeback", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer test-token")
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, readErr := io.ReadAll(res.Body)
+		res.Body.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if i < localAPILockoutThreshold {
+			if res.StatusCode != http.StatusFailedDependency {
+				t.Fatalf("attempt %d status=%d body=%s", i, res.StatusCode, payload)
+			}
+			continue
+		}
+		if res.StatusCode != http.StatusLocked || !bytes.Contains(payload, []byte(`"lockoutActive":true`)) || !bytes.Contains(payload, []byte(`"lockoutScope":"writeback:source_auth:create:api-service:services/api-service/runtime/API_TOKEN"`)) {
+			t.Fatalf("lockout status=%d body=%s", res.StatusCode, payload)
+		}
+		if bytes.Contains(payload, []byte("generated-http-secret")) || bytes.Contains(payload, []byte("test-token")) {
+			t.Fatalf("writeback lockout response leaked sensitive input: %s", payload)
+		}
+	}
+}
+
 func TestSecretBearingEndpointRejectsOversizedBodyWithoutLeakingToken(t *testing.T) {
 	backend := testBackend(t)
 	state := "ready"

--- a/cmd/secretsbroker/local_store_test.go
+++ b/cmd/secretsbroker/local_store_test.go
@@ -179,6 +179,184 @@ func TestGeneratedSecretCaptureDistinctFailureOutcomes(t *testing.T) {
 	}
 }
 
+func TestGeneratedSecretCaptureIdentityFailuresStartScopedLockout(t *testing.T) {
+	backend := testBackend(t)
+	req := generatedSecretCaptureRequest{
+		RequestID: "req-writeback-lockout",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-06T23:59:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}},
+		Operation: "create",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "generated-secret-value",
+	}
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, err := backend.captureGeneratedSecret(req)
+		if i < localAPILockoutThreshold {
+			if !errors.Is(err, errIdentityExpired) || res.LockoutActive {
+				t.Fatalf("attempt %d response = %#v err=%v", i, res, err)
+			}
+			continue
+		}
+		if !errors.Is(err, errLockoutActive) || res.Outcome != "lockout_active" || !res.LockoutActive || res.LockoutScope != "writeback:identity:create:api:services/api/runtime/token" || res.RetryAfterSeconds < 1 {
+			t.Fatalf("lockout response = %#v err=%v", res, err)
+		}
+		if res.Metadata.SourceID != "" {
+			t.Fatalf("lockout should not include generated secret metadata: %#v", res.Metadata)
+		}
+	}
+
+	other, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID: "req-writeback-other",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}},
+		Operation: "create",
+		Namespace: "services/api",
+		Ref:       "runtime/other",
+		Value:     "other-generated-secret",
+	})
+	if err != nil || other.Outcome != "ready" {
+		t.Fatalf("identity lockout should not block unrelated ref: %#v err=%v", other, err)
+	}
+
+	locked, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID: "req-writeback-valid-same-ref",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}},
+		Operation: "create",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "valid-secret-after-lockout",
+	})
+	if !errors.Is(err, errLockoutActive) || locked.Outcome != "lockout_active" || locked.Metadata.SourceID != "" {
+		t.Fatalf("active identity lockout should block same writeback scope: %#v err=%v", locked, err)
+	}
+
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit := string(auditBytes)
+	if strings.Contains(audit, "generated-secret-value") || strings.Contains(audit, "valid-secret-after-lockout") {
+		t.Fatalf("audit leaked generated secret material: %s", audit)
+	}
+	for _, want := range []string{"writeback_lockout", "lockout_active", "identity_expired"} {
+		if !strings.Contains(audit, want) {
+			t.Fatalf("audit missing %q: %s", want, audit)
+		}
+	}
+}
+
+func TestGeneratedSecretCaptureSourceAuthFailuresStartScopedLockout(t *testing.T) {
+	backend := testBackend(t)
+	req := generatedSecretCaptureRequest{
+		RequestID:          "req-source-auth-lockout",
+		Identity:           writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:             writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"rotate"}},
+		Operation:          "rotate",
+		Namespace:          "services/api",
+		Ref:                "runtime/token",
+		Value:              "rotated-generated-secret",
+		SourceAuthRequired: true,
+	}
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, err := backend.captureGeneratedSecret(req)
+		if i < localAPILockoutThreshold {
+			if !errors.Is(err, errSourceAuthRequired) || res.Outcome != "source_auth_required" {
+				t.Fatalf("attempt %d response = %#v err=%v", i, res, err)
+			}
+			continue
+		}
+		if !errors.Is(err, errLockoutActive) || res.LockoutScope != "writeback:source_auth:rotate:api:services/api/runtime/token" || !res.LockoutActive {
+			t.Fatalf("source auth lockout response = %#v err=%v", res, err)
+		}
+	}
+
+	other, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID: "req-source-auth-unrelated-operation",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"create"}},
+		Operation: "create",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "create-secret-value",
+	})
+	if err != nil || other.Outcome != "ready" {
+		t.Fatalf("source-auth lockout should not block unrelated operation: %#v err=%v", other, err)
+	}
+}
+
+func TestGeneratedSecretCapturePolicyFailuresStartScopedLockout(t *testing.T) {
+	backend := testBackend(t)
+	now := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+	req := generatedSecretCaptureRequest{
+		RequestID: "req-writeback-policy-lockout",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/other"}, AllowedOperations: []string{"update"}},
+		Operation: "update",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "policy-denied-generated-secret",
+	}
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, err := backend.captureGeneratedSecret(req)
+		if i < localAPILockoutThreshold {
+			if !errors.Is(err, errPolicyDenied) || res.LockoutActive {
+				t.Fatalf("attempt %d response = %#v err=%v", i, res, err)
+			}
+			continue
+		}
+		if !errors.Is(err, errLockoutActive) || res.Outcome != "lockout_active" || !res.LockoutActive || res.LockoutScope != "writeback:policy:update:api:services/api/runtime/token" || res.RetryAfterSeconds < 1 {
+			t.Fatalf("policy lockout response = %#v err=%v", res, err)
+		}
+	}
+
+	locked, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID: "req-writeback-policy-valid-same-ref",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:05:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"update"}},
+		Operation: "update",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "valid-policy-secret-after-lockout",
+	})
+	if !errors.Is(err, errLockoutActive) || locked.Outcome != "lockout_active" || locked.Metadata.SourceID != "" {
+		t.Fatalf("active policy lockout should block same writeback scope: %#v err=%v", locked, err)
+	}
+
+	now = now.Add(localAPILockoutCooldown + time.Second)
+	applied, err := backend.captureGeneratedSecret(generatedSecretCaptureRequest{
+		RequestID: "req-writeback-policy-after-cooldown",
+		Identity:  writebackIdentity{ServiceID: "api", ExpiresAt: "2026-05-07T00:10:00Z"},
+		Policy:    writebackPolicy{AllowedNamespaces: []string{"services/api"}, AllowedOperations: []string{"update"}},
+		Operation: "update",
+		Namespace: "services/api",
+		Ref:       "runtime/token",
+		Value:     "valid-policy-secret-after-cooldown",
+	})
+	if err != nil || applied.Outcome != "ready" {
+		t.Fatalf("writeback after cooldown = %#v err=%v", applied, err)
+	}
+
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit := string(auditBytes)
+	if strings.Contains(audit, "policy-denied-generated-secret") || strings.Contains(audit, "valid-policy-secret-after-lockout") || strings.Contains(audit, "valid-policy-secret-after-cooldown") {
+		t.Fatalf("audit leaked generated secret material: %s", audit)
+	}
+	for _, want := range []string{"writeback_lockout", "lockout_active", "policy_denied"} {
+		if !strings.Contains(audit, want) {
+			t.Fatalf("audit missing %q: %s", want, audit)
+		}
+	}
+}
+
 func TestLockedBackendResolveDoesNotRevealValues(t *testing.T) {
 	backend := testBackend(t)
 	_, err := backend.writeSecret(writeSecretRequest{Ref: "openclaw/anthropic/api_key", Value: "secret-value"})

--- a/cmd/secretsbroker/session.go
+++ b/cmd/secretsbroker/session.go
@@ -127,16 +127,23 @@ func (s localAPISecurity) auditOutcome(operation, outcome string) {
 }
 
 func writeLockoutAPIError(w http.ResponseWriter, decision lockoutDecision) {
+	writeScopedLockoutAPIError(w, decision.Scope, decision.RetryAfterSeconds, "Local API authentication is temporarily locked for this scope.")
+}
+
+func writeScopedLockoutAPIError(w http.ResponseWriter, scope string, retryAfterSeconds int, message string) {
+	if strings.TrimSpace(message) == "" {
+		message = "Operation is temporarily locked for this scope."
+	}
 	writeJSON(w, http.StatusLocked, ErrorEnvelope{Error: APIError{
 		Code:              "lockout_active",
-		Message:           "Local API authentication is temporarily locked for this scope.",
+		Message:           message,
 		Outcome:           "policy_denied",
 		NextAction:        "wait_or_clear_lockout",
 		AffectedRefs:      []string{},
 		AffectedServices:  []string{},
 		LockoutActive:     true,
-		LockoutScope:      decision.Scope,
-		RetryAfterSeconds: decision.RetryAfterSeconds,
+		LockoutScope:      scope,
+		RetryAfterSeconds: retryAfterSeconds,
 	}})
 }
 

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -66,6 +66,14 @@ Repeated policy-denied management reveal/apply attempts are also tracked with na
 
 Three denied attempts for the same management operation/ref/service start the same five-minute cooldown. The cooldown blocks that exact reveal/apply scope while unrelated refs, unrelated operations, and read-only status/list/dry-run surfaces remain available.
 
+Repeated write-back failures for launch identity, write-back policy, and provider/source auth state are tracked with similarly narrow scopes:
+
+- `writeback:identity:<operation>:<serviceId>:<ref>`
+- `writeback:policy:<operation>:<serviceId>:<ref>`
+- `writeback:source_auth:<operation>:<serviceId>:<ref>`
+
+Three failures for the same write-back operation/ref/service start a five-minute cooldown for that exact write-back scope. The cooldown does not block unrelated refs, unrelated operations, local status endpoints, management list/search surfaces, or other services.
+
 Secret-bearing endpoints cap request bodies at 1 MiB before JSON decode. Oversized requests return `413 request_too_large` with a safe fixed message; request content and bearer tokens are not echoed.
 
 ## CLI helpers
@@ -141,6 +149,26 @@ Management reveal/apply lockout response:
 ```
 
 The management lockout response never includes raw secret values, submitted replacement values, provider credentials, local API tokens, auth headers, private keys, cookies, passwords, or environment values.
+
+Write-back lockout response:
+
+```json
+{
+  "error": {
+    "code": "lockout_active",
+    "message": "Write-back is temporarily locked for this scope.",
+    "outcome": "policy_denied",
+    "nextAction": "wait_or_clear_lockout",
+    "affectedRefs": [],
+    "affectedServices": [],
+    "lockoutActive": true,
+    "lockoutScope": "writeback:source_auth:create:api-service:services/api-service/runtime/API_TOKEN",
+    "retryAfterSeconds": 300
+  }
+}
+```
+
+The write-back lockout response never includes generated replacement values, source/provider credentials, local API tokens, auth headers, private keys, cookies, passwords, environment values, or raw provider output.
 
 No server token configured:
 

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -198,7 +198,14 @@ Implemented management-denial slice:
 - Three denied attempts for the same management scope start a five-minute cooldown for that exact reveal/apply operation.
 - Active management lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
 - Unrelated refs, unrelated management operations, and safe read-only status/list/dry-run surfaces remain available during the cooldown.
-- Provider/source, service-identity, and audited admin-clear persistence are follow-up slices under #66.
+
+Implemented write-back identity/source-auth slice:
+
+- Repeated write-back launch identity failures, write-back policy denials, and source/provider auth-required outcomes are tracked in memory by family, operation, service id, and safe ref handle.
+- Three failures for the same write-back scope start a five-minute cooldown for that exact write-back operation.
+- Active write-back lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
+- Unrelated refs, unrelated operations, local status endpoints, and safe management list/search surfaces remain available during the cooldown.
+- Durable audited admin-clear persistence and broader provider-specific credential lockout surfaces are follow-up slices under #66.
 
 ## API/backend mapping
 


### PR DESCRIPTION
Refs #66

## Summary
- add scoped write-back lockouts for launch identity failures, policy denials, and source/provider auth-required outcomes
- return metadata-only lockout responses with scope and retry metadata for write-back HTTP calls
- document the write-back lockout scopes and no-secret response guarantees

## Validation
- `go test ./cmd/secretsbroker`
- `go test ./...`
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- `git diff --check`

## Safety
- Lockout scope includes only family, operation, service id, and safe ref handle.
- Tests assert generated values, local API tokens, and sensitive input do not appear in lockout responses or audit output.