### PR TITLE
feat(lockout): add audited management clear endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The first bootstrap slice provides:
   - `POST /v1/writeback`
   - `POST /v1/resolve`
   - `GET /v1/sources/status`
+  - `POST /v1/management/lockouts/clear`
 - CLI-style commands:
   - `secretsbroker serve`
   - `secretsbroker-resolve`

--- a/cmd/secretsbroker/events.go
+++ b/cmd/secretsbroker/events.go
@@ -117,6 +117,10 @@ func eventFamily(audit auditEvent) string {
 		return "audit_unavailable"
 	}
 	switch {
+	case audit.Operation == "lockout_clear":
+		return "lockout_cleared"
+	case strings.Contains(audit.Operation, "lockout"):
+		return "lockout_started"
 	case audit.Operation == "policy_decision":
 		return "policy_decision"
 	case audit.Operation == "source_lifecycle" && audit.Outcome == "ready":
@@ -142,7 +146,7 @@ func eventFamily(audit auditEvent) string {
 
 func eventSeverity(outcome string) string {
 	switch outcome {
-	case "ready", "allowed":
+	case "ready", "allowed", "cleared", "not_found":
 		return "info"
 	case "degraded", "invalid_ref", "identity_expired":
 		return "error"

--- a/cmd/secretsbroker/local_store_http_test.go
+++ b/cmd/secretsbroker/local_store_http_test.go
@@ -78,6 +78,83 @@ func TestHTTPGeneratedSecretWritebackLockoutResponseIsMetadataOnly(t *testing.T)
 	}
 }
 
+func TestHTTPManagementLockoutClearRequiresReasonAndClearsScope(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/@serviceadmin/runtime/API_TOKEN"
+	writeManagedTestSecret(t, backend, ref, "management-clear-secret")
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	deniedBody := []byte(`{"requestId":"req-reveal-denied","serviceId":"@serviceadmin","ref":"` + ref + `"}`)
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, payload := postJSON(t, server.URL+"/v1/management/secrets/reveal", "test-token", deniedBody)
+		if i < localAPILockoutThreshold {
+			if res.StatusCode != http.StatusForbidden {
+				t.Fatalf("attempt %d status=%d body=%s", i, res.StatusCode, payload)
+			}
+			continue
+		}
+		if res.StatusCode != http.StatusLocked || !bytes.Contains(payload, []byte(`"lockoutActive":true`)) {
+			t.Fatalf("lockout status=%d body=%s", res.StatusCode, payload)
+		}
+		assertNoSecretMaterial(t, payload, "management-clear-secret", "test-token")
+	}
+
+	scope := "management:reveal:@serviceadmin:" + ref
+	missingReason := []byte(`{"requestId":"req-clear-denied","serviceId":"@operator","scope":"` + scope + `"}`)
+	res, payload := postJSON(t, server.URL+"/v1/management/lockouts/clear", "test-token", missingReason)
+	if res.StatusCode != http.StatusForbidden || bytes.Contains(payload, []byte("management-clear-secret")) || bytes.Contains(payload, []byte("test-token")) {
+		t.Fatalf("missing reason clear status=%d body=%s", res.StatusCode, payload)
+	}
+
+	clearBody := []byte(`{"requestId":"req-clear-ok","serviceId":"@operator","scope":"` + scope + `","reason":"operator reviewed denial"}`)
+	res, payload = postJSON(t, server.URL+"/v1/management/lockouts/clear", "test-token", clearBody)
+	if res.StatusCode != http.StatusOK || !bytes.Contains(payload, []byte(`"outcome":"cleared"`)) || !bytes.Contains(payload, []byte(`"cleared":true`)) {
+		t.Fatalf("clear status=%d body=%s", res.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, "management-clear-secret", "test-token")
+
+	revealBody := []byte(`{"requestId":"req-reveal-ok","serviceId":"@serviceadmin","ref":"` + ref + `","reason":"operator check","confirm":true,"noEcho":true}`)
+	res, payload = postJSON(t, server.URL+"/v1/management/secrets/reveal", "test-token", revealBody)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("post-clear reveal status=%d body=%s", res.StatusCode, payload)
+	}
+}
+
+func TestHTTPLocalAPILockoutClearAcceptsValidTokenDuringLockout(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	writeBody := []byte(`{"ref":"services/api/runtime/API_TOKEN","value":"local-api-clear-secret"}`)
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, payload := postJSON(t, server.URL+"/v1/secrets", "wrong-token", writeBody)
+		if i < localAPILockoutThreshold {
+			if res.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("attempt %d status=%d body=%s", i, res.StatusCode, payload)
+			}
+			continue
+		}
+		if res.StatusCode != http.StatusLocked || bytes.Contains(payload, []byte("wrong-token")) || bytes.Contains(payload, []byte("test-token")) {
+			t.Fatalf("local api lockout status=%d body=%s", res.StatusCode, payload)
+		}
+	}
+
+	clearBody := []byte(`{"requestId":"req-clear-local-api","serviceId":"@operator","scope":"local_api:127.0.0.1","reason":"operator verified local client"}`)
+	res, payload := postJSON(t, server.URL+"/v1/management/lockouts/clear", "test-token", clearBody)
+	if res.StatusCode != http.StatusOK || !bytes.Contains(payload, []byte(`"outcome":"cleared"`)) {
+		t.Fatalf("local api clear status=%d body=%s", res.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, "local-api-clear-secret", "test-token", "wrong-token")
+
+	res, payload = postJSON(t, server.URL+"/v1/secrets", "test-token", writeBody)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("post-clear write status=%d body=%s", res.StatusCode, payload)
+	}
+}
+
 func TestSecretBearingEndpointRejectsOversizedBodyWithoutLeakingToken(t *testing.T) {
 	backend := testBackend(t)
 	state := "ready"
@@ -106,6 +183,28 @@ func TestSecretBearingEndpointRejectsOversizedBodyWithoutLeakingToken(t *testing
 	if bytes.Contains(payload, []byte("test-token")) || bytes.Contains(payload, []byte(strings.Repeat("x", 64))) {
 		t.Fatalf("oversized error leaked sensitive input: %s", payload)
 	}
+}
+
+func postJSON(t *testing.T, url, token string, body []byte) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	payload, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res, payload
 }
 
 func TestLocalStoreHTTPWriteAndResolve(t *testing.T) {

--- a/cmd/secretsbroker/lockout.go
+++ b/cmd/secretsbroker/lockout.go
@@ -102,6 +102,17 @@ func (s *lockoutStore) recordSuccess(scope string) {
 	delete(s.entries, scope)
 }
 
+func (s *lockoutStore) clear(scope string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, existed := s.entries[scope]
+	delete(s.entries, scope)
+	return existed
+}
+
 func (s *lockoutStore) activeLocked(scope string, now time.Time) lockoutDecision {
 	entry, ok := s.entries[scope]
 	if !ok {

--- a/cmd/secretsbroker/lockout_management.go
+++ b/cmd/secretsbroker/lockout_management.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type lockoutClearRequest struct {
+	RequestID string `json:"requestId"`
+	ServiceID string `json:"serviceId"`
+	Scope     string `json:"scope"`
+	Reason    string `json:"reason"`
+}
+
+type lockoutClearResponse struct {
+	ServiceID    string `json:"serviceId"`
+	APIVersion   string `json:"apiVersion"`
+	RequestID    string `json:"requestId,omitempty"`
+	Operation    string `json:"operation"`
+	Outcome      string `json:"outcome"`
+	Cleared      bool   `json:"cleared"`
+	LockoutScope string `json:"lockoutScope"`
+	AuditStatus  string `json:"auditStatus"`
+	NextAction   string `json:"nextAction,omitempty"`
+}
+
+func clearLockout(backend *localBackend, security localAPISecurity, req lockoutClearRequest) (lockoutClearResponse, error) {
+	scope := scrubLockoutScope(req.Scope)
+	reason := scrubAuditField(req.Reason)
+	service := firstNonEmpty(req.ServiceID, "@operator")
+	res := lockoutClearResponse{
+		ServiceID:    serviceID,
+		APIVersion:   apiVersion,
+		RequestID:    req.RequestID,
+		Operation:    "lockout_clear",
+		Outcome:      "pending",
+		LockoutScope: scope,
+		AuditStatus:  "audit_pending",
+	}
+	if scope == "" || strings.TrimSpace(reason) == "" {
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_scope_and_audit_reason"
+		if backend != nil {
+			_ = backend.audit("lockout_clear", scope, res.Outcome, service, req.RequestID)
+		}
+		return res, errPolicyDenied
+	}
+
+	cleared := false
+	switch {
+	case strings.HasPrefix(scope, "local_api:"):
+		cleared = security.lockouts.clear(scope)
+	default:
+		if backend != nil && backend.lockouts != nil {
+			cleared = backend.lockouts.clear(scope)
+		}
+	}
+	res.Cleared = cleared
+	res.AuditStatus = "audit_recorded"
+	if cleared {
+		res.Outcome = "cleared"
+		res.NextAction = "retry_operation"
+	} else {
+		res.Outcome = "not_found"
+		res.NextAction = "check_lockout_scope"
+	}
+	if backend != nil {
+		_ = backend.audit("lockout_clear", scope, res.Outcome, service, req.RequestID)
+	}
+	return res, nil
+}
+
+func scrubLockoutScope(scope string) string {
+	scope = scrubAuditField(scope)
+	if scope == "" || strings.ContainsAny(scope, " \r\n\t") {
+		return ""
+	}
+	for _, prefix := range []string{"local_api:", "management:", "writeback:"} {
+		if strings.HasPrefix(scope, prefix) {
+			return scope
+		}
+	}
+	return ""
+}
+
+func registerLockoutManagementHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/management/lockouts/clear", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/management/lockouts/clear.", "invalid_ref", "")
+			return
+		}
+		if !security.requireValidToken(w, r) {
+			return
+		}
+		var req lockoutClearRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := clearLockout(backend, security, req)
+		if err != nil {
+			status := http.StatusForbidden
+			if !errors.Is(err, errPolicyDenied) {
+				status = http.StatusServiceUnavailable
+			}
+			writeJSON(w, status, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -43,6 +43,8 @@ var typedOutcomes = []string{
 	"source_unavailable",
 	"identity_expired",
 	"lockout_active",
+	"cleared",
+	"not_found",
 	"disabled",
 }
 
@@ -231,6 +233,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /v1/providers/config/status",
 			"GET /v1/telemetry",
 			"GET /v1/events",
+			"POST /v1/management/lockouts/clear",
 			"POST /v1/providers/config/validate|apply",
 			"POST /v1/providers/migration/dry-run|apply",
 			"GET /v1/management/secrets",
@@ -260,6 +263,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"redacted-telemetry",
 			"bounded-operational-events",
 			"scoped-local-api-lockout",
+			"audited-lockout-clear",
 			"provider-migration-dry-run-apply",
 			"secrets-management-metadata-search",
 			"secrets-management-value-search-metadata-only",
@@ -398,6 +402,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerProviderConfigMigrationHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)
 		registerEventsHandlers(mux, backend)
+		registerLockoutManagementHandlers(mux, backend, security)
 	}
 	return mux
 }

--- a/cmd/secretsbroker/session.go
+++ b/cmd/secretsbroker/session.go
@@ -120,6 +120,24 @@ func (s localAPISecurity) require(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
+func (s localAPISecurity) requireValidToken(w http.ResponseWriter, r *http.Request) bool {
+	expected := strings.TrimSpace(s.token)
+	if expected == "" {
+		writeAPIError(w, http.StatusServiceUnavailable, "security_not_configured", "Secret-bearing endpoints require SECRETSBROKER_API_TOKEN or --api-token.", "policy_denied", "configure_api_token")
+		return false
+	}
+	got := bearerToken(r.Header.Get("Authorization"))
+	if got == "" {
+		got = strings.TrimSpace(r.Header.Get("X-SecretsBroker-Token"))
+	}
+	if got == "" || !constantTimeTokenEqual(got, expected) {
+		s.auditOutcome("local_api_auth", "unauthorized")
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized", "A valid local API token is required.", "policy_denied", "authenticate_local_session")
+		return false
+	}
+	return true
+}
+
 func (s localAPISecurity) auditOutcome(operation, outcome string) {
 	if s.audit != nil {
 		_ = s.audit(operation, "", outcome, "@operator", "")

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -162,6 +162,7 @@ Example response:
     "GET /capabilities",
     "POST /v1/secrets",
     "POST /v1/resolve",
+    "POST /v1/management/lockouts/clear",
     "GET /v1/sources/status"
   ],
   "features": [
@@ -174,6 +175,7 @@ Example response:
     "batched-resolve",
     "typed-errors",
     "audit-redaction",
+    "audited-lockout-clear",
     "source-status"
   ],
   "futureFeatures": [

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -16,6 +16,7 @@ Secret-bearing endpoints require a local API token:
 - `POST /v1/secrets`
 - `POST /v1/writeback`
 - `POST /v1/resolve`
+- `POST /v1/management/lockouts/clear`
 
 Safe bootstrap/status endpoints remain unauthenticated:
 
@@ -75,6 +76,26 @@ Repeated write-back failures for launch identity, write-back policy, and provide
 Three failures for the same write-back operation/ref/service start a five-minute cooldown for that exact write-back scope. The cooldown does not block unrelated refs, unrelated operations, local status endpoints, management list/search surfaces, or other services.
 
 Secret-bearing endpoints cap request bodies at 1 MiB before JSON decode. Oversized requests return `413 request_too_large` with a safe fixed message; request content and bearer tokens are not echoed.
+
+## Lockout clear workflow
+
+Management clients can clear a scoped lockout with:
+
+```http
+POST /v1/management/lockouts/clear
+Authorization: Bearer <token>
+```
+
+The request body must include a lockout scope and an audit reason:
+
+```json
+{
+  "scope": "local_api:127.0.0.1",
+  "reason": "operator confirmed local token rotation"
+}
+```
+
+The endpoint requires a valid local API token even while the requested scope is locked out. Invalid or missing clear requests do not bypass token checks, and clear responses include metadata only: service id, API version, request id, scope, outcome, audit status, and next action. The audit reason is trimmed and control-character scrubbed before use. Raw secret values, presented tokens, expected tokens, auth headers, private keys, cookies, passwords, and environment values are never echoed.
 
 ## CLI helpers
 
@@ -215,7 +236,7 @@ Planned session model:
 - per-service/ref policy checks before resolve/write-back
 - lease/renew/revoke for runtime identities where applicable
 - audit events for allow/deny/resolve/write-back without plaintext values
-- durable audited lockout clear workflow for management clients
+- durable persistence for audited lockout clear records
 
 ## Non-goals for this slice
 

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -205,7 +205,13 @@ Implemented write-back identity/source-auth slice:
 - Three failures for the same write-back scope start a five-minute cooldown for that exact write-back operation.
 - Active write-back lockout responses return metadata only: `lockoutActive`, `lockoutScope`, `retryAfterSeconds`, outcome, and next action.
 - Unrelated refs, unrelated operations, local status endpoints, and safe management list/search surfaces remain available during the cooldown.
-- Durable audited admin-clear persistence and broader provider-specific credential lockout surfaces are follow-up slices under #66.
+
+Implemented management clear slice:
+
+- `POST /v1/management/lockouts/clear` clears a requested lockout scope after validating the local API token and requiring an audit reason.
+- Valid local API tokens are allowed to clear a local API lockout even while that exact scope is active; invalid tokens remain denied.
+- Clear responses and emitted events are metadata-only and include scope, outcome, audit status, and next action without raw secret values, presented tokens, expected tokens, auth headers, private keys, cookies, passwords, or environment values.
+- Durable audited admin-clear persistence and broader provider-specific credential lockout surfaces remain follow-up slices.
 
 ## API/backend mapping
 
@@ -245,7 +251,8 @@ These slices should be separate issues because they can be designed, implemented
 3. Broker redacted telemetry endpoint/CLI: [lasso-secretsbroker#64](https://github.com/service-lasso/lasso-secretsbroker/issues/64).
 4. Broker bounded event store and metadata filtering API: [lasso-secretsbroker#65](https://github.com/service-lasso/lasso-secretsbroker/issues/65).
 5. Broker scoped lockout state and audited clear workflow: [lasso-secretsbroker#66](https://github.com/service-lasso/lasso-secretsbroker/issues/66).
-6. Service Admin operational controls surfaces for policy, audit, telemetry, events, and lockout once the broker contracts exist: [lasso-serviceadmin#118](https://github.com/service-lasso/lasso-serviceadmin/issues/118).
+6. Broker management lockout clear endpoint: [lasso-secretsbroker#79](https://github.com/service-lasso/lasso-secretsbroker/issues/79).
+7. Service Admin operational controls surfaces for policy, audit, telemetry, events, and lockout once the broker contracts exist: [lasso-serviceadmin#118](https://github.com/service-lasso/lasso-serviceadmin/issues/118).
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Adds POST /v1/management/lockouts/clear for audited scoped lockout clearing.
- Requires a valid local API token and audit reason, including valid-token clear during an active local API lockout.
- Keeps responses/events metadata-only and documents the endpoint in the local API/security/bootstrap contracts.

## Validation
- git diff --check
- go test ./...
- pwsh -NoLogo -NoProfile -File .\scripts\test.ps1

Closes #79.