### PR TITLE
fix #52 harden file source adapter

### DIFF
--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -42,6 +42,7 @@ type sourceRefConfig struct {
 	Path           string   `json:"path"`
 	Command        string   `json:"command"`
 	Args           []string `json:"args"`
+	MaxBytes       int      `json:"maxBytes"`
 	TimeoutMs      int      `json:"timeoutMs"`
 	MaxStdoutBytes int      `json:"maxStdoutBytes"`
 	UnsafeStdout   bool     `json:"unsafeStdout"`
@@ -106,7 +107,7 @@ func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveR
 	case "env":
 		return resolveEnv(refCfg)
 	case "file":
-		return resolveFile(refCfg)
+		return s.resolveFile(refCfg)
 	case "exec":
 		return s.resolveExec(refCfg)
 	case "vault", "openbao":
@@ -127,19 +128,58 @@ func resolveEnv(refCfg sourceRefConfig) sourceResolveResult {
 	return sourceResolveResult{Outcome: "ready", Value: value}
 }
 
-func resolveFile(refCfg sourceRefConfig) sourceResolveResult {
-	if strings.TrimSpace(refCfg.Path) == "" {
-		return sourceResolveResult{Outcome: "invalid_ref", Message: "File source mapping is missing path."}
+func (s sourceConfig) resolveFile(refCfg sourceRefConfig) sourceResolveResult {
+	if err := validateFileConfig(s, refCfg); err != nil {
+		if errors.Is(err, errFilePathOutsideTrustedDirs) {
+			return sourceResolveResult{Outcome: "policy_denied", Message: "File source path is outside trustedDirs."}
+		}
+		return sourceResolveResult{Outcome: "invalid_ref", Message: err.Error()}
 	}
-	bytes, err := os.ReadFile(refCfg.Path)
+	maxBytes := firstPositive(refCfg.MaxBytes, firstPositive(refCfg.MaxStdoutBytes, 65536))
+	file, err := os.Open(refCfg.Path)
 	if err != nil {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file could not be read."}
+	}
+	defer file.Close()
+	bytes, err := io.ReadAll(io.LimitReader(file, int64(maxBytes)+1))
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file could not be read."}
+	}
+	if len(bytes) > maxBytes {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file exceeded byte limit."}
 	}
 	value := strings.TrimSpace(string(bytes))
 	if value == "" {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Mapped file is empty."}
 	}
 	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+var errFilePathOutsideTrustedDirs = errors.New("file path is outside trustedDirs")
+
+func validateFileConfig(source sourceConfig, refCfg sourceRefConfig) error {
+	path := strings.TrimSpace(refCfg.Path)
+	if path == "" {
+		return errors.New("file source mapping is missing path")
+	}
+	if len(source.TrustedDirs) == 0 {
+		return nil
+	}
+	cleanPath, err := filepath.Abs(path)
+	if err != nil {
+		return errors.New("file source path is invalid")
+	}
+	for _, dir := range source.TrustedDirs {
+		cleanDir, err := filepath.Abs(strings.TrimSpace(dir))
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(cleanDir, cleanPath)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return nil
+		}
+	}
+	return errFilePathOutsideTrustedDirs
 }
 
 func (s sourceConfig) resolveExec(refCfg sourceRefConfig) sourceResolveResult {

--- a/cmd/secretsbroker/source_adapters_test.go
+++ b/cmd/secretsbroker/source_adapters_test.go
@@ -73,6 +73,82 @@ func TestFileSourceAdapter(t *testing.T) {
 	}
 }
 
+func TestFileSourceAdapterNormalizesFailuresWithoutLeakingContents(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret.txt")
+	oversizedPath := filepath.Join(dir, "oversized.txt")
+	emptyPath := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(secretPath, []byte("SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oversizedPath, []byte("0123456789SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(emptyPath, []byte(" \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := sourceConfigFile{Sources: []sourceConfig{{
+		SourceID:    "file-local",
+		Kind:        "file",
+		Enabled:     true,
+		TrustedDirs: []string{dir},
+		Refs: map[string]sourceRefConfig{
+			"openclaw/empty":      {Path: emptyPath},
+			"openclaw/invalid":    {Path: " "},
+			"openclaw/missing":    {Path: filepath.Join(dir, "missing.txt")},
+			"openclaw/oversized":  {Path: oversizedPath, MaxBytes: 8},
+			"openclaw/ready":      {Path: secretPath},
+			"openclaw/unreadable": {Path: dir},
+			"openclaw/untrusted":  {Path: filepath.Join(t.TempDir(), "outside.txt")},
+		},
+	}}}
+
+	tests := []struct {
+		ref         string
+		wantOutcome string
+		wantState   string
+	}{
+		{ref: "openclaw/empty", wantOutcome: "source_unavailable", wantState: "degraded"},
+		{ref: "openclaw/invalid", wantOutcome: "invalid_ref", wantState: "config_error"},
+		{ref: "openclaw/missing", wantOutcome: "source_unavailable", wantState: "degraded"},
+		{ref: "openclaw/oversized", wantOutcome: "source_unavailable", wantState: "degraded"},
+		{ref: "openclaw/unreadable", wantOutcome: "source_unavailable", wantState: "degraded"},
+		{ref: "openclaw/untrusted", wantOutcome: "policy_denied", wantState: "denied"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.ref, func(t *testing.T) {
+			res := cfg.resolve(tc.ref)
+			if res.Outcome != tc.wantOutcome || res.Lifecycle.State != tc.wantState || res.Value != "" {
+				t.Fatalf("file result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{
+				"message":    res.Message,
+				"sourceID":   res.SourceID,
+				"outcome":    res.Outcome,
+				"state":      res.Lifecycle.State,
+				"nextAction": res.Lifecycle.NextAction,
+			})
+		})
+	}
+
+	ready := cfg.resolve("openclaw/ready")
+	if ready.Outcome != "ready" || ready.Value == "" {
+		t.Fatalf("ready file result = %#v", ready)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": ready.Message})
+}
+
+func TestFileSourceStatusReportsContractCapabilities(t *testing.T) {
+	caps := capabilitiesForSourceKind("file")
+	for _, capability := range []string{"read", "reveal", "migration", "health"} {
+		assertContains(t, caps, capability)
+	}
+	for _, capability := range []string{"write/update", "rotate/reset", "policy", "value-search", "audit"} {
+		assertNotContains(t, caps, capability)
+	}
+}
+
 func TestSourcePriorityAndMissing(t *testing.T) {
 	t.Setenv("LOW", "low")
 	t.Setenv("HIGH", "high")

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -127,7 +127,13 @@ func capabilitiesForSourceKind(kind string) []string {
 			return append(adapterCapabilityNames(contract.Capabilities), "health")
 		}
 		return []string{"read", "reveal", "migration", "health"}
-	case "file", "vault", "openbao":
+	case "file":
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "migration", "health"}
+	case "vault", "openbao":
 		return []string{"read", "health"}
 	default:
 		return []string{"health"}

--- a/docs/env-file-exec-sources.md
+++ b/docs/env-file-exec-sources.md
@@ -51,8 +51,12 @@ Example:
       "kind": "file",
       "enabled": true,
       "priority": 20,
+      "trustedDirs": ["./secrets"],
       "refs": {
-        "openclaw/telegram/bot_token": { "path": "./secrets/telegram-token.txt" }
+        "openclaw/telegram/bot_token": {
+          "path": "./secrets/telegram-token.txt",
+          "maxBytes": 65536
+        }
       }
     },
     {
@@ -99,9 +103,13 @@ Reads a file path from the source config.
 Rules:
 
 - file value is trimmed of surrounding whitespace
+- when `trustedDirs` is configured on the source, mapped files must resolve under one trusted directory
+- `maxBytes` limits the file read and defaults to 65536 bytes
 - empty file is `source_unavailable`
-- missing file is `source_unavailable`
+- missing or unreadable file is `source_unavailable`
+- files over the configured byte limit are `source_unavailable`
 - value is returned only through authenticated resolve
+- diagnostics and status output must not include file contents
 
 ## Exec adapter hardening
 


### PR DESCRIPTION
## Summary
- harden the file source adapter with `trustedDirs` policy checks and bounded `maxBytes` reads
- normalize missing, unreadable, empty, oversized, invalid, and policy-denied outcomes without exposing file contents
- align file source status capabilities with the external adapter contract and document the file mapping controls

## Validation
- `go test ./cmd/secretsbroker`
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`

Closes #52