### PR TITLE
#58 Add recovery policy metadata contract

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -31,6 +31,7 @@ type adminStatusResponse struct {
 	State      StateResponse                `json:"state"`
 	Key        keyStatusResponse            `json:"key"`
 	Providers  providerConfigStatusResponse `json:"providers"`
+	Recovery   recoveryPolicyStatusResponse `json:"recovery"`
 }
 
 type adminAuditExportResponse struct {
@@ -60,6 +61,8 @@ func executeAdmin(args []string, out io.Writer) error {
 		return runAdminProviders(args[1:], out)
 	case "migration":
 		return runAdminMigration(args[1:], out)
+	case "recovery":
+		return runAdminRecovery(args[1:], out)
 	case "audit":
 		return runAdminAudit(args[1:], out)
 	case "telemetry":
@@ -82,7 +85,11 @@ func runAdminStatus(args []string, out io.Writer) error {
 		return err
 	}
 	statusState := normalizeAdminState(*state, backend, material)
-	res := adminStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: statusState, Health: defaultHealth(statusState), Status: defaultStatus(statusState), State: defaultState(statusState), Key: keyStatus(material), Providers: backend.providerConfigStatusResponse()}
+	recovery, recoveryErr := backend.recoveryPolicyStatus()
+	if recoveryErr != nil && statusState == "ready" {
+		statusState = "degraded"
+	}
+	res := adminStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: statusState, Health: defaultHealth(statusState), Status: defaultStatus(statusState), State: defaultState(statusState), Key: keyStatus(material), Providers: backend.providerConfigStatusResponse(), Recovery: recovery}
 	return encodeAdminJSON(out, res)
 }
 
@@ -232,6 +239,58 @@ func runAdminMigration(args []string, out io.Writer) error {
 		return encodeAdminJSON(out, res)
 	default:
 		return fmt.Errorf("unknown admin migration command %q", sub)
+	}
+}
+
+func runAdminRecovery(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin recovery command %q", "")
+	}
+	sub := args[0]
+	fs, opts := newAdminFlagSet("admin recovery " + sub)
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	policyID := fs.String("policy-id", "", "recovery policy id")
+	keyID := fs.String("key-id", "", "portable master key id")
+	keyVersion := fs.String("key-version", masterKeyVersion, "portable master key version")
+	threshold := fs.Int("threshold", 0, "threshold required to recover")
+	shareCount := fs.Int("share-count", 0, "total recovery share count")
+	status := fs.String("status", "active", "policy status: active, rotated, or revoked")
+	shareFingerprints := multiFlag{}
+	recipientFingerprints := multiFlag{}
+	fs.Var(&shareFingerprints, "share-fingerprint", "safe recovery share fingerprint; repeatable")
+	fs.Var(&recipientFingerprints, "recipient-fingerprint", "safe recipient fingerprint; repeatable")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil && !errors.Is(err, errLocked) {
+		return err
+	}
+	switch sub {
+	case "status":
+		res, err := backend.recoveryPolicyStatus()
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "enroll":
+		res, err := backend.upsertRecoveryPolicy(recoveryPolicyRequest{RequestID: *requestID, ServiceID: *service, PolicyID: *policyID, KeyID: *keyID, KeyVersion: *keyVersion, Threshold: *threshold, ShareCount: *shareCount, ShareFingerprints: []string(shareFingerprints), RecipientFingerprints: []string(recipientFingerprints), Status: *status})
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	case "revoke":
+		res, err := backend.revokeRecoveryPolicy(*policyID, *service, *requestID)
+		if err != nil {
+			_ = encodeAdminJSON(out, res)
+			return err
+		}
+		return encodeAdminJSON(out, res)
+	default:
+		return fmt.Errorf("unknown admin recovery command %q", sub)
 	}
 }
 

--- a/cmd/secretsbroker/events.go
+++ b/cmd/secretsbroker/events.go
@@ -30,6 +30,8 @@ type operationalEvent struct {
 	ServiceID  string    `json:"serviceId,omitempty"`
 	ProviderID string    `json:"providerId,omitempty"`
 	SourceID   string    `json:"sourceId,omitempty"`
+	PolicyID   string    `json:"policyId,omitempty"`
+	KeyID      string    `json:"keyId,omitempty"`
 	RefPrefix  string    `json:"refPrefix,omitempty"`
 	RefHash    string    `json:"refHash,omitempty"`
 	Outcome    string    `json:"outcome"`
@@ -103,6 +105,8 @@ func operationalEventFromAudit(audit auditEvent) operationalEvent {
 		ServiceID:  audit.ServiceID,
 		ProviderID: audit.ProviderID,
 		SourceID:   audit.SourceID,
+		PolicyID:   audit.PolicyID,
+		KeyID:      audit.KeyID,
 		RefPrefix:  safeRefPrefix(audit.Ref),
 		RefHash:    audit.RefHash,
 		Outcome:    audit.Outcome,
@@ -136,6 +140,8 @@ func eventFamily(audit auditEvent) string {
 	case strings.HasPrefix(audit.Operation, "management_"):
 		return "management_apply"
 	case strings.HasPrefix(audit.Operation, "key_"):
+		return "key_lifecycle"
+	case strings.HasPrefix(audit.Operation, "recovery_policy_"):
 		return "key_lifecycle"
 	case strings.HasPrefix(audit.Operation, "backup_"):
 		return "backup_restore"
@@ -212,6 +218,8 @@ func normalizeOperationalEvent(event operationalEvent) operationalEvent {
 	event.ServiceID = scrubAuditField(event.ServiceID)
 	event.ProviderID = scrubAuditField(event.ProviderID)
 	event.SourceID = scrubAuditField(event.SourceID)
+	event.PolicyID = scrubAuditField(event.PolicyID)
+	event.KeyID = scrubAuditField(event.KeyID)
 	event.RefPrefix = scrubAuditField(event.RefPrefix)
 	event.RefHash = scrubAuditField(event.RefHash)
 	event.Outcome = scrubAuditField(event.Outcome)

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -46,11 +46,12 @@ type localBackend struct {
 }
 
 type localStoreFile struct {
-	Version   int                    `json:"version"`
-	ServiceID string                 `json:"serviceId"`
-	CreatedAt time.Time              `json:"createdAt"`
-	UpdatedAt time.Time              `json:"updatedAt"`
-	Secrets   map[string]secretEntry `json:"secrets"`
+	Version   int                     `json:"version"`
+	ServiceID string                  `json:"serviceId"`
+	CreatedAt time.Time               `json:"createdAt"`
+	UpdatedAt time.Time               `json:"updatedAt"`
+	Secrets   map[string]secretEntry  `json:"secrets"`
+	Recovery  *recoveryPolicyMetadata `json:"recoveryPolicy,omitempty"`
 }
 
 type secretEntry struct {
@@ -166,6 +167,8 @@ type auditEvent struct {
 	RefHash     string    `json:"refHash,omitempty"`
 	ProviderID  string    `json:"providerId,omitempty"`
 	SourceID    string    `json:"sourceId,omitempty"`
+	PolicyID    string    `json:"policyId,omitempty"`
+	KeyID       string    `json:"keyId,omitempty"`
 	Outcome     string    `json:"outcome"`
 	ReasonCode  string    `json:"reasonCode"`
 	State       string    `json:"state,omitempty"`
@@ -624,6 +627,8 @@ func normalizeAuditEvent(event auditEvent) auditEvent {
 	event.Outcome = scrubAuditField(event.Outcome)
 	event.State = scrubAuditField(event.State)
 	event.SourceID = scrubAuditField(event.SourceID)
+	event.PolicyID = scrubAuditField(event.PolicyID)
+	event.KeyID = scrubAuditField(event.KeyID)
 	event.ServiceID = scrubAuditField(event.ServiceID)
 	event.RequestID = scrubAuditField(event.RequestID)
 	event.ProviderID = scrubAuditField(event.ProviderID)

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -233,6 +233,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"GET /v1/providers/config/status",
 			"GET /v1/telemetry",
 			"GET /v1/events",
+			"GET|POST /v1/recovery/policy",
 			"POST /v1/management/lockouts/clear",
 			"POST /v1/providers/config/validate|apply",
 			"POST /v1/providers/migration/dry-run|apply",
@@ -245,7 +246,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
-			"CLI secretsbroker admin status|secrets|providers|migration|audit|events",
+			"CLI secretsbroker admin status|secrets|providers|migration|recovery|audit|events",
 		},
 		Features: []string{
 			"liveness",
@@ -280,6 +281,8 @@ func defaultCapabilities() CapabilitiesResponse {
 			"master-key-initialize-unlock-import-rewrap",
 			"os-wrapper-status",
 			"master-key-rotation",
+			"recovery-policy-metadata",
+			"recovery-policy-status",
 			"headless-admin-cli",
 		},
 		FutureFeatures: []string{
@@ -400,6 +403,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerRotationHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
+		registerRecoveryPolicyHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)
 		registerEventsHandlers(mux, backend)
 		registerLockoutManagementHandlers(mux, backend, security)

--- a/cmd/secretsbroker/recovery_policy.go
+++ b/cmd/secretsbroker/recovery_policy.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var errInvalidRecoveryPolicy = errors.New("invalid recovery policy metadata")
+
+type recoveryPolicyMetadata struct {
+	PolicyID              string     `json:"policyId"`
+	KeyID                 string     `json:"keyId"`
+	KeyVersion            string     `json:"keyVersion"`
+	Threshold             int        `json:"threshold"`
+	ShareCount            int        `json:"shareCount"`
+	ShareFingerprints     []string   `json:"shareFingerprints"`
+	RecipientFingerprints []string   `json:"recipientFingerprints,omitempty"`
+	CreatedAt             time.Time  `json:"createdAt"`
+	RotatedAt             *time.Time `json:"rotatedAt,omitempty"`
+	RevokedAt             *time.Time `json:"revokedAt,omitempty"`
+	Status                string     `json:"status"`
+	NextAction            string     `json:"nextAction"`
+}
+
+type recoveryPolicyRequest struct {
+	RequestID             string     `json:"requestId,omitempty"`
+	ServiceID             string     `json:"serviceId,omitempty"`
+	PolicyID              string     `json:"policyId"`
+	KeyID                 string     `json:"keyId"`
+	KeyVersion            string     `json:"keyVersion"`
+	Threshold             int        `json:"threshold"`
+	ShareCount            int        `json:"shareCount"`
+	ShareFingerprints     []string   `json:"shareFingerprints"`
+	RecipientFingerprints []string   `json:"recipientFingerprints,omitempty"`
+	CreatedAt             *time.Time `json:"createdAt,omitempty"`
+	RotatedAt             *time.Time `json:"rotatedAt,omitempty"`
+	RevokedAt             *time.Time `json:"revokedAt,omitempty"`
+	Status                string     `json:"status,omitempty"`
+}
+
+type recoveryPolicyStatusResponse struct {
+	ServiceID  string                  `json:"serviceId"`
+	APIVersion string                  `json:"apiVersion"`
+	Outcome    string                  `json:"outcome"`
+	Policy     *recoveryPolicyMetadata `json:"policy,omitempty"`
+	NextAction string                  `json:"nextAction"`
+}
+
+func (b *localBackend) recoveryPolicyStatus() (recoveryPolicyStatusResponse, error) {
+	res := recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "setup_needed", NextAction: "enroll_recovery_policy"}
+	store, err := b.loadStore()
+	if err != nil {
+		res.Outcome = "degraded"
+		res.NextAction = "inspect_recovery_policy_state"
+		_ = b.auditRecoveryPolicy("recovery_policy_status", nil, "degraded", "", "")
+		return res, errBackendDegraded
+	}
+	if store.Recovery == nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_status", nil, "setup_needed", "", "")
+		return res, nil
+	}
+	policy, err := normalizeRecoveryPolicyRequest(recoveryPolicyRequest{
+		PolicyID:              store.Recovery.PolicyID,
+		KeyID:                 store.Recovery.KeyID,
+		KeyVersion:            store.Recovery.KeyVersion,
+		Threshold:             store.Recovery.Threshold,
+		ShareCount:            store.Recovery.ShareCount,
+		ShareFingerprints:     store.Recovery.ShareFingerprints,
+		RecipientFingerprints: store.Recovery.RecipientFingerprints,
+		CreatedAt:             &store.Recovery.CreatedAt,
+		RotatedAt:             store.Recovery.RotatedAt,
+		RevokedAt:             store.Recovery.RevokedAt,
+		Status:                store.Recovery.Status,
+	}, b.now())
+	if err != nil {
+		res.Outcome = "degraded"
+		res.NextAction = "repair_recovery_policy_metadata"
+		_ = b.auditRecoveryPolicy("recovery_policy_status", store.Recovery, "degraded", "", "")
+		return res, errInvalidRecoveryPolicy
+	}
+	res.Outcome = policy.Status
+	res.Policy = &policy
+	res.NextAction = policy.NextAction
+	_ = b.auditRecoveryPolicy("recovery_policy_status", &policy, policy.Status, "", "")
+	return res, nil
+}
+
+func (b *localBackend) upsertRecoveryPolicy(req recoveryPolicyRequest) (recoveryPolicyStatusResponse, error) {
+	res := recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "degraded", NextAction: "repair_recovery_policy_metadata"}
+	store, err := b.loadStore()
+	if err != nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_update", nil, "degraded", req.ServiceID, req.RequestID)
+		return res, errBackendDegraded
+	}
+	if req.CreatedAt == nil && store.Recovery != nil && store.Recovery.PolicyID == strings.TrimSpace(req.PolicyID) && !store.Recovery.CreatedAt.IsZero() {
+		createdAt := store.Recovery.CreatedAt
+		req.CreatedAt = &createdAt
+	}
+	policy, err := normalizeRecoveryPolicyRequest(req, b.now())
+	if err != nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_update", nil, "policy_denied", req.ServiceID, req.RequestID)
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_complete_safe_recovery_metadata"
+		return res, err
+	}
+	operation := "recovery_policy_create"
+	if store.Recovery != nil {
+		operation = "recovery_policy_update"
+	}
+	store.Recovery = &policy
+	store.UpdatedAt = b.now()
+	if err := b.saveStore(store); err != nil {
+		_ = b.auditRecoveryPolicy(operation, &policy, "degraded", req.ServiceID, req.RequestID)
+		return res, errBackendDegraded
+	}
+	_ = b.auditRecoveryPolicy(operation, &policy, policy.Status, req.ServiceID, req.RequestID)
+	return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: policy.Status, Policy: &policy, NextAction: policy.NextAction}, nil
+}
+
+func (b *localBackend) revokeRecoveryPolicy(policyID, serviceIDValue, requestID string) (recoveryPolicyStatusResponse, error) {
+	store, err := b.loadStore()
+	if err != nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_revoke", nil, "degraded", serviceIDValue, requestID)
+		return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "degraded", NextAction: "inspect_recovery_policy_state"}, errBackendDegraded
+	}
+	if store.Recovery == nil || strings.TrimSpace(policyID) == "" || store.Recovery.PolicyID != strings.TrimSpace(policyID) {
+		_ = b.auditRecoveryPolicy("recovery_policy_revoke", store.Recovery, "missing_ref", serviceIDValue, requestID)
+		return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "missing_ref", NextAction: "enroll_recovery_policy"}, errMissingRef
+	}
+	now := b.now()
+	req := recoveryPolicyRequest{
+		PolicyID:              store.Recovery.PolicyID,
+		KeyID:                 store.Recovery.KeyID,
+		KeyVersion:            store.Recovery.KeyVersion,
+		Threshold:             store.Recovery.Threshold,
+		ShareCount:            store.Recovery.ShareCount,
+		ShareFingerprints:     store.Recovery.ShareFingerprints,
+		RecipientFingerprints: store.Recovery.RecipientFingerprints,
+		CreatedAt:             &store.Recovery.CreatedAt,
+		RotatedAt:             store.Recovery.RotatedAt,
+		RevokedAt:             &now,
+		Status:                "revoked",
+		ServiceID:             serviceIDValue,
+		RequestID:             requestID,
+	}
+	policy, err := normalizeRecoveryPolicyRequest(req, now)
+	if err != nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_revoke", store.Recovery, "degraded", serviceIDValue, requestID)
+		return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "degraded", NextAction: "repair_recovery_policy_metadata"}, err
+	}
+	store.Recovery = &policy
+	store.UpdatedAt = now
+	if err := b.saveStore(store); err != nil {
+		_ = b.auditRecoveryPolicy("recovery_policy_revoke", &policy, "degraded", serviceIDValue, requestID)
+		return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "degraded", NextAction: "inspect_recovery_policy_state"}, errBackendDegraded
+	}
+	_ = b.auditRecoveryPolicy("recovery_policy_revoke", &policy, policy.Status, serviceIDValue, requestID)
+	return recoveryPolicyStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: policy.Status, Policy: &policy, NextAction: policy.NextAction}, nil
+}
+
+func normalizeRecoveryPolicyRequest(req recoveryPolicyRequest, now time.Time) (recoveryPolicyMetadata, error) {
+	policy := recoveryPolicyMetadata{
+		PolicyID:              scrubAuditField(req.PolicyID),
+		KeyID:                 scrubAuditField(req.KeyID),
+		KeyVersion:            scrubAuditField(req.KeyVersion),
+		Threshold:             req.Threshold,
+		ShareCount:            req.ShareCount,
+		ShareFingerprints:     normalizeSafeFingerprints(req.ShareFingerprints),
+		RecipientFingerprints: normalizeSafeFingerprints(req.RecipientFingerprints),
+		Status:                scrubAuditField(req.Status),
+	}
+	if policy.KeyVersion == "" {
+		policy.KeyVersion = masterKeyVersion
+	}
+	if policy.Status == "" {
+		policy.Status = "active"
+	}
+	if req.CreatedAt != nil {
+		policy.CreatedAt = req.CreatedAt.UTC()
+	} else {
+		policy.CreatedAt = now.UTC()
+	}
+	if req.RotatedAt != nil {
+		rotated := req.RotatedAt.UTC()
+		policy.RotatedAt = &rotated
+	}
+	if req.RevokedAt != nil {
+		revoked := req.RevokedAt.UTC()
+		policy.RevokedAt = &revoked
+	}
+	if policy.Status == "rotated" && policy.RotatedAt == nil {
+		rotated := now.UTC()
+		policy.RotatedAt = &rotated
+	}
+	if policy.Status == "revoked" && policy.RevokedAt == nil {
+		revoked := now.UTC()
+		policy.RevokedAt = &revoked
+	}
+	if err := validateRecoveryPolicyMetadata(policy); err != nil {
+		return recoveryPolicyMetadata{}, err
+	}
+	policy.NextAction = nextActionForRecoveryPolicy(policy)
+	return policy, nil
+}
+
+func validateRecoveryPolicyMetadata(policy recoveryPolicyMetadata) error {
+	if !validSafeMetadataID(policy.PolicyID) || !validSafeMetadataID(policy.KeyID) || !validSafeMetadataID(policy.KeyVersion) {
+		return errInvalidRecoveryPolicy
+	}
+	if policy.Threshold < 1 || policy.ShareCount < 1 || policy.Threshold > policy.ShareCount {
+		return errInvalidRecoveryPolicy
+	}
+	if len(policy.ShareFingerprints) != policy.ShareCount || hasDuplicate(policy.ShareFingerprints) {
+		return errInvalidRecoveryPolicy
+	}
+	for _, value := range append(append([]string{}, policy.ShareFingerprints...), policy.RecipientFingerprints...) {
+		if !validSafeMetadataID(value) {
+			return errInvalidRecoveryPolicy
+		}
+	}
+	switch policy.Status {
+	case "active", "rotated", "revoked":
+	default:
+		return errInvalidRecoveryPolicy
+	}
+	if policy.CreatedAt.IsZero() {
+		return errInvalidRecoveryPolicy
+	}
+	if policy.Status == "rotated" && policy.RotatedAt == nil {
+		return errInvalidRecoveryPolicy
+	}
+	if policy.Status == "revoked" && policy.RevokedAt == nil {
+		return errInvalidRecoveryPolicy
+	}
+	return nil
+}
+
+func normalizeSafeFingerprints(values []string) []string {
+	clean := make([]string, 0, len(values))
+	for _, value := range values {
+		value = scrubAuditField(value)
+		if value != "" {
+			clean = append(clean, value)
+		}
+	}
+	return clean
+}
+
+func validSafeMetadataID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 128 || strings.Contains(value, "..") {
+		return false
+	}
+	for _, r := range value {
+		if r <= 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func hasDuplicate(values []string) bool {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			return true
+		}
+		seen[value] = struct{}{}
+	}
+	return false
+}
+
+func nextActionForRecoveryPolicy(policy recoveryPolicyMetadata) string {
+	switch policy.Status {
+	case "active":
+		return "monitor_recovery_policy"
+	case "rotated":
+		return "verify_new_recovery_material"
+	case "revoked":
+		return "enroll_replacement_recovery_policy"
+	default:
+		return "repair_recovery_policy_metadata"
+	}
+}
+
+func (b *localBackend) auditRecoveryPolicy(operation string, policy *recoveryPolicyMetadata, outcome, requestServiceID, requestID string) error {
+	event := auditEvent{TS: b.now(), Operation: operation, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID}
+	if policy != nil {
+		event.PolicyID = policy.PolicyID
+		event.KeyID = policy.KeyID
+		event.State = policy.Status
+	}
+	return b.writeAuditEvent(event)
+}
+
+func registerRecoveryPolicyHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/recovery/policy", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			res, err := backend.recoveryPolicyStatus()
+			if err != nil {
+				writeJSON(w, http.StatusServiceUnavailable, res)
+				return
+			}
+			writeJSON(w, http.StatusOK, res)
+		case http.MethodPost:
+			if !security.require(w, r) {
+				return
+			}
+			var req recoveryPolicyRequest
+			dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxSecretBearingRequestBytes))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&req); err != nil {
+				writeAPIError(w, http.StatusBadRequest, "invalid_recovery_policy", "Recovery policy metadata must use the safe metadata contract.", "policy_denied", "provide_complete_safe_recovery_metadata")
+				return
+			}
+			res, err := backend.upsertRecoveryPolicy(req)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, res)
+				return
+			}
+			writeJSON(w, http.StatusOK, res)
+		default:
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET or POST /v1/recovery/policy.", "invalid_ref", "")
+		}
+	})
+}

--- a/cmd/secretsbroker/recovery_policy_test.go
+++ b/cmd/secretsbroker/recovery_policy_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRecoveryPolicyMetadataPersistsAndAuditsSafeMetadataOnly(t *testing.T) {
+	backend := testBackend(t)
+	res, err := backend.upsertRecoveryPolicy(recoveryPolicyRequest{
+		RequestID:             "req-recovery-create",
+		ServiceID:             "@operator",
+		PolicyID:              "recovery-policy-1",
+		KeyID:                 "mk-safe-key",
+		KeyVersion:            masterKeyVersion,
+		Threshold:             2,
+		ShareCount:            3,
+		ShareFingerprints:     []string{"share-fp-1", "share-fp-2", "share-fp-3"},
+		RecipientFingerprints: []string{"age-recipient-1", "age-recipient-2", "age-recipient-3"},
+		Status:                "active",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "active" || res.Policy == nil || res.Policy.NextAction != "monitor_recovery_policy" {
+		t.Fatalf("recovery create response = %#v", res)
+	}
+
+	status, err := backend.recoveryPolicyStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Policy == nil || status.Policy.PolicyID != "recovery-policy-1" || status.Policy.Threshold != 2 || len(status.Policy.ShareFingerprints) != 3 {
+		t.Fatalf("recovery status = %#v", status)
+	}
+
+	storeBytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, storeBytes, "portable-master-key-bytes", "plaintext-recovery-share", "recipient-private-key", "source-credential-value")
+	assertNoSecretMaterial(t, auditBytes, "portable-master-key-bytes", "plaintext-recovery-share", "recipient-private-key", "source-credential-value")
+	for _, want := range []string{"recovery_policy_create", "recovery_policy_status", "recovery-policy-1", "mk-safe-key"} {
+		if !bytes.Contains(auditBytes, []byte(want)) {
+			t.Fatalf("audit missing %q: %s", want, auditBytes)
+		}
+	}
+}
+
+func TestRecoveryPolicyMetadataValidationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		req  recoveryPolicyRequest
+	}{
+		{name: "missing key id", req: recoveryPolicyRequest{PolicyID: "policy", Threshold: 1, ShareCount: 1, ShareFingerprints: []string{"share-fp-1"}}},
+		{name: "threshold greater than shares", req: recoveryPolicyRequest{PolicyID: "policy", KeyID: "mk-safe", Threshold: 3, ShareCount: 2, ShareFingerprints: []string{"share-fp-1", "share-fp-2"}}},
+		{name: "missing share fingerprint", req: recoveryPolicyRequest{PolicyID: "policy", KeyID: "mk-safe", Threshold: 1, ShareCount: 2, ShareFingerprints: []string{"share-fp-1"}}},
+		{name: "duplicate share fingerprint", req: recoveryPolicyRequest{PolicyID: "policy", KeyID: "mk-safe", Threshold: 1, ShareCount: 2, ShareFingerprints: []string{"share-fp-1", "share-fp-1"}}},
+		{name: "bad status", req: recoveryPolicyRequest{PolicyID: "policy", KeyID: "mk-safe", Threshold: 1, ShareCount: 1, ShareFingerprints: []string{"share-fp-1"}, Status: "plaintext"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := testBackend(t)
+			res, err := backend.upsertRecoveryPolicy(tt.req)
+			if !errors.Is(err, errInvalidRecoveryPolicy) || res.Outcome != "policy_denied" {
+				t.Fatalf("err=%v res=%#v", err, res)
+			}
+			status, statusErr := backend.recoveryPolicyStatus()
+			if statusErr != nil || status.Policy != nil || status.Outcome != "setup_needed" {
+				t.Fatalf("invalid metadata should not persist, status=%#v err=%v", status, statusErr)
+			}
+		})
+	}
+}
+
+func TestHTTPRecoveryPolicyRejectsUnknownSecretMaterialField(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"policyId":"recovery-policy-1","keyId":"mk-safe-key","threshold":1,"shareCount":1,"shareFingerprints":["share-fp-1"],"recoveryShare":"plaintext-recovery-share"}`)
+	res, payload := postJSON(t, server.URL+"/v1/recovery/policy", "test-token", body)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unknown secret field status=%d body=%s", res.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, "plaintext-recovery-share", "test-token")
+
+	statusRes, err := http.Get(server.URL + "/v1/recovery/policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer statusRes.Body.Close()
+	statusPayload, err := io.ReadAll(statusRes.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusRes.StatusCode != http.StatusOK || !bytes.Contains(statusPayload, []byte(`"outcome":"setup_needed"`)) {
+		t.Fatalf("status after rejection code=%d body=%s", statusRes.StatusCode, statusPayload)
+	}
+	assertNoSecretMaterial(t, statusPayload, "plaintext-recovery-share", "test-token")
+}
+
+func TestRecoveryPolicyHTTPAndCLIStatusExposeSafeLifecycle(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-http-recovery","serviceId":"@operator","policyId":"policy-http","keyId":"mk-http-safe","threshold":2,"shareCount":2,"shareFingerprints":["share-fp-a","share-fp-b"],"recipientFingerprints":["age-recipient-a","age-recipient-b"]}`)
+	res, payload := postJSON(t, server.URL+"/v1/recovery/policy", "test-token", body)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("enroll status=%d body=%s", res.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, "test-token", "portable-master-key-bytes")
+
+	var cli bytes.Buffer
+	if err := executeAdmin([]string{"recovery", "status", "--store", backend.storePath, "--audit", backend.auditPath}, &cli); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, cli.Bytes(), "test-token", "portable-master-key-bytes")
+	if !bytes.Contains(cli.Bytes(), []byte(`"policyId": "policy-http"`)) || !bytes.Contains(cli.Bytes(), []byte(`"nextAction": "monitor_recovery_policy"`)) {
+		t.Fatalf("cli recovery status missing lifecycle metadata: %s", cli.String())
+	}
+
+	var adminStatus bytes.Buffer
+	if err := executeAdmin([]string{"status", "--store", backend.storePath, "--audit", backend.auditPath, "--master-key", "test-master-key"}, &adminStatus); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, adminStatus.Bytes(), "test-token", "portable-master-key-bytes")
+	if !strings.Contains(adminStatus.String(), `"recovery"`) || !strings.Contains(adminStatus.String(), `"policy-http"`) {
+		t.Fatalf("admin status missing recovery metadata: %s", adminStatus.String())
+	}
+}
+
+func TestRecoveryPolicyRevokeSetsSafeLifecycleState(t *testing.T) {
+	backend := testBackend(t)
+	if _, err := backend.upsertRecoveryPolicy(recoveryPolicyRequest{PolicyID: "policy-revoke", KeyID: "mk-revoke", Threshold: 1, ShareCount: 1, ShareFingerprints: []string{"share-fp-1"}}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := backend.revokeRecoveryPolicy("policy-revoke", "@operator", "req-revoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "revoked" || res.Policy == nil || res.Policy.RevokedAt == nil || res.NextAction != "enroll_replacement_recovery_policy" {
+		t.Fatalf("revoke response = %#v", res)
+	}
+}

--- a/docs/headless-admin-cli.md
+++ b/docs/headless-admin-cli.md
@@ -10,7 +10,7 @@ Headless/server operators need a safe CLI surface for Secrets Broker when Servic
 
 ## Safety defaults
 
-- Status, list, search, provider status, migration dry-run, and audit export output metadata only.
+- Status, list, search, provider status, recovery policy status, migration dry-run, and audit export output metadata only.
 - Provider credentials, portable master keys, wrapper plaintext, raw env values, tokens, passwords, cookies, private keys, and secret values are never printed by default.
 - Raw secret values are printed only by `admin secrets reveal` when all of these are present:
   - a valid ref
@@ -95,6 +95,24 @@ secretsbroker admin migration dry-run `
 ```
 
 Migration dry-run is metadata-only. Apply requires `--confirm`, `--operation-id`, and `--reason` and still does not print raw values.
+
+### Recovery policy metadata
+
+```powershell
+secretsbroker admin recovery enroll `
+  --policy-id recovery-policy-1 `
+  --key-id mk-safe-key `
+  --threshold 2 `
+  --share-count 3 `
+  --share-fingerprint share-fp-1 `
+  --share-fingerprint share-fp-2 `
+  --share-fingerprint share-fp-3
+
+secretsbroker admin recovery status
+secretsbroker admin recovery revoke --policy-id recovery-policy-1
+```
+
+Recovery policy commands persist and report safe lifecycle metadata only: policy id, key id fingerprint, threshold, share count, share fingerprints, optional recipient fingerprints, timestamps, status, and next action. They do not generate, import, print, or persist portable master key bytes, recovery share contents, private keys, passphrases, API tokens, source credentials, or plaintext secret values.
 
 ### Audit export
 

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -162,6 +162,7 @@ Example response:
     "GET /capabilities",
     "POST /v1/secrets",
     "POST /v1/resolve",
+    "GET|POST /v1/recovery/policy",
     "POST /v1/management/lockouts/clear",
     "GET /v1/sources/status"
   ],
@@ -176,6 +177,8 @@ Example response:
     "typed-errors",
     "audit-redaction",
     "audited-lockout-clear",
+    "recovery-policy-metadata",
+    "recovery-policy-status",
     "source-status"
   ],
   "futureFeatures": [
@@ -195,6 +198,59 @@ Example response:
   ]
 }
 ```
+
+## Recovery policy metadata contract
+
+Endpoint:
+
+```text
+GET /v1/recovery/policy
+POST /v1/recovery/policy
+```
+
+`GET` returns safe recovery lifecycle metadata. `POST` requires local API authentication and creates or updates the metadata contract. This endpoint records metadata only; it does not accept, generate, import, or return recovery shares, portable master key bytes, recipient private keys, passphrases, source credentials, API tokens, or plaintext secret values.
+
+Request:
+
+```json
+{
+  "requestId": "01HV...",
+  "serviceId": "@operator",
+  "policyId": "recovery-policy-1",
+  "keyId": "mk-safe-key",
+  "keyVersion": "v1",
+  "threshold": 2,
+  "shareCount": 3,
+  "shareFingerprints": ["share-fp-1", "share-fp-2", "share-fp-3"],
+  "recipientFingerprints": ["age-recipient-1", "age-recipient-2", "age-recipient-3"],
+  "status": "active"
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "outcome": "active",
+  "policy": {
+    "policyId": "recovery-policy-1",
+    "keyId": "mk-safe-key",
+    "keyVersion": "v1",
+    "threshold": 2,
+    "shareCount": 3,
+    "shareFingerprints": ["share-fp-1", "share-fp-2", "share-fp-3"],
+    "recipientFingerprints": ["age-recipient-1", "age-recipient-2", "age-recipient-3"],
+    "createdAt": "2026-06-07T00:00:00Z",
+    "status": "active",
+    "nextAction": "monitor_recovery_policy"
+  },
+  "nextAction": "monitor_recovery_policy"
+}
+```
+
+Invalid or incomplete metadata fails closed with `policy_denied` and `provide_complete_safe_recovery_metadata`. Corrupted stored metadata reports `degraded` and `repair_recovery_policy_metadata`.
 
 ## Batched resolve contract
 

--- a/docs/secure-initialization-recovery.md
+++ b/docs/secure-initialization-recovery.md
@@ -8,7 +8,9 @@ Service id: `@secretsbroker`
 
 This note defines the recommended initialization and recovery-key model for the local-first Secrets Broker. It answers whether PGP-based initialization should be the primary path, how operators can initialize without Keybase, how recovery material should be generated and stored, and what must stay out of UI, logs, diagnostics, and support artifacts.
 
-This is a design contract, not a production-readiness claim. The implemented foundation remains the portable master key, local encrypted store, local wrapper, backup/restore, and rotation flows documented in `docs/portable-master-key.md`, `docs/master-key-lifecycle.md`, `docs/backup-restore-rotation.md`, and `docs/threat-model.md`.
+This is a design contract, not a production-readiness claim. The implemented foundation remains the portable master key, local encrypted store, local wrapper, backup/restore, rotation flows, and recovery policy metadata surfaces documented in `docs/portable-master-key.md`, `docs/master-key-lifecycle.md`, `docs/backup-restore-rotation.md`, `docs/local-api-bootstrap-contract.md`, and `docs/threat-model.md`.
+
+Current implementation note for #58: the broker persists and reports recovery policy/share metadata through API and CLI status surfaces. It still does not generate threshold shares, import shares, or create recipient envelopes; those remain follow-up implementation slices.
 
 ## Recommendation
 


### PR DESCRIPTION
## Summary
- add safe recovery policy/share metadata persistence, status, API, and admin CLI surfaces
- add recovery policy audit/event metadata without recovery material
- document recovery metadata API/CLI boundaries

## Validation
- git diff --check
- go test ./...
- ./scripts/test.ps1

Closes #58