### PR TITLE
feat(#59): add threshold recovery shares

### DIFF
--- a/cmd/secretsbroker/backup_restore.go
+++ b/cmd/secretsbroker/backup_restore.go
@@ -255,6 +255,8 @@ func (b *localBackend) rotateMasterKey(newMasterKey string) (keyRotateResponse, 
 		entry.Metadata.UpdatedAt = b.now()
 		store.Secrets[ref] = entry
 	}
+	store.KeyID = masterKeyID(newMasterKey)
+	store.KeyVersion = masterKeyVersion
 	store.UpdatedAt = b.now()
 	if err := b.saveStore(store); err != nil {
 		_ = b.audit("key_rotate", "", "degraded", "", "")

--- a/cmd/secretsbroker/key_lifecycle.go
+++ b/cmd/secretsbroker/key_lifecycle.go
@@ -185,7 +185,7 @@ func (b *localBackend) initializeStore(masterKey string) (keyLifecycleResponse, 
 		_ = b.audit("key_initialize", "", "degraded", "", "")
 		return keyLifecycleResponse{}, err
 	}
-	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: b.now(), UpdatedAt: b.now(), Secrets: map[string]secretEntry{}}
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, KeyID: masterKeyID(masterKey), KeyVersion: masterKeyVersion, CreatedAt: b.now(), UpdatedAt: b.now(), Secrets: map[string]secretEntry{}}
 	if err := b.saveStore(store); err != nil {
 		_ = b.audit("key_initialize", "", "degraded", "", "")
 		return keyLifecycleResponse{}, errBackendDegraded
@@ -244,6 +244,12 @@ func (b *localBackend) validateStoreForKey() (string, int, error) {
 	store, err := b.loadStore()
 	if err != nil {
 		return "degraded", 0, errBackendDegraded
+	}
+	if store.KeyID != "" && store.KeyID != masterKeyID(b.masterKey) {
+		return "locked", len(store.Secrets), errInvalidBackupKey
+	}
+	if store.KeyVersion != "" && store.KeyVersion != masterKeyVersion {
+		return "locked", len(store.Secrets), errInvalidBackupKey
 	}
 	for _, entry := range store.Secrets {
 		if entry.Payload.KeyID != "" && entry.Payload.KeyID != masterKeyID(b.masterKey) {

--- a/cmd/secretsbroker/key_material.go
+++ b/cmd/secretsbroker/key_material.go
@@ -61,6 +61,8 @@ func runKey(args []string) error {
 		return runKeyWrapperStatus(args[1:])
 	case "rotate":
 		return runKeyRotate(args[1:])
+	case "recovery":
+		return runKeyRecovery(args[1:])
 	default:
 		return fmt.Errorf("unknown key command %q", args[0])
 	}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -46,12 +46,14 @@ type localBackend struct {
 }
 
 type localStoreFile struct {
-	Version   int                     `json:"version"`
-	ServiceID string                  `json:"serviceId"`
-	CreatedAt time.Time               `json:"createdAt"`
-	UpdatedAt time.Time               `json:"updatedAt"`
-	Secrets   map[string]secretEntry  `json:"secrets"`
-	Recovery  *recoveryPolicyMetadata `json:"recoveryPolicy,omitempty"`
+	Version    int                     `json:"version"`
+	ServiceID  string                  `json:"serviceId"`
+	KeyID      string                  `json:"keyId,omitempty"`
+	KeyVersion string                  `json:"keyVersion,omitempty"`
+	CreatedAt  time.Time               `json:"createdAt"`
+	UpdatedAt  time.Time               `json:"updatedAt"`
+	Secrets    map[string]secretEntry  `json:"secrets"`
+	Recovery   *recoveryPolicyMetadata `json:"recoveryPolicy,omitempty"`
 }
 
 type secretEntry struct {
@@ -238,6 +240,12 @@ func (b *localBackend) writeSecret(req writeSecretRequest) (writeSecretResponse,
 		return writeSecretResponse{}, err
 	}
 	now := b.now()
+	if store.KeyID == "" {
+		store.KeyID = masterKeyID(b.masterKey)
+	}
+	if store.KeyVersion == "" {
+		store.KeyVersion = masterKeyVersion
+	}
 	version := now.Format(time.RFC3339Nano)
 	metadata := SecretMetadata{
 		SourceID:  firstNonEmpty(req.Metadata["sourceId"], localStoreSource),

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -245,7 +245,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/rotation/dry-run",
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker backup create|restore",
-			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate",
+			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate|recovery generate|recovery import",
 			"CLI secretsbroker admin status|secrets|providers|migration|recovery|audit|events",
 		},
 		Features: []string{
@@ -283,6 +283,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"master-key-rotation",
 			"recovery-policy-metadata",
 			"recovery-policy-status",
+			"threshold-recovery-shares",
 			"headless-admin-cli",
 		},
 		FutureFeatures: []string{

--- a/cmd/secretsbroker/recovery_shares.go
+++ b/cmd/secretsbroker/recovery_shares.go
@@ -1,0 +1,538 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	recoveryShareVersion = 1
+	recoveryShareAlg     = "shamir-gf256-v1"
+	maxRecoveryShareSize = 64 * 1024
+)
+
+var (
+	errInvalidRecoveryShare        = errors.New("invalid recovery share")
+	errInsufficientRecoveryShares  = errors.New("insufficient recovery shares")
+	errRecoveryShareOutputRequired = errors.New("explicit recovery share output targets are required")
+	errRecoveryKeyMismatch         = errors.New("recovery shares do not match store key")
+)
+
+type recoveryShareFile struct {
+	Version          int       `json:"version"`
+	ServiceID        string    `json:"serviceId"`
+	APIVersion       string    `json:"apiVersion"`
+	PolicyID         string    `json:"policyId"`
+	KeyID            string    `json:"keyId"`
+	KeyVersion       string    `json:"keyVersion"`
+	Threshold        int       `json:"threshold"`
+	ShareCount       int       `json:"shareCount"`
+	ShareIndex       int       `json:"shareIndex"`
+	Alg              string    `json:"alg"`
+	Share            string    `json:"share"`
+	ShareFingerprint string    `json:"shareFingerprint"`
+	CreatedAt        time.Time `json:"createdAt"`
+}
+
+type recoveryShareGenerateRequest struct {
+	PolicyID  string
+	Threshold int
+	Outputs   []string
+	ServiceID string
+	RequestID string
+}
+
+type recoveryShareImportRequest struct {
+	Inputs      []string
+	WrapperPath string
+	OS          string
+	ServiceID   string
+	RequestID   string
+}
+
+type recoveryShareFileMetadata struct {
+	ShareIndex       int    `json:"shareIndex"`
+	Path             string `json:"path"`
+	ShareFingerprint string `json:"shareFingerprint"`
+}
+
+type recoveryShareOperationResponse struct {
+	ServiceID   string                      `json:"serviceId"`
+	APIVersion  string                      `json:"apiVersion"`
+	Outcome     string                      `json:"outcome"`
+	KeyID       string                      `json:"keyId,omitempty"`
+	KeyVersion  string                      `json:"keyVersion,omitempty"`
+	Policy      *recoveryPolicyMetadata     `json:"policy,omitempty"`
+	Shares      []recoveryShareFileMetadata `json:"shares,omitempty"`
+	StorePath   string                      `json:"storePath,omitempty"`
+	WrapperPath string                      `json:"wrapperPath,omitempty"`
+	Wrapper     *wrapperStatusDetail        `json:"wrapper,omitempty"`
+	SecretCount int                         `json:"secretCount"`
+	NextAction  string                      `json:"nextAction"`
+	AuditStatus string                      `json:"auditStatus"`
+}
+
+func runKeyRecovery(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown key recovery command %q", "")
+	}
+	switch args[0] {
+	case "generate":
+		return runKeyRecoveryGenerate(args[1:])
+	case "import":
+		return runKeyRecoveryImport(args[1:])
+	default:
+		return fmt.Errorf("unknown key recovery command %q", args[0])
+	}
+}
+
+func runKeyRecoveryGenerate(args []string) error {
+	fs := flag.NewFlagSet("key recovery generate", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	masterKey := fs.String("master-key", getenvDefault("SECRETSBROKER_MASTER_KEY", ""), "portable master key")
+	masterKeyFile := fs.String("master-key-file", getenvDefault("SECRETSBROKER_MASTER_KEY_FILE", ""), "file containing portable master key")
+	policyID := fs.String("policy-id", "", "recovery policy id")
+	threshold := fs.Int("threshold", 0, "threshold required to recover")
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	outputs := multiFlag{}
+	fs.Var(&outputs, "share-out", "explicit recovery share output file; repeatable")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	material, err := loadKeyMaterial(*masterKey, *masterKeyFile)
+	if err != nil {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, material.Value)
+	res, err := backend.generateRecoveryShares(recoveryShareGenerateRequest{PolicyID: *policyID, Threshold: *threshold, Outputs: []string(outputs), ServiceID: *service, RequestID: *requestID})
+	if err != nil {
+		_ = encodeIndented(os.Stdout, res)
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func runKeyRecoveryImport(args []string) error {
+	fs := flag.NewFlagSet("key recovery import", flag.ContinueOnError)
+	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
+	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
+	wrapperPath := fs.String("wrapper", getenvDefault("SECRETSBROKER_WRAPPER_PATH", defaultWrapperPath()), "local OS wrapper path")
+	osName := fs.String("os", runtime.GOOS, "wrapper OS override for validation/testing")
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	inputs := multiFlag{}
+	fs.Var(&inputs, "share-in", "explicit recovery share input file; repeatable")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	backend := newLocalBackend(*storePath, *auditPath, "")
+	res, err := backend.importRecoveryShares(recoveryShareImportRequest{Inputs: []string(inputs), WrapperPath: *wrapperPath, OS: *osName, ServiceID: *service, RequestID: *requestID})
+	if err != nil {
+		_ = encodeIndented(os.Stdout, res)
+		return err
+	}
+	return encodeIndented(os.Stdout, res)
+}
+
+func (b *localBackend) generateRecoveryShares(req recoveryShareGenerateRequest) (recoveryShareOperationResponse, error) {
+	res := recoveryShareOperationResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "degraded", StorePath: b.storePath, NextAction: "inspect_recovery_share_generation", AuditStatus: "audit_recorded"}
+	if err := validatePortableMasterKey(b.masterKey); err != nil {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "locked", req.ServiceID, req.RequestID)
+		res.Outcome = "locked"
+		res.NextAction = "provide_portable_master_key"
+		return res, err
+	}
+	b.masterKey = strings.TrimSpace(b.masterKey)
+	state, secretCount, err := b.validateStoreForKey()
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", state, req.ServiceID, req.RequestID)
+		res.Outcome = state
+		res.SecretCount = secretCount
+		res.NextAction = "verify_store_before_recovery_enrollment"
+		return res, err
+	}
+	outputs := safeList(req.Outputs)
+	if len(outputs) == 0 {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "policy_denied", req.ServiceID, req.RequestID)
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_explicit_share_output_targets"
+		return res, errRecoveryShareOutputRequired
+	}
+	if hasDuplicate(outputs) {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "policy_denied", req.ServiceID, req.RequestID)
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_unique_share_output_targets"
+		return res, errRecoveryShareOutputRequired
+	}
+	if req.Threshold < 1 || req.Threshold > len(outputs) || len(outputs) > 255 {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "policy_denied", req.ServiceID, req.RequestID)
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_valid_threshold_and_share_count"
+		return res, errInvalidRecoveryPolicy
+	}
+	keyBytes, err := base64.RawURLEncoding.DecodeString(b.masterKey)
+	if err != nil || len(keyBytes) != 32 {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "locked", req.ServiceID, req.RequestID)
+		res.Outcome = "locked"
+		res.NextAction = "provide_valid_portable_master_key"
+		return res, errInvalidMasterKey
+	}
+	defer zeroBytes(keyBytes)
+	shares, err := splitSecretGF256(keyBytes, req.Threshold, len(outputs))
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_generate", "", "degraded", req.ServiceID, req.RequestID)
+		res.NextAction = "retry_recovery_share_generation"
+		return res, err
+	}
+	keyID := masterKeyID(b.masterKey)
+	policyID := scrubAuditField(req.PolicyID)
+	if policyID == "" {
+		policyID = "recovery-" + keyID
+	}
+	now := b.now().UTC()
+	metadata := make([]recoveryShareFileMetadata, 0, len(shares))
+	fingerprints := make([]string, 0, len(shares))
+	files := make([]recoveryShareFile, 0, len(shares))
+	for i, share := range shares {
+		encodedShare := base64.RawURLEncoding.EncodeToString(share.Value)
+		fp := recoveryShareFingerprint(policyID, keyID, share.Index, encodedShare)
+		files = append(files, recoveryShareFile{Version: recoveryShareVersion, ServiceID: serviceID, APIVersion: apiVersion, PolicyID: policyID, KeyID: keyID, KeyVersion: masterKeyVersion, Threshold: req.Threshold, ShareCount: len(shares), ShareIndex: share.Index, Alg: recoveryShareAlg, Share: encodedShare, ShareFingerprint: fp, CreatedAt: now})
+		fingerprints = append(fingerprints, fp)
+		metadata = append(metadata, recoveryShareFileMetadata{ShareIndex: share.Index, Path: outputs[i], ShareFingerprint: fp})
+	}
+	if _, err := normalizeRecoveryPolicyRequest(recoveryPolicyRequest{PolicyID: policyID, KeyID: keyID, KeyVersion: masterKeyVersion, Threshold: req.Threshold, ShareCount: len(shares), ShareFingerprints: fingerprints, CreatedAt: &now, Status: "active"}, now); err != nil {
+		_ = b.auditRecoveryShares("recovery_share_generate", policyID, "policy_denied", req.ServiceID, req.RequestID)
+		res.Outcome = "policy_denied"
+		res.NextAction = "provide_valid_recovery_policy_metadata"
+		return res, err
+	}
+	for i, file := range files {
+		if err := writeRecoveryShareFile(outputs[i], file); err != nil {
+			_ = b.auditRecoveryShares("recovery_share_generate", policyID, "degraded", req.ServiceID, req.RequestID)
+			res.NextAction = "inspect_recovery_share_output_targets"
+			return res, err
+		}
+	}
+	policyRes, err := b.upsertRecoveryPolicy(recoveryPolicyRequest{RequestID: req.RequestID, ServiceID: req.ServiceID, PolicyID: policyID, KeyID: keyID, KeyVersion: masterKeyVersion, Threshold: req.Threshold, ShareCount: len(shares), ShareFingerprints: fingerprints, CreatedAt: &now, Status: "active"})
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_generate", policyID, "degraded", req.ServiceID, req.RequestID)
+		return res, err
+	}
+	_ = b.auditRecoveryShares("recovery_share_generate", policyID, "ready", req.ServiceID, req.RequestID)
+	return recoveryShareOperationResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", KeyID: keyID, KeyVersion: masterKeyVersion, Policy: policyRes.Policy, Shares: metadata, StorePath: b.storePath, SecretCount: secretCount, NextAction: "store_recovery_shares_separately_and_verify_recovery_import", AuditStatus: "audit_recorded"}, nil
+}
+
+func (b *localBackend) importRecoveryShares(req recoveryShareImportRequest) (recoveryShareOperationResponse, error) {
+	res := recoveryShareOperationResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "locked", StorePath: b.storePath, WrapperPath: req.WrapperPath, NextAction: "provide_threshold_recovery_shares", AuditStatus: "audit_recorded"}
+	inputs := safeList(req.Inputs)
+	if len(inputs) == 0 {
+		_ = b.auditRecoveryShares("recovery_share_import", "", "locked", req.ServiceID, req.RequestID)
+		return res, errInsufficientRecoveryShares
+	}
+	shareFiles := make([]recoveryShareFile, 0, len(inputs))
+	metadata := make([]recoveryShareFileMetadata, 0, len(inputs))
+	for _, path := range inputs {
+		file, err := readRecoveryShareFile(path)
+		if err != nil {
+			_ = b.auditRecoveryShares("recovery_share_import", "", "locked", req.ServiceID, req.RequestID)
+			res.NextAction = "inspect_recovery_share_files"
+			return res, err
+		}
+		shareFiles = append(shareFiles, file)
+		metadata = append(metadata, recoveryShareFileMetadata{ShareIndex: file.ShareIndex, Path: path, ShareFingerprint: file.ShareFingerprint})
+	}
+	header, sharePoints, err := validateRecoveryShareSet(shareFiles)
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_import", "", "locked", req.ServiceID, req.RequestID)
+		res.Shares = metadata
+		res.NextAction = "provide_valid_threshold_recovery_shares"
+		return res, err
+	}
+	res.KeyID = header.KeyID
+	res.KeyVersion = header.KeyVersion
+	res.Shares = metadata
+	if len(sharePoints) < header.Threshold {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "locked", req.ServiceID, req.RequestID)
+		res.NextAction = "provide_configured_threshold_number_of_shares"
+		return res, errInsufficientRecoveryShares
+	}
+	recoveredBytes, err := combineSecretGF256(sharePoints[:header.Threshold])
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "locked", req.ServiceID, req.RequestID)
+		res.NextAction = "provide_valid_threshold_recovery_shares"
+		return res, err
+	}
+	defer zeroBytes(recoveredBytes)
+	recoveredKey := base64.RawURLEncoding.EncodeToString(recoveredBytes)
+	if err := validatePortableMasterKey(recoveredKey); err != nil {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "locked", req.ServiceID, req.RequestID)
+		res.NextAction = "provide_valid_threshold_recovery_shares"
+		return res, err
+	}
+	if masterKeyID(recoveredKey) != header.KeyID {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "locked", req.ServiceID, req.RequestID)
+		res.NextAction = "provide_recovery_shares_for_matching_key"
+		return res, errRecoveryKeyMismatch
+	}
+	ctx := wrapperContextFor(req.OS)
+	if !ctx.Supported {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "degraded", req.ServiceID, req.RequestID)
+		res.Outcome = "degraded"
+		res.NextAction = "use_portable_key_unlock_until_wrapper_supported"
+		return res, errUnsupportedOSWrapper
+	}
+	b.masterKey = recoveredKey
+	state, secretCount, err := b.validateStoreForKey()
+	res.SecretCount = secretCount
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, state, req.ServiceID, req.RequestID)
+		res.Outcome = state
+		res.NextAction = "inspect_store_before_wrapper_refresh"
+		return res, err
+	}
+	wrapper, err := wrapMasterKey(req.WrapperPath, recoveredKey, ctx, b.now())
+	if err != nil {
+		_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "degraded", req.ServiceID, req.RequestID)
+		res.Outcome = "degraded"
+		res.NextAction = "inspect_wrapper_output_target"
+		return res, err
+	}
+	_ = b.auditRecoveryShares("recovery_share_import", header.PolicyID, "ready", req.ServiceID, req.RequestID)
+	detail := wrapper.detail(true, "ready", "")
+	return recoveryShareOperationResponse{ServiceID: serviceID, APIVersion: apiVersion, Outcome: "ready", KeyID: wrapper.KeyID, KeyVersion: wrapper.KeyVersion, Shares: metadata, StorePath: b.storePath, WrapperPath: req.WrapperPath, Wrapper: &detail, SecretCount: secretCount, NextAction: "operate_normally", AuditStatus: "audit_recorded"}, nil
+}
+
+func (b *localBackend) auditRecoveryShares(operation, policyID, outcome, requestServiceID, requestID string) error {
+	return b.writeAuditEvent(auditEvent{TS: b.now(), Operation: operation, PolicyID: policyID, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID})
+}
+
+type recoverySharePoint struct {
+	Index int
+	Value []byte
+}
+
+func splitSecretGF256(secret []byte, threshold, shareCount int) ([]recoverySharePoint, error) {
+	if threshold < 1 || threshold > shareCount || shareCount > 255 || len(secret) == 0 {
+		return nil, errInvalidRecoveryPolicy
+	}
+	shares := make([]recoverySharePoint, shareCount)
+	for i := range shares {
+		shares[i] = recoverySharePoint{Index: i + 1, Value: make([]byte, len(secret))}
+	}
+	coefficients := make([]byte, threshold)
+	for secretIndex, secretByte := range secret {
+		coefficients[0] = secretByte
+		if threshold > 1 {
+			if _, err := io.ReadFull(rand.Reader, coefficients[1:]); err != nil {
+				return nil, err
+			}
+		}
+		for shareIndex := range shares {
+			x := byte(shares[shareIndex].Index)
+			y := coefficients[threshold-1]
+			for i := threshold - 2; i >= 0; i-- {
+				y = gfMul(y, x) ^ coefficients[i]
+				if i == 0 {
+					break
+				}
+			}
+			shares[shareIndex].Value[secretIndex] = y
+		}
+	}
+	zeroBytes(coefficients)
+	return shares, nil
+}
+
+func combineSecretGF256(shares []recoverySharePoint) ([]byte, error) {
+	if len(shares) == 0 {
+		return nil, errInsufficientRecoveryShares
+	}
+	length := len(shares[0].Value)
+	if length == 0 {
+		return nil, errInvalidRecoveryShare
+	}
+	seen := map[int]struct{}{}
+	for _, share := range shares {
+		if share.Index < 1 || share.Index > 255 || len(share.Value) != length {
+			return nil, errInvalidRecoveryShare
+		}
+		if _, ok := seen[share.Index]; ok {
+			return nil, errInvalidRecoveryShare
+		}
+		seen[share.Index] = struct{}{}
+	}
+	secret := make([]byte, length)
+	for byteIndex := 0; byteIndex < length; byteIndex++ {
+		var value byte
+		for i, share := range shares {
+			xi := byte(share.Index)
+			basis := byte(1)
+			for j, other := range shares {
+				if i == j {
+					continue
+				}
+				xj := byte(other.Index)
+				denominator := xi ^ xj
+				if denominator == 0 {
+					return nil, errInvalidRecoveryShare
+				}
+				basis = gfMul(basis, gfDiv(xj, denominator))
+			}
+			value ^= gfMul(share.Value[byteIndex], basis)
+		}
+		secret[byteIndex] = value
+	}
+	return secret, nil
+}
+
+func validateRecoveryShareSet(files []recoveryShareFile) (recoveryShareFile, []recoverySharePoint, error) {
+	if len(files) == 0 {
+		return recoveryShareFile{}, nil, errInsufficientRecoveryShares
+	}
+	header := files[0]
+	if err := validateRecoveryShareHeader(header); err != nil {
+		return recoveryShareFile{}, nil, err
+	}
+	points := make([]recoverySharePoint, 0, len(files))
+	seen := map[int]struct{}{}
+	for _, file := range files {
+		if err := validateRecoveryShareHeader(file); err != nil {
+			return recoveryShareFile{}, nil, err
+		}
+		if file.PolicyID != header.PolicyID || file.KeyID != header.KeyID || file.KeyVersion != header.KeyVersion || file.Threshold != header.Threshold || file.ShareCount != header.ShareCount {
+			return recoveryShareFile{}, nil, errInvalidRecoveryShare
+		}
+		if _, ok := seen[file.ShareIndex]; ok {
+			return recoveryShareFile{}, nil, errInvalidRecoveryShare
+		}
+		seen[file.ShareIndex] = struct{}{}
+		shareValue, err := base64.RawURLEncoding.DecodeString(file.Share)
+		if err != nil || len(shareValue) == 0 {
+			return recoveryShareFile{}, nil, errInvalidRecoveryShare
+		}
+		if recoveryShareFingerprint(file.PolicyID, file.KeyID, file.ShareIndex, file.Share) != file.ShareFingerprint {
+			return recoveryShareFile{}, nil, errInvalidRecoveryShare
+		}
+		points = append(points, recoverySharePoint{Index: file.ShareIndex, Value: shareValue})
+	}
+	return header, points, nil
+}
+
+func validateRecoveryShareHeader(file recoveryShareFile) error {
+	if file.Version != recoveryShareVersion || file.ServiceID != serviceID || file.APIVersion != apiVersion || file.Alg != recoveryShareAlg {
+		return errInvalidRecoveryShare
+	}
+	if !validSafeMetadataID(file.PolicyID) || !validSafeMetadataID(file.KeyID) || !validSafeMetadataID(file.KeyVersion) || !validSafeMetadataID(file.ShareFingerprint) {
+		return errInvalidRecoveryShare
+	}
+	if file.Threshold < 1 || file.ShareCount < 1 || file.Threshold > file.ShareCount || file.ShareCount > 255 || file.ShareIndex < 1 || file.ShareIndex > file.ShareCount {
+		return errInvalidRecoveryShare
+	}
+	if strings.TrimSpace(file.Share) == "" || file.CreatedAt.IsZero() {
+		return errInvalidRecoveryShare
+	}
+	return nil
+}
+
+func writeRecoveryShareFile(path string, share recoveryShareFile) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errRecoveryShareOutputRequired
+	}
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("recovery share output already exists: %s", path)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(share, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, bytes, 0o600)
+}
+
+func readRecoveryShareFile(path string) (recoveryShareFile, error) {
+	file, err := os.Open(strings.TrimSpace(path))
+	if err != nil {
+		return recoveryShareFile{}, err
+	}
+	defer file.Close()
+	dec := json.NewDecoder(io.LimitReader(file, maxRecoveryShareSize))
+	dec.DisallowUnknownFields()
+	var share recoveryShareFile
+	if err := dec.Decode(&share); err != nil {
+		return recoveryShareFile{}, errInvalidRecoveryShare
+	}
+	if err := validateRecoveryShareHeader(share); err != nil {
+		return recoveryShareFile{}, err
+	}
+	return share, nil
+}
+
+func recoveryShareFingerprint(policyID, keyID string, shareIndex int, encodedShare string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{policyID, keyID, fmt.Sprintf("%d", shareIndex), encodedShare}, "|")))
+	return "share-" + hex.EncodeToString(sum[:])[:16]
+}
+
+func gfMul(a, b byte) byte {
+	var product byte
+	for b != 0 {
+		if b&1 == 1 {
+			product ^= a
+		}
+		high := a & 0x80
+		a <<= 1
+		if high != 0 {
+			a ^= 0x1b
+		}
+		b >>= 1
+	}
+	return product
+}
+
+func gfDiv(a, b byte) byte {
+	if b == 0 {
+		return 0
+	}
+	return gfMul(a, gfInv(b))
+}
+
+func gfInv(a byte) byte {
+	if a == 0 {
+		return 0
+	}
+	var result byte = 1
+	base := a
+	power := 254
+	for power > 0 {
+		if power&1 == 1 {
+			result = gfMul(result, base)
+		}
+		base = gfMul(base, base)
+		power >>= 1
+	}
+	return result
+}
+
+func zeroBytes(bytes []byte) {
+	for i := range bytes {
+		bytes[i] = 0
+	}
+}

--- a/cmd/secretsbroker/recovery_shares_test.go
+++ b/cmd/secretsbroker/recovery_shares_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func recoveryShareBackend(t *testing.T, masterKey string) *localBackend {
+	t.Helper()
+	b := lifecycleBackend(t, masterKey)
+	b.now = func() time.Time { return time.Date(2026, 6, 7, 13, 45, 0, 0, time.UTC) }
+	if _, err := b.initializeStore(masterKey); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestRecoveryShareGenerateAndImportRefreshesWrapper(t *testing.T) {
+	key := lifecycleTestKey(21)
+	backend := recoveryShareBackend(t, key)
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: "services/api/RECOVERY_TOKEN", Value: "recoverable-secret"}); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	outputs := []string{
+		filepath.Join(dir, "share-1.json"),
+		filepath.Join(dir, "share-2.json"),
+		filepath.Join(dir, "share-3.json"),
+	}
+
+	generated, err := backend.generateRecoveryShares(recoveryShareGenerateRequest{PolicyID: "policy-break-glass", Threshold: 2, Outputs: outputs, ServiceID: "@operator", RequestID: "req-generate"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if generated.Outcome != "ready" || generated.KeyID != masterKeyID(key) || generated.Policy == nil || generated.Policy.Threshold != 2 || len(generated.Shares) != 3 {
+		t.Fatalf("generated response = %#v", generated)
+	}
+	storeBytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(storeBytes), key) || strings.Contains(string(storeBytes), "recoverable-secret") {
+		t.Fatalf("store leaked recovery material or secret: %s", string(storeBytes))
+	}
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(auditBytes), key) || strings.Contains(string(auditBytes), "recoverable-secret") {
+		t.Fatalf("audit leaked recovery material or secret: %s", string(auditBytes))
+	}
+	for _, output := range outputs {
+		bytes, err := os.ReadFile(output)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(bytes), key) || strings.Contains(string(bytes), "recoverable-secret") {
+			t.Fatalf("share file leaked portable key or secret: %s", string(bytes))
+		}
+		var share recoveryShareFile
+		if err := json.Unmarshal(bytes, &share); err != nil {
+			t.Fatal(err)
+		}
+		if share.Share == "" || share.ShareFingerprint == "" || share.KeyID != masterKeyID(key) {
+			t.Fatalf("share metadata = %#v", share)
+		}
+	}
+
+	wrapperPath := filepath.Join(t.TempDir(), "wrapper.json")
+	recovered := newLocalBackend(backend.storePath, filepath.Join(t.TempDir(), "recovery-audit.jsonl"), "")
+	recovered.now = backend.now
+	imported, err := recovered.importRecoveryShares(recoveryShareImportRequest{Inputs: outputs[:2], WrapperPath: wrapperPath, OS: "linux", ServiceID: "@operator", RequestID: "req-import"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported.Outcome != "ready" || imported.Wrapper == nil || imported.Wrapper.KeyID != masterKeyID(key) || imported.SecretCount != 1 {
+		t.Fatalf("import response = %#v", imported)
+	}
+	resolved := recovered.resolve(resolveRequest{ServiceID: "api", Refs: []string{"services/api/RECOVERY_TOKEN"}})
+	if resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "recoverable-secret" {
+		t.Fatalf("recovered resolve = %#v", resolved.Results[0])
+	}
+	wrapperBytes, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(wrapperBytes), key) || strings.Contains(string(wrapperBytes), "recoverable-secret") {
+		t.Fatalf("wrapper leaked recovery material or secret: %s", string(wrapperBytes))
+	}
+}
+
+func TestRecoveryShareImportFailuresFailClosed(t *testing.T) {
+	key := lifecycleTestKey(22)
+	backend := recoveryShareBackend(t, key)
+	dir := t.TempDir()
+	outputs := []string{
+		filepath.Join(dir, "share-1.json"),
+		filepath.Join(dir, "share-2.json"),
+		filepath.Join(dir, "share-3.json"),
+	}
+	if _, err := backend.generateRecoveryShares(recoveryShareGenerateRequest{PolicyID: "policy-fail-closed", Threshold: 2, Outputs: outputs}); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapperPath := filepath.Join(t.TempDir(), "too-few-wrapper.json")
+	recovered := newLocalBackend(backend.storePath, filepath.Join(t.TempDir(), "too-few-audit.jsonl"), "")
+	if _, err := recovered.importRecoveryShares(recoveryShareImportRequest{Inputs: outputs[:1], WrapperPath: wrapperPath, OS: "linux"}); !errors.Is(err, errInsufficientRecoveryShares) {
+		t.Fatalf("too few shares err = %v", err)
+	}
+	if _, err := os.Stat(wrapperPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("too few shares should not write wrapper, stat err = %v", err)
+	}
+
+	tamperedPath := filepath.Join(t.TempDir(), "tampered-share.json")
+	bytes, err := os.ReadFile(outputs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tampered recoveryShareFile
+	if err := json.Unmarshal(bytes, &tampered); err != nil {
+		t.Fatal(err)
+	}
+	tampered.ShareFingerprint = "share-tampered"
+	tamperedBytes, err := json.MarshalIndent(tampered, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tamperedPath, tamperedBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recovered.importRecoveryShares(recoveryShareImportRequest{Inputs: []string{tamperedPath, outputs[1]}, WrapperPath: filepath.Join(t.TempDir(), "tampered-wrapper.json"), OS: "linux"}); !errors.Is(err, errInvalidRecoveryShare) {
+		t.Fatalf("tampered share err = %v", err)
+	}
+
+	unsupportedWrapper := filepath.Join(t.TempDir(), "unsupported-wrapper.json")
+	if _, err := recovered.importRecoveryShares(recoveryShareImportRequest{Inputs: outputs[:2], WrapperPath: unsupportedWrapper, OS: "plan9"}); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("unsupported wrapper err = %v", err)
+	}
+	if _, err := os.Stat(unsupportedWrapper); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unsupported wrapper should not write file, stat err = %v", err)
+	}
+
+	corruptedStorePath := filepath.Join(t.TempDir(), "corrupted-store.json")
+	if err := os.WriteFile(corruptedStorePath, []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corrupted := newLocalBackend(corruptedStorePath, filepath.Join(t.TempDir(), "corrupted-audit.jsonl"), "")
+	corruptedWrapper := filepath.Join(t.TempDir(), "corrupted-wrapper.json")
+	if _, err := corrupted.importRecoveryShares(recoveryShareImportRequest{Inputs: outputs[:2], WrapperPath: corruptedWrapper, OS: "linux"}); !errors.Is(err, errBackendDegraded) {
+		t.Fatalf("corrupted store err = %v", err)
+	}
+	if _, err := os.Stat(corruptedWrapper); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("corrupted store should not write wrapper, stat err = %v", err)
+	}
+}
+
+func TestRecoveryShareGenerateRequiresExplicitSafePolicy(t *testing.T) {
+	key := lifecycleTestKey(23)
+	backend := recoveryShareBackend(t, key)
+
+	if _, err := backend.generateRecoveryShares(recoveryShareGenerateRequest{Threshold: 1}); !errors.Is(err, errRecoveryShareOutputRequired) {
+		t.Fatalf("missing output err = %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "share.json")
+	if _, err := backend.generateRecoveryShares(recoveryShareGenerateRequest{Threshold: 2, Outputs: []string{out}}); !errors.Is(err, errInvalidRecoveryPolicy) {
+		t.Fatalf("invalid threshold err = %v", err)
+	}
+}

--- a/docs/secure-initialization-recovery.md
+++ b/docs/secure-initialization-recovery.md
@@ -8,9 +8,9 @@ Service id: `@secretsbroker`
 
 This note defines the recommended initialization and recovery-key model for the local-first Secrets Broker. It answers whether PGP-based initialization should be the primary path, how operators can initialize without Keybase, how recovery material should be generated and stored, and what must stay out of UI, logs, diagnostics, and support artifacts.
 
-This is a design contract, not a production-readiness claim. The implemented foundation remains the portable master key, local encrypted store, local wrapper, backup/restore, rotation flows, and recovery policy metadata surfaces documented in `docs/portable-master-key.md`, `docs/master-key-lifecycle.md`, `docs/backup-restore-rotation.md`, `docs/local-api-bootstrap-contract.md`, and `docs/threat-model.md`.
+This is a design contract, not a production-readiness claim. The implemented foundation remains the portable master key, local encrypted store, local wrapper, backup/restore, rotation flows, threshold recovery share generation/import, and recovery policy metadata surfaces documented in `docs/portable-master-key.md`, `docs/master-key-lifecycle.md`, `docs/backup-restore-rotation.md`, `docs/local-api-bootstrap-contract.md`, and `docs/threat-model.md`.
 
-Current implementation note for #58: the broker persists and reports recovery policy/share metadata through API and CLI status surfaces. It still does not generate threshold shares, import shares, or create recipient envelopes; those remain follow-up implementation slices.
+Current implementation note for #59: the broker can generate CLI-first threshold recovery shares, import the configured threshold of share files, verify the reconstructed portable master key against store metadata/decryptability, and refresh a local wrapper only after verification succeeds. Recipient-encrypted share envelopes are still a follow-up implementation slice.
 
 ## Recommendation
 
@@ -98,6 +98,33 @@ Failure behavior:
 - Shares for the wrong key id: fail `locked`, no state mutation.
 - Corrupted store or unverifiable payloads: fail `degraded`, no wrapper mutation.
 - Unsupported wrapper provider: keep the store recoverable through explicit portable-key or recovery-share unlock, but do not claim durable local unlock.
+
+CLI recovery share generation writes share material only to explicit operator-selected files:
+
+```powershell
+secretsbroker key recovery generate `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --master-key-file .\secure\portable-master-key.txt `
+  --policy-id break-glass-2026 `
+  --threshold 2 `
+  --share-out .\secure\share-1.json `
+  --share-out .\secure\share-2.json `
+  --share-out .\secure\share-3.json
+```
+
+CLI recovery import reconstructs the key in memory, verifies the store, then writes or refreshes the local wrapper:
+
+```powershell
+secretsbroker key recovery import `
+  --store .\data\secretsbroker-store.json `
+  --audit .\data\secretsbroker-audit.jsonl `
+  --wrapper .\data\secretsbroker-wrapper.json `
+  --share-in .\secure\share-1.json `
+  --share-in .\secure\share-2.json
+```
+
+The share files contain recovery material and must be stored separately from encrypted stores and local wrappers. Broker state, audit events, responses, diagnostics, and Service Admin surfaces must carry only safe policy/share fingerprints and status metadata.
 
 ## Rotation Workflow
 
@@ -190,7 +217,7 @@ Audit events must never include:
 Recommended follow-up implementation sequence:
 
 1. Add a recovery policy and share metadata contract.
-2. Add CLI-first threshold recovery share generation and recovery import.
+2. Add CLI-first threshold recovery share generation and recovery import. Completed for the local-first baseline in #59.
 3. Add optional `age`/X25519 recipient envelopes for individual shares.
 4. Add wrapper and recovery-policy status surfaces to API/CLI.
 5. Add a Service Admin initialization guide only after the broker CLI/API contract is proven.


### PR DESCRIPTION
## Summary
- add CLI `key recovery generate` and `key recovery import` for threshold recovery shares
- persist store-level key metadata and verify recovered keys against store metadata/decryptability before wrapper refresh
- add fail-closed recovery share tests and update the recovery design note/capability surface

## Validation
- `go test ./...`
- `powershell -ExecutionPolicy Bypass -File .\scripts\test.ps1`
- `git diff --check`

## Safety
- share material is written only to explicit `--share-out` files
- responses, store recovery policy metadata, audit events, and tests keep portable master keys/plaintext secrets out of logs and broker metadata

Closes #59