### PR TITLE
fix(#53): harden exec source adapter diagnostics

### DIFF
--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -125,7 +125,7 @@ func defaultProviderCapabilities() []providerCapability {
 		{ProviderKind: "openbao", DisplayName: "OpenBao", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
 		{ProviderKind: "env", DisplayName: "Environment variables", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 		{ProviderKind: "file", DisplayName: "File source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
-		{ProviderKind: "exec", DisplayName: "Exec source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
+		{ProviderKind: "exec", DisplayName: "Exec source", Supported: true, Capabilities: []string{"read", "reveal", "health", "audit", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 	}
 }
 

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -152,27 +152,30 @@ func (s sourceConfig) resolveExec(refCfg sourceRefConfig) sourceResolveResult {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, refCfg.Command, refCfg.Args...)
 	cmd.Env = []string{}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	stdout := newBoundedOutput(maxStdout)
+	cmd.Stdout = stdout
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source timed out."}
 	}
 	if err != nil {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source failed."}
 	}
-	if len(out) > maxStdout {
+	if stdout.Exceeded() {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source stdout exceeded limit."}
 	}
+	out := stdout.Bytes()
 	value := ""
 	if refCfg.UnsafeStdout {
 		value = strings.TrimSpace(string(out))
 	} else {
-		var payload struct {
-			Value string `json:"value"`
-		}
+		var payload execSourceProtocolPayload
 		if err := json.Unmarshal(out, &payload); err != nil {
 			return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source did not return JSON value protocol."}
+		}
+		if outcome := normalizeExecProtocolOutcome(payload.Outcome); outcome != "" && outcome != "ready" {
+			return sourceResolveResult{Outcome: outcome, Message: execProtocolOutcomeMessage(outcome)}
 		}
 		value = strings.TrimSpace(payload.Value)
 	}
@@ -180,6 +183,65 @@ func (s sourceConfig) resolveExec(refCfg sourceRefConfig) sourceResolveResult {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Exec source returned empty value."}
 	}
 	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+type execSourceProtocolPayload struct {
+	Value   string `json:"value"`
+	Outcome string `json:"outcome"`
+}
+
+type boundedOutput struct {
+	limit int
+	buf   bytes.Buffer
+}
+
+func newBoundedOutput(limit int) *boundedOutput {
+	return &boundedOutput{limit: firstPositive(limit, 4096)}
+}
+
+func (w *boundedOutput) Write(p []byte) (int, error) {
+	remaining := w.limit + 1 - w.buf.Len()
+	if remaining > 0 {
+		if len(p) < remaining {
+			remaining = len(p)
+		}
+		_, _ = w.buf.Write(p[:remaining])
+	}
+	return len(p), nil
+}
+
+func (w *boundedOutput) Bytes() []byte {
+	return w.buf.Bytes()
+}
+
+func (w *boundedOutput) Exceeded() bool {
+	return w.buf.Len() > w.limit
+}
+
+func normalizeExecProtocolOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "", "ready":
+		return strings.TrimSpace(outcome)
+	case "source_auth_required", "policy_denied", "missing_ref", "source_unavailable", "invalid_ref":
+		return strings.TrimSpace(outcome)
+	default:
+		return "source_unavailable"
+	}
+}
+
+func execProtocolOutcomeMessage(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "Exec source reported authentication is required."
+	case "policy_denied":
+		return "Exec source policy denied access."
+	case "missing_ref":
+		return "Exec source reported the ref was not found."
+	case "invalid_ref":
+		return "Exec source protocol mapping is invalid."
+	default:
+		return "Exec source reported unavailable state."
+	}
 }
 
 func (s sourceConfig) resolveVault(refCfg sourceRefConfig) sourceResolveResult {

--- a/cmd/secretsbroker/source_adapters_test.go
+++ b/cmd/secretsbroker/source_adapters_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestEnvSourceAdapter(t *testing.T) {
@@ -51,4 +53,141 @@ func TestExecSourceRejectsUntrustedCommand(t *testing.T) {
 	if res.Outcome != "invalid_ref" {
 		t.Fatalf("exec result = %#v", res)
 	}
+}
+
+func TestExecSourceAdapterJSONProtocolSuccess(t *testing.T) {
+	cfg, refCfg := execSourceFixture(t, "success-json")
+	res := cfg.resolve("ref", refCfg)
+	if res.Outcome != "ready" || res.Value != "exec-secret" {
+		t.Fatalf("exec result = %#v", res)
+	}
+}
+
+func TestExecSourceAdapterNormalizesProtocolOutcomes(t *testing.T) {
+	cases := []struct {
+		name        string
+		mode        string
+		wantOutcome string
+	}{
+		{name: "auth required", mode: "auth-required", wantOutcome: "source_auth_required"},
+		{name: "missing ref", mode: "missing-ref", wantOutcome: "missing_ref"},
+		{name: "policy denied", mode: "policy-denied", wantOutcome: "policy_denied"},
+		{name: "invalid mapping", mode: "invalid-ref", wantOutcome: "invalid_ref"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, refCfg := execSourceFixture(t, tc.mode)
+			res := cfg.resolve("ref", refCfg)
+			if res.Outcome != tc.wantOutcome || res.Value != "" {
+				t.Fatalf("exec result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+		})
+	}
+}
+
+func TestExecSourceAdapterRejectsInvalidProtocolWithoutLeakingOutput(t *testing.T) {
+	cfg, refCfg := execSourceFixture(t, "invalid-json")
+	res := cfg.resolve("ref", refCfg)
+	if res.Outcome != "source_unavailable" || res.Value != "" {
+		t.Fatalf("exec result = %#v", res)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+}
+
+func TestExecSourceAdapterBoundsStdoutWithoutLeakingOutput(t *testing.T) {
+	cfg, refCfg := execSourceFixture(t, "oversized")
+	refCfg.MaxStdoutBytes = 16
+	res := cfg.resolve("ref", refCfg)
+	if res.Outcome != "source_unavailable" || res.Value != "" {
+		t.Fatalf("exec result = %#v", res)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+}
+
+func TestExecSourceAdapterHandlesFailureAndTimeoutWithoutLeakingOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{name: "command failure", mode: "failure"},
+		{name: "timeout", mode: "timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, refCfg := execSourceFixture(t, tc.mode)
+			refCfg.TimeoutMs = 50
+			res := cfg.resolve("ref", refCfg)
+			if res.Outcome != "source_unavailable" || res.Value != "" {
+				t.Fatalf("exec result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+		})
+	}
+}
+
+func TestExecSourceStatusReportsContractCapabilities(t *testing.T) {
+	caps := capabilitiesForSourceKind("exec")
+	for _, capability := range []string{"read", "reveal", "audit", "migration", "health"} {
+		assertContains(t, caps, capability)
+	}
+}
+
+func execSourceFixture(t *testing.T, mode string) (sourceConfig, sourceRefConfig) {
+	t.Helper()
+	command, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := sourceConfig{
+		SourceID:            "exec-local",
+		Kind:                "exec",
+		Enabled:             true,
+		TrustedDirs:         []string{filepath.Dir(command)},
+		AllowSymlinkCommand: true,
+	}
+	refCfg := sourceRefConfig{
+		Command:        command,
+		Args:           []string{"-test.run=TestExecSourceHelperProcess", "--", mode},
+		TimeoutMs:      2000,
+		MaxStdoutBytes: 4096,
+	}
+	return source, refCfg
+}
+
+func TestExecSourceHelperProcess(t *testing.T) {
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		return
+	}
+	switch args[separator+1] {
+	case "success-json":
+		os.Stdout.WriteString(`{"value":"exec-secret"}`)
+	case "auth-required":
+		os.Stdout.WriteString(`{"outcome":"source_auth_required","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+	case "missing-ref":
+		os.Stdout.WriteString(`{"outcome":"missing_ref","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE"}`)
+	case "policy-denied":
+		os.Stdout.WriteString(`{"outcome":"policy_denied","message":"-----BEGIN SERVICE LASSO FAKE PRIVATE KEY-----"}`)
+	case "invalid-ref":
+		os.Stdout.WriteString(`{"outcome":"invalid_ref","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+	case "invalid-json":
+		os.Stdout.WriteString(`not-json SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+	case "oversized":
+		os.Stdout.WriteString(strings.Repeat("A", 64) + "SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE")
+	case "failure":
+		os.Stdout.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+		os.Stderr.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE`)
+		os.Exit(2)
+	case "timeout":
+		time.Sleep(2 * time.Second)
+	}
+	os.Exit(0)
 }

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -95,7 +95,7 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 	if !source.Enabled {
 		return disabledSourceLifecycle()
 	}
-	switch source.Kind {
+	switch strings.ToLower(strings.TrimSpace(source.Kind)) {
 	case "env", "file", "exec":
 		if len(source.Refs) == 0 {
 			return normalizeSourceLifecycle("missing_ref")
@@ -114,8 +114,14 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 }
 
 func capabilitiesForSourceKind(kind string) []string {
-	switch kind {
-	case "env", "file", "exec", "vault", "openbao":
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "exec":
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "audit", "migration", "health"}
+	case "env", "file", "vault", "openbao":
 		return []string{"read", "health"}
 	default:
 		return []string{"health"}


### PR DESCRIPTION
## Summary
- bound exec source stdout and discard stderr so command output is never echoed in diagnostics
- normalize exec JSON protocol outcomes for auth-required, missing-ref, policy-denied, invalid mapping, unavailable, timeout, failure, and oversized output states
- advertise exec read/reveal/audit/migration capability metadata and add fake executable no-leak tests

## Validation
- `go test ./cmd/secretsbroker`
- `go test ./...`

Closes #53