### PR TITLE
fix #46 align local encrypted store adapter contract

### DIFF
--- a/cmd/secretsbroker/adapter_contract.go
+++ b/cmd/secretsbroker/adapter_contract.go
@@ -60,15 +60,16 @@ type AdapterDiagnosticsSpec struct {
 }
 
 type AdapterDiagnostic struct {
-	Kind        string            `json:"kind"`
-	SourceID    string            `json:"sourceId"`
-	Ref         string            `json:"ref,omitempty"`
-	State       string            `json:"state"`
-	Outcome     string            `json:"outcome"`
-	NextAction  string            `json:"nextAction,omitempty"`
-	Retryable   bool              `json:"retryable"`
-	Capability  AdapterCapability `json:"capability,omitempty"`
-	MessageCode string            `json:"messageCode,omitempty"`
+	Kind         string            `json:"kind"`
+	SourceID     string            `json:"sourceId"`
+	Ref          string            `json:"ref,omitempty"`
+	State        string            `json:"state"`
+	Outcome      string            `json:"outcome"`
+	NextAction   string            `json:"nextAction,omitempty"`
+	Retryable    bool              `json:"retryable"`
+	RetryAfterMs int               `json:"retryAfterMs,omitempty"`
+	Capability   AdapterCapability `json:"capability,omitempty"`
+	MessageCode  string            `json:"messageCode,omitempty"`
 }
 
 func externalAdapterContracts() []AdapterContract {
@@ -182,7 +183,7 @@ func externalAdapterContracts() []AdapterContract {
 
 func defaultAdapterDiagnosticsSpec() AdapterDiagnosticsSpec {
 	return AdapterDiagnosticsSpec{
-		SecretSafeFields: []string{"kind", "sourceId", "ref", "state", "outcome", "nextAction", "retryable", "capability", "messageCode"},
+		SecretSafeFields: []string{"kind", "sourceId", "ref", "state", "outcome", "nextAction", "retryable", "retryAfterMs", "capability", "messageCode"},
 		ForbiddenFields:  []string{"value", "secret", "token", "password", "privateKey", "credential", "rawOutput", "stdout", "stderr"},
 	}
 }
@@ -219,14 +220,15 @@ func adapterHasCapability(contract AdapterContract, capability AdapterCapability
 
 func buildAdapterDiagnostic(source sourceConfig, ref string, capability AdapterCapability, lifecycle SourceLifecycle) AdapterDiagnostic {
 	return AdapterDiagnostic{
-		Kind:        strings.ToLower(strings.TrimSpace(source.Kind)),
-		SourceID:    source.SourceID,
-		Ref:         ref,
-		State:       lifecycle.State,
-		Outcome:     lifecycle.Outcome,
-		NextAction:  lifecycle.NextAction,
-		Retryable:   lifecycle.Retryable,
-		Capability:  capability,
-		MessageCode: lifecycle.Outcome,
+		Kind:         strings.ToLower(strings.TrimSpace(source.Kind)),
+		SourceID:     source.SourceID,
+		Ref:          ref,
+		State:        lifecycle.State,
+		Outcome:      lifecycle.Outcome,
+		NextAction:   lifecycle.NextAction,
+		Retryable:    lifecycle.Retryable,
+		RetryAfterMs: lifecycle.RetryAfterMs,
+		Capability:   capability,
+		MessageCode:  lifecycle.Outcome,
 	}
 }

--- a/cmd/secretsbroker/adapter_contract_test.go
+++ b/cmd/secretsbroker/adapter_contract_test.go
@@ -38,6 +38,17 @@ func TestExternalAdapterContractsCoverRequiredFamilies(t *testing.T) {
 func TestAdapterContractsReportExpectedCapabilityMatrix(t *testing.T) {
 	contracts := adapterContractsByKind()
 
+	local := contracts["local-encrypted-store"]
+	for _, capability := range []AdapterCapability{AdapterCapabilityRead, AdapterCapabilityReveal, AdapterCapabilityWrite, AdapterCapabilityRotate, AdapterCapabilityAudit, AdapterCapabilityMigration} {
+		if !adapterHasCapability(local, capability) {
+			t.Fatalf("local encrypted store missing %s capability: %#v", capability, local.Capabilities)
+		}
+	}
+	for _, capability := range []AdapterCapability{AdapterCapabilityPolicy, AdapterCapabilityValueSearch} {
+		if adapterHasCapability(local, capability) {
+			t.Fatalf("local encrypted store should not declare %s capability: %#v", capability, local.Capabilities)
+		}
+	}
 	if !adapterHasCapability(contracts["vault-openbao"], AdapterCapabilityPolicy) || !adapterHasCapability(contracts["vault-openbao"], AdapterCapabilityRotate) {
 		t.Fatalf("vault/openbao capabilities = %#v", contracts["vault-openbao"].Capabilities)
 	}
@@ -68,6 +79,44 @@ func TestAdapterDiagnosticsAreMetadataOnly(t *testing.T) {
 	}
 	if !strings.Contains(string(payload), "api/DB_PASSWORD") || strings.Contains(string(payload), "token") {
 		t.Fatalf("diagnostic should include ref metadata only: %s", payload)
+	}
+}
+
+func TestLocalEncryptedStoreAdapterDiagnosticsNormalizeFailureStates(t *testing.T) {
+	source := sourceConfig{SourceID: "local", Kind: "local-encrypted-store"}
+	cases := []struct {
+		outcome     string
+		wantState   string
+		wantAction  string
+		wantRetry   bool
+		wantRetryMs int
+	}{
+		{outcome: "locked", wantState: "reconnect_required", wantAction: "unlock_or_unseal_source"},
+		{outcome: "missing_ref", wantState: "missing", wantAction: "check_ref"},
+		{outcome: "policy_denied", wantState: "denied", wantAction: "review_policy"},
+		{outcome: "degraded", wantState: "degraded", wantAction: "retry_or_inspect_source", wantRetry: true, wantRetryMs: defaultSourceRetryAfterMs},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.outcome, func(t *testing.T) {
+			diagnostic := buildAdapterDiagnostic(source, "services/api/runtime/ref", AdapterCapabilityRead, normalizeSourceLifecycle(tt.outcome))
+			if diagnostic.Kind != "local-encrypted-store" || diagnostic.SourceID != "local" || diagnostic.Outcome != tt.outcome {
+				t.Fatalf("diagnostic identity = %#v", diagnostic)
+			}
+			if diagnostic.State != tt.wantState || diagnostic.NextAction != tt.wantAction || diagnostic.Retryable != tt.wantRetry || diagnostic.RetryAfterMs != tt.wantRetryMs {
+				t.Fatalf("diagnostic lifecycle = %#v", diagnostic)
+			}
+			payload, err := json.Marshal(diagnostic)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertNoSecretMaterial(t, payload, "SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE")
+			for _, forbidden := range defaultAdapterDiagnosticsSpec().ForbiddenFields {
+				if strings.Contains(string(payload), `"`+forbidden+`":`) {
+					t.Fatalf("local diagnostic contains forbidden field %q: %s", forbidden, payload)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -120,7 +120,7 @@ type migrationPlanResponse struct {
 
 func defaultProviderCapabilities() []providerCapability {
 	return []providerCapability{
-		{ProviderKind: "local-encrypted-store", DisplayName: "Local encrypted store", Supported: true, Capabilities: []string{"read", "reveal", "write", "rotate", "policy", "value_search", "audit", "migration_source", "migration_target"}, Limitations: []string{"local-first development backend"}},
+		{ProviderKind: "local-encrypted-store", DisplayName: "Local encrypted store", Supported: true, Capabilities: capabilitiesForSourceKind("local-encrypted-store"), Limitations: []string{"local-first development backend"}},
 		{ProviderKind: "vault", DisplayName: "Vault", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
 		{ProviderKind: "openbao", DisplayName: "OpenBao", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
 		{ProviderKind: "env", DisplayName: "Environment variables", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -22,6 +22,13 @@ func TestProviderCapabilitiesAndStatusAreSafeMetadataOnly(t *testing.T) {
 	if capabilities.Outcome != "ready" || len(capabilities.Capabilities) == 0 {
 		t.Fatalf("capabilities = %#v", capabilities)
 	}
+	localCapabilities := providerCapabilitiesByKind("local-encrypted-store").Capabilities
+	for _, capability := range []string{"read", "reveal", "write/update", "rotate/reset", "audit", "migration", "health"} {
+		assertContains(t, localCapabilities, capability)
+	}
+	for _, capability := range []string{"policy", "value-search", "value_search"} {
+		assertNotContains(t, localCapabilities, capability)
+	}
 	assertNoSecretMaterial(t, mustManagedJSON(t, capabilities), providerCredentialValue)
 
 	status := backend.providerConfigStatusResponse()

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -49,7 +49,7 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 			Enabled:          true,
 			Critical:         true,
 			Priority:         0,
-			Capabilities:     []string{"read", "write", "health"},
+			Capabilities:     capabilitiesForSourceKind("local-encrypted-store"),
 			Namespaces:       []string{"*"},
 			State:            localLifecycle.State,
 			Outcome:          localLifecycle.Outcome,
@@ -115,6 +115,12 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 
 func capabilitiesForSourceKind(kind string) []string {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "local-encrypted-store":
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "write/update", "rotate/reset", "audit", "migration", "health"}
 	case "exec":
 		contract, ok := adapterContractForKind(kind)
 		if ok {

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -16,11 +16,29 @@ func TestDefaultSourceRegistryReflectsLocalKeyState(t *testing.T) {
 		t.Fatalf("locked source = %#v", locked.Sources[0])
 	}
 	assertContains(t, locked.Sources[0].Capabilities, "read")
+	assertContains(t, locked.Sources[0].Capabilities, "reveal")
+	assertContains(t, locked.Sources[0].Capabilities, "write/update")
+	assertContains(t, locked.Sources[0].Capabilities, "rotate/reset")
+	assertContains(t, locked.Sources[0].Capabilities, "audit")
+	assertContains(t, locked.Sources[0].Capabilities, "migration")
+	assertContains(t, locked.Sources[0].Capabilities, "health")
+	assertNotContains(t, locked.Sources[0].Capabilities, "policy")
+	assertNotContains(t, locked.Sources[0].Capabilities, "value-search")
 	assertContains(t, locked.Sources[0].Namespaces, "*")
 
 	ready := defaultSourceRegistry(newLocalBackend("store.json", "audit.jsonl", "master-key"))
 	if ready.Sources[0].State != "connected" || ready.Sources[0].Outcome != "ready" {
 		t.Fatalf("ready source = %#v", ready.Sources[0])
+	}
+}
+
+func TestLocalEncryptedStoreSourceStatusUsesAdapterContractCapabilities(t *testing.T) {
+	caps := capabilitiesForSourceKind("local-encrypted-store")
+	for _, capability := range []string{"read", "reveal", "write/update", "rotate/reset", "audit", "migration", "health"} {
+		assertContains(t, caps, capability)
+	}
+	for _, capability := range []string{"policy", "value-search"} {
+		assertNotContains(t, caps, capability)
 	}
 }
 

--- a/docs/provider-source-registry.md
+++ b/docs/provider-source-registry.md
@@ -29,7 +29,7 @@ A source registry entry describes a configured backend/source without revealing 
   "enabled": true,
   "critical": true,
   "priority": 0,
-  "capabilities": ["read", "write", "health"],
+  "capabilities": ["read", "reveal", "write/update", "rotate/reset", "audit", "migration", "health"],
   "namespaces": ["*"],
   "state": "connected",
   "outcome": "ready",
@@ -156,7 +156,7 @@ The implemented registry includes the default local source plus configured `env`
 
 - `sourceId`: visible stable source identifier
 - `kind`: `local-encrypted-store`, `env`, `file`, `exec`, `vault`, or `openbao`
-- `capabilities`: source-safe capabilities such as `read`, `write`, and `health`
+- `capabilities`: source-safe capabilities from the external adapter contract, plus `health` for status probes
 - `namespaces`: claimed namespaces or `*`
 - `state`/`outcome`/`nextAction`/`retryable`: normalized lifecycle view
 - `lifecycle`: structured lifecycle object mirroring the normalized fields


### PR DESCRIPTION
## Summary
- align local encrypted store source/provider capability reporting with docs/external-adapter-contract.md
- add retryAfterMs to adapter diagnostics metadata
- add local adapter tests for capability reporting, locked/missing/policy/degraded diagnostics, retry metadata, and no-leak assertions
- update provider-source registry docs sample for the local adapter capability matrix

## Validation
- go test ./cmd/secretsbroker -run "Test(Adapter|LocalEncryptedStore|DefaultSourceRegistry|SourceRegistry|ProviderCapabilities|ProviderConfig)"
- go test ./...
- SERVICE_LASSO_HARNESS_BIN=.harness/bin/service-lasso-harness.exe powershell -ExecutionPolicy Bypass -File ./scripts/verify.ps1
- git diff --check

Fixes #46