### PR TITLE
fix #50 implement Bitwarden/BWS source adapter

### DIFF
--- a/cmd/secretsbroker/bitwarden_source_test.go
+++ b/cmd/secretsbroker/bitwarden_source_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBitwardenBWSSourceAdapterAPISuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/secrets/secret-123" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer fake-bws-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"value":"bws-secret-value"}}`)
+	}))
+	defer server.Close()
+
+	cfg := sourceConfigFile{Sources: []sourceConfig{{SourceID: "bws-prod", Kind: "bitwarden-bws", Enabled: true, Address: server.URL, Token: "fake-bws-token", Refs: map[string]sourceRefConfig{"prod/openclaw/api_key": {Path: "secret-123"}}}}}
+	res := cfg.resolve("prod/openclaw/api_key")
+	if res.Outcome != "ready" || res.Value != "bws-secret-value" || res.SourceID != "bws-prod" {
+		t.Fatalf("bitwarden result = %#v", res)
+	}
+}
+
+func TestBitwardenBWSSourceAdapterStatusMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		outcome string
+	}{
+		{name: "auth required", status: http.StatusUnauthorized, outcome: "source_auth_required"},
+		{name: "policy denied", status: http.StatusForbidden, outcome: "policy_denied"},
+		{name: "missing ref", status: http.StatusNotFound, outcome: "missing_ref"},
+		{name: "degraded", status: http.StatusTooManyRequests, outcome: "degraded"},
+		{name: "identity expired body", status: http.StatusUnauthorized, body: `{"outcome":"identity_expired","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`, outcome: "identity_expired"},
+		{name: "unavailable", status: http.StatusInternalServerError, outcome: "source_unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			source := sourceConfig{SourceID: "bws", Kind: "bitwarden-bws", Enabled: true, Address: server.URL, Token: "fake-bws-token"}
+			res := source.resolve("ref", sourceRefConfig{Path: "secret-123"})
+			if res.Outcome != tt.outcome || res.Value != "" {
+				t.Fatalf("outcome = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message, "outcome": res.Outcome})
+		})
+	}
+}
+
+func TestBitwardenBWSSourceAdapterRequiresTokenAndMapping(t *testing.T) {
+	missingToken := sourceConfig{SourceID: "bws", Kind: "bitwarden-bws", Enabled: true, Address: "https://bws.invalid"}
+	res := missingToken.resolve("ref", sourceRefConfig{Path: "secret-123"})
+	if res.Outcome != "source_auth_required" {
+		t.Fatalf("missing token outcome = %#v", res)
+	}
+
+	missingMapping := sourceConfig{SourceID: "bws", Kind: "bitwarden-bws", Enabled: true, Address: "https://bws.invalid", Token: "fake-bws-token"}
+	res = missingMapping.resolve("ref", sourceRefConfig{})
+	if res.Outcome != "invalid_ref" {
+		t.Fatalf("missing mapping outcome = %#v", res)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+}
+
+func TestBitwardenBWSSourceAdapterBoundsAPIResponseWithoutLeaking(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":"`+strings.Repeat("A", 64)+`SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE"}`)
+	}))
+	defer server.Close()
+
+	source := sourceConfig{SourceID: "bws", Kind: "bitwarden-bws", Enabled: true, Address: server.URL, Token: "fake-bws-token"}
+	res := source.resolve("ref", sourceRefConfig{Path: "secret-123", MaxStdoutBytes: 16})
+	if res.Outcome != "source_unavailable" || res.Value != "" {
+		t.Fatalf("oversized result = %#v", res)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+}
+
+func TestBitwardenBWSSourceAdapterCLISuccessAndOutcomes(t *testing.T) {
+	cases := []struct {
+		mode        string
+		wantOutcome string
+		wantValue   string
+	}{
+		{mode: "success", wantOutcome: "ready", wantValue: "bws-cli-secret"},
+		{mode: "auth-required", wantOutcome: "source_auth_required"},
+		{mode: "policy-denied", wantOutcome: "policy_denied"},
+		{mode: "missing-ref", wantOutcome: "missing_ref"},
+		{mode: "degraded", wantOutcome: "degraded"},
+		{mode: "invalid-ref", wantOutcome: "invalid_ref"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			source, refCfg := bitwardenBWSCLIFixture(t, tc.mode)
+			res := source.resolve("ref", refCfg)
+			if res.Outcome != tc.wantOutcome || res.Value != tc.wantValue {
+				t.Fatalf("cli result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+		})
+	}
+}
+
+func TestBitwardenBWSSourceAdapterCLIHandlesFailureTimeoutAndLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{name: "failure", mode: "failure"},
+		{name: "timeout", mode: "timeout"},
+		{name: "invalid json", mode: "invalid-json"},
+		{name: "oversized", mode: "oversized"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source, refCfg := bitwardenBWSCLIFixture(t, tc.mode)
+			refCfg.TimeoutMs = 50
+			if tc.mode == "oversized" {
+				refCfg.MaxStdoutBytes = 16
+			}
+			res := source.resolve("ref", refCfg)
+			if res.Outcome != "source_unavailable" || res.Value != "" {
+				t.Fatalf("cli result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+		})
+	}
+}
+
+func TestBitwardenBWSSourceStatusReportsContractCapabilities(t *testing.T) {
+	caps := capabilitiesForSourceKind("bitwarden-bws")
+	for _, capability := range []string{"read", "reveal", "write/update", "audit", "migration", "health"} {
+		assertContains(t, caps, capability)
+	}
+	for _, capability := range []string{"rotate/reset", "policy", "value-search"} {
+		assertNotContains(t, caps, capability)
+	}
+}
+
+func TestBitwardenBWSSourceRegistryStateAndNoTokenLeak(t *testing.T) {
+	backend := newLocalBackend("store.json", "audit.jsonl", "master-key")
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID:   "bws-prod",
+		Kind:       "bitwarden-bws",
+		Enabled:    true,
+		Address:    "https://bws.example.com",
+		TokenEnv:   "MISSING_BWS_TOKEN",
+		Namespaces: []string{"prod/*"},
+		Refs:       map[string]sourceRefConfig{"prod/openclaw/api_key": {Path: "secret-123"}},
+	}}}
+
+	registry := defaultSourceRegistry(backend)
+	if len(registry.Sources) != 2 {
+		t.Fatalf("sources = %#v", registry.Sources)
+	}
+	bws := registry.Sources[1]
+	if bws.SourceID != "bws-prod" || bws.State != "auth_required" || bws.Outcome != "source_auth_required" {
+		t.Fatalf("bws source = %#v", bws)
+	}
+	assertContains(t, bws.Capabilities, "write/update")
+	assertContains(t, bws.Capabilities, "migration")
+	assertContains(t, bws.Namespaces, "prod/*")
+	assertNoSecretMaterialSurfaces(t, map[string]string{
+		"sourceID":   bws.SourceID,
+		"kind":       bws.Kind,
+		"outcome":    bws.Outcome,
+		"nextAction": bws.NextAction,
+	})
+}
+
+func bitwardenBWSCLIFixture(t *testing.T, mode string) (sourceConfig, sourceRefConfig) {
+	t.Helper()
+	command, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := sourceConfig{
+		SourceID:            "bws-cli",
+		Kind:                "bitwarden-bws",
+		Enabled:             true,
+		Token:               "fake-bws-token",
+		TrustedDirs:         []string{filepath.Dir(command)},
+		AllowSymlinkCommand: true,
+	}
+	refCfg := sourceRefConfig{
+		Path:           "secret-123",
+		Command:        command,
+		Args:           []string{"-test.run=TestBitwardenBWSSourceHelperProcess", "--", mode},
+		TimeoutMs:      2000,
+		MaxStdoutBytes: 4096,
+	}
+	return source, refCfg
+}
+
+func TestBitwardenBWSSourceHelperProcess(t *testing.T) {
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		return
+	}
+	if os.Getenv("BWS_ACCESS_TOKEN") == "" || os.Getenv("BITWARDEN_BWS_SECRET_ID") != "secret-123" {
+		os.Exit(3)
+	}
+	switch args[separator+1] {
+	case "success":
+		os.Stdout.WriteString(`{"value":"bws-cli-secret"}`)
+	case "auth-required":
+		os.Stdout.WriteString(`{"outcome":"source_auth_required","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+	case "policy-denied":
+		os.Stdout.WriteString(`{"outcome":"policy_denied","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE"}`)
+	case "missing-ref":
+		os.Stdout.WriteString(`{"outcome":"missing_ref","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+	case "degraded":
+		os.Stdout.WriteString(`{"outcome":"degraded","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+	case "invalid-ref":
+		os.Stdout.WriteString(`{"outcome":"invalid_ref","message":"-----BEGIN SERVICE LASSO FAKE PRIVATE KEY-----"}`)
+	case "invalid-json":
+		os.Stdout.WriteString(`not-json SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+	case "oversized":
+		os.Stdout.WriteString(strings.Repeat("A", 64) + "SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE")
+	case "failure":
+		os.Stdout.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+		os.Stderr.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE`)
+		os.Exit(2)
+	case "timeout":
+		time.Sleep(2 * time.Second)
+	}
+	os.Exit(0)
+}

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -126,6 +126,7 @@ func defaultProviderCapabilities() []providerCapability {
 		{ProviderKind: "env", DisplayName: "Environment variables", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 		{ProviderKind: "file", DisplayName: "File source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 		{ProviderKind: "exec", DisplayName: "Exec source", Supported: true, Capabilities: []string{"read", "reveal", "health", "audit", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
+		{ProviderKind: "bitwarden-bws", DisplayName: "Bitwarden/BWS", Supported: true, Capabilities: capabilitiesForSourceKind("bitwarden-bws"), Limitations: []string{"migration target apply requires a configured remote write path"}},
 	}
 }
 
@@ -154,7 +155,7 @@ func (b *localBackend) providerConfigStatusResponse() providerConfigStatusRespon
 func providerStatusFromSource(source SourceStatus, backend *localBackend) providerConfigStatus {
 	credential := ""
 	address := ""
-	if source.Kind == "vault" || source.Kind == "openbao" {
+	if source.Kind == "vault" || source.Kind == "openbao" || source.Kind == "bitwarden-bws" {
 		credential = "configured-ref-or-env"
 	}
 	if source.SourceID == "local" {
@@ -225,12 +226,12 @@ func providerStatusFromConfigRequest(req providerConfigRequest, apply bool) (pro
 		status.Outcome = "unsupported"
 		return status, errUnsupportedProvider
 	}
-	if (kind == "vault" || kind == "openbao") && strings.TrimSpace(req.CredentialRef) == "" {
+	if (kind == "vault" || kind == "openbao" || kind == "bitwarden-bws") && strings.TrimSpace(req.CredentialRef) == "" {
 		status.State = "auth_required"
 		status.Outcome = "source_auth_required"
 		return status, errSourceAuthRequired
 	}
-	if (kind == "vault" || kind == "openbao") && strings.TrimSpace(req.Address) == "" {
+	if (kind == "vault" || kind == "openbao" || kind == "bitwarden-bws") && strings.TrimSpace(req.Address) == "" {
 		status.State = "config_error"
 		status.Outcome = "invalid_ref"
 		return status, errInvalidRef

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,8 @@ func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveR
 		return s.resolveExec(refCfg)
 	case "vault", "openbao":
 		return s.resolveVault(refCfg)
+	case "bitwarden-bws":
+		return s.resolveBitwardenBWS(refCfg)
 	default:
 		return sourceResolveResult{Outcome: "invalid_ref", Message: fmt.Sprintf("Unsupported source kind %q.", s.Kind)}
 	}
@@ -362,6 +365,179 @@ func vaultField(payload map[string]any, field string) (string, bool) {
 	}
 	text, ok := value.(string)
 	return text, ok
+}
+
+func (s sourceConfig) resolveBitwardenBWS(refCfg sourceRefConfig) sourceResolveResult {
+	if strings.TrimSpace(refCfg.Path) == "" {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Bitwarden/BWS source mapping requires a secret id path."}
+	}
+	token := firstNonEmpty(s.Token, os.Getenv(s.TokenEnv))
+	if strings.TrimSpace(token) == "" {
+		return sourceResolveResult{Outcome: "source_auth_required", Message: "Bitwarden/BWS access token is missing or expired."}
+	}
+	if strings.TrimSpace(refCfg.Command) != "" {
+		return s.resolveBitwardenBWSCLI(refCfg, token)
+	}
+	return s.resolveBitwardenBWSAPI(refCfg, token)
+}
+
+func (s sourceConfig) resolveBitwardenBWSAPI(refCfg sourceRefConfig, token string) sourceResolveResult {
+	if strings.TrimSpace(s.Address) == "" {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Bitwarden/BWS API source requires address or command."}
+	}
+	secretURL, err := url.JoinPath(strings.TrimRight(s.Address, "/"), "v1", "secrets", strings.TrimLeft(refCfg.Path, "/"))
+	if err != nil {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Bitwarden/BWS API URL is invalid."}
+	}
+	req, err := http.NewRequest(http.MethodGet, secretURL, nil)
+	if err != nil {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Bitwarden/BWS API request is invalid."}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := http.Client{Timeout: time.Duration(firstPositive(refCfg.TimeoutMs, 5000)) * time.Millisecond}
+	res, err := client.Do(req)
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Bitwarden/BWS API is unavailable."}
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return bitwardenStatusResult(res.StatusCode, res.Body, refCfg)
+	}
+	return decodeBitwardenBWSValue(res.Body, refCfg, "Bitwarden/BWS API")
+}
+
+func (s sourceConfig) resolveBitwardenBWSCLI(refCfg sourceRefConfig, token string) sourceResolveResult {
+	if err := validateExecConfig(s, refCfg); err != nil {
+		return sourceResolveResult{Outcome: "invalid_ref", Message: err.Error()}
+	}
+	timeout := time.Duration(firstPositive(refCfg.TimeoutMs, 5000)) * time.Millisecond
+	maxStdout := firstPositive(refCfg.MaxStdoutBytes, 65536)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, refCfg.Command, refCfg.Args...)
+	cmd.Env = append(os.Environ(), "BWS_ACCESS_TOKEN="+token, "BITWARDEN_BWS_SECRET_ID="+refCfg.Path)
+	stdout := newBoundedOutput(maxStdout)
+	cmd.Stdout = stdout
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Bitwarden/BWS CLI timed out."}
+	}
+	if err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Bitwarden/BWS CLI failed."}
+	}
+	if stdout.Exceeded() {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Bitwarden/BWS CLI output exceeded limit."}
+	}
+	return decodeBitwardenBWSValue(bytes.NewReader(stdout.Bytes()), refCfg, "Bitwarden/BWS CLI")
+}
+
+func bitwardenStatusResult(status int, body io.Reader, refCfg sourceRefConfig) sourceResolveResult {
+	if outcome := bitwardenOutcomeFromBody(body, refCfg); outcome != "" && outcome != "ready" {
+		return sourceResolveResult{Outcome: outcome, Message: bitwardenOutcomeMessage(outcome)}
+	}
+	switch status {
+	case http.StatusUnauthorized:
+		return sourceResolveResult{Outcome: "source_auth_required", Message: "Bitwarden/BWS access token is missing or expired."}
+	case http.StatusForbidden:
+		return sourceResolveResult{Outcome: "policy_denied", Message: "Bitwarden/BWS policy denied access."}
+	case http.StatusNotFound:
+		return sourceResolveResult{Outcome: "missing_ref", Message: "Bitwarden/BWS secret was not found."}
+	case http.StatusTooManyRequests:
+		return sourceResolveResult{Outcome: "degraded", Message: "Bitwarden/BWS source is degraded."}
+	default:
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "Bitwarden/BWS source returned a non-success status."}
+	}
+}
+
+func bitwardenOutcomeFromBody(body io.Reader, refCfg sourceRefConfig) string {
+	limit := int64(firstPositive(refCfg.MaxStdoutBytes, 65536))
+	bytes, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil || int64(len(bytes)) > limit || len(strings.TrimSpace(string(bytes))) == 0 {
+		return ""
+	}
+	var payload bitwardenBWSPayload
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return ""
+	}
+	return normalizeBitwardenOutcome(payload.Outcome)
+}
+
+func decodeBitwardenBWSValue(body io.Reader, refCfg sourceRefConfig, label string) sourceResolveResult {
+	limit := int64(firstPositive(refCfg.MaxStdoutBytes, 65536))
+	bytes, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil || int64(len(bytes)) > limit {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: label + " response could not be read safely."}
+	}
+	var payload bitwardenBWSPayload
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: label + " response was not JSON."}
+	}
+	if outcome := normalizeBitwardenOutcome(payload.Outcome); outcome != "" && outcome != "ready" {
+		return sourceResolveResult{Outcome: outcome, Message: bitwardenOutcomeMessage(outcome)}
+	}
+	value, ok := bitwardenBWSField(payload, firstNonEmpty(refCfg.Field, "value"))
+	if !ok || strings.TrimSpace(value) == "" {
+		return sourceResolveResult{Outcome: "missing_ref", Message: label + " value field was not found."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: value}
+}
+
+type bitwardenBWSPayload struct {
+	Value   string         `json:"value"`
+	Outcome string         `json:"outcome"`
+	Data    map[string]any `json:"data"`
+	Secret  map[string]any `json:"secret"`
+}
+
+func bitwardenBWSField(payload bitwardenBWSPayload, field string) (string, bool) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		field = "value"
+	}
+	if field == "value" && payload.Value != "" {
+		return payload.Value, true
+	}
+	for _, candidate := range []map[string]any{payload.Data, payload.Secret} {
+		if candidate == nil {
+			continue
+		}
+		if value, ok := candidate[field]; ok {
+			text, ok := value.(string)
+			return text, ok
+		}
+	}
+	return "", false
+}
+
+func normalizeBitwardenOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "", "ready":
+		return strings.TrimSpace(outcome)
+	case "source_auth_required", "identity_expired", "policy_denied", "missing_ref", "source_unavailable", "degraded", "invalid_ref":
+		return strings.TrimSpace(outcome)
+	default:
+		return "source_unavailable"
+	}
+}
+
+func bitwardenOutcomeMessage(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "Bitwarden/BWS authentication is required."
+	case "identity_expired":
+		return "Bitwarden/BWS identity expired."
+	case "policy_denied":
+		return "Bitwarden/BWS policy denied access."
+	case "missing_ref":
+		return "Bitwarden/BWS secret was not found."
+	case "invalid_ref":
+		return "Bitwarden/BWS source mapping is invalid."
+	case "degraded":
+		return "Bitwarden/BWS source is degraded."
+	default:
+		return "Bitwarden/BWS source is unavailable."
+	}
 }
 
 func validateExecConfig(source sourceConfig, refCfg sourceRefConfig) error {

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -107,6 +107,16 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
 			return normalizeSourceLifecycle("source_auth_required")
 		}
+	case "bitwarden-bws":
+		if len(source.Refs) == 0 {
+			return normalizeSourceLifecycle("missing_ref")
+		}
+		if strings.TrimSpace(source.Address) == "" && !sourceHasCommandMapping(source) {
+			return normalizeSourceLifecycle("invalid_ref")
+		}
+		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
+			return normalizeSourceLifecycle("source_auth_required")
+		}
 	default:
 		return normalizeSourceLifecycle("invalid_ref")
 	}
@@ -139,11 +149,26 @@ func capabilitiesForSourceKind(kind string) []string {
 			return append(adapterCapabilityNames(contract.Capabilities), "health")
 		}
 		return []string{"read", "reveal", "migration", "health"}
+	case "bitwarden-bws":
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "write/update", "audit", "migration", "health"}
 	case "vault", "openbao":
 		return []string{"read", "health"}
 	default:
 		return []string{"health"}
 	}
+}
+
+func sourceHasCommandMapping(source sourceConfig) bool {
+	for _, ref := range source.Refs {
+		if strings.TrimSpace(ref.Command) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func registerSourceRegistryHandlers(mux *http.ServeMux, backend *localBackend) {


### PR DESCRIPTION
## Summary
- add `bitwarden-bws` source resolution via bounded fake-compatible API and trusted CLI protocols
- map BWS auth, policy denied, missing ref, degraded, unavailable, invalid mapping, timeout, and output-limit states to normalized broker outcomes
- expose BWS source/provider lifecycle metadata and capabilities without surfacing tokens or secret values

## Validation
- `go test ./...`
- `git diff --check`
- `$env:SERVICE_LASSO_HARNESS_BIN='C:\projects\service-lasso\lasso-secretsbroker\.harness\bin\service-lasso-harness.exe'; .\scripts\verify.ps1`

Closes #50