### PR TITLE
fix #49 implement 1Password CLI source adapter

### DIFF
--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -366,10 +366,13 @@ func onePasswordCLIArgs(refCfg sourceRefConfig) []string {
 	}
 	path := strings.TrimSpace(refCfg.Path)
 	field := strings.TrimSpace(refCfg.Field)
-	if field == "" {
-		return []string{"read", path, "--format", "json"}
+	if strings.HasPrefix(strings.ToLower(path), "op://") {
+		return []string{"read", path}
 	}
-	return []string{"item", "get", path, "--field", field, "--format", "json"}
+	if field == "" {
+		return []string{"item", "get", path, "--format", "json"}
+	}
+	return []string{"item", "get", path, "--fields", "label=" + field, "--format", "json"}
 }
 
 func decodeOnePasswordCLIValue(output []byte, refCfg sourceRefConfig) sourceResolveResult {

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -113,6 +113,8 @@ func (s sourceConfig) resolve(ref string, refCfg sourceRefConfig) sourceResolveR
 		return s.resolveExec(refCfg)
 	case "vault", "openbao":
 		return s.resolveVault(refCfg)
+	case "onepassword-cli":
+		return s.resolveOnePasswordCLI(ref, refCfg)
 	case "bitwarden-bws":
 		return s.resolveBitwardenBWS(refCfg)
 	default:
@@ -284,6 +286,208 @@ func execProtocolOutcomeMessage(outcome string) string {
 		return "Exec source protocol mapping is invalid."
 	default:
 		return "Exec source reported unavailable state."
+	}
+}
+
+func (s sourceConfig) resolveOnePasswordCLI(ref string, refCfg sourceRefConfig) sourceResolveResult {
+	if err := validateOnePasswordCLIConfig(s, refCfg); err != nil {
+		if errors.Is(err, errOnePasswordCommandOutsideTrustedDirs) {
+			return sourceResolveResult{Outcome: "policy_denied", Message: "1Password CLI command is outside trustedDirs."}
+		}
+		return sourceResolveResult{Outcome: "invalid_ref", Message: err.Error()}
+	}
+	timeout := time.Duration(firstPositive(refCfg.TimeoutMs, 5000)) * time.Millisecond
+	maxOutput := firstPositive(refCfg.MaxStdoutBytes, firstPositive(refCfg.MaxBytes, 32768))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, refCfg.Command, onePasswordCLIArgs(refCfg)...)
+	cmd.Env = append(os.Environ(),
+		"OP_ITEM_REF="+refCfg.Path,
+		"OP_FIELD_REF="+refCfg.Field,
+		"SERVICE_LASSO_SECRET_REF="+ref,
+		"SERVICE_LASSO_SOURCE_ID="+s.SourceID,
+	)
+	stdout := newBoundedOutput(maxOutput)
+	stderr := newBoundedOutput(maxOutput)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "1Password CLI timed out."}
+	}
+	if stdout.Exceeded() || stderr.Exceeded() {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "1Password CLI output exceeded limit."}
+	}
+	if err != nil {
+		if outcome := onePasswordCLIOutcomeFromOutput(stdout.Bytes(), stderr.Bytes()); outcome != "" {
+			return sourceResolveResult{Outcome: outcome, Message: onePasswordCLIOutcomeMessage(outcome)}
+		}
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "1Password CLI is unavailable or failed."}
+	}
+	return decodeOnePasswordCLIValue(stdout.Bytes(), refCfg)
+}
+
+var errOnePasswordCommandOutsideTrustedDirs = errors.New("onepassword-cli command is outside trustedDirs")
+
+func validateOnePasswordCLIConfig(source sourceConfig, refCfg sourceRefConfig) error {
+	if strings.TrimSpace(refCfg.Command) == "" {
+		return errors.New("1Password CLI source mapping is missing command")
+	}
+	if strings.TrimSpace(refCfg.Path) == "" {
+		return errors.New("1Password CLI source mapping is missing item/ref path")
+	}
+	if len(source.TrustedDirs) > 0 {
+		cleanCommand, err := filepath.Abs(strings.TrimSpace(refCfg.Command))
+		if err != nil {
+			return errors.New("1Password CLI command path is invalid")
+		}
+		allowed := false
+		for _, dir := range source.TrustedDirs {
+			cleanDir, err := filepath.Abs(strings.TrimSpace(dir))
+			if err != nil {
+				continue
+			}
+			rel, err := filepath.Rel(cleanDir, cleanCommand)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return errOnePasswordCommandOutsideTrustedDirs
+		}
+	}
+	return validateExecConfig(source, refCfg)
+}
+
+func onePasswordCLIArgs(refCfg sourceRefConfig) []string {
+	if len(refCfg.Args) > 0 {
+		return append([]string{}, refCfg.Args...)
+	}
+	path := strings.TrimSpace(refCfg.Path)
+	field := strings.TrimSpace(refCfg.Field)
+	if field == "" {
+		return []string{"read", path, "--format", "json"}
+	}
+	return []string{"item", "get", path, "--field", field, "--format", "json"}
+}
+
+func decodeOnePasswordCLIValue(output []byte, refCfg sourceRefConfig) sourceResolveResult {
+	if outcome := onePasswordCLIOutcomeFromOutput(output, nil); outcome != "" && outcome != "ready" {
+		return sourceResolveResult{Outcome: outcome, Message: onePasswordCLIOutcomeMessage(outcome)}
+	}
+	value, ok := onePasswordCLIValueFromJSON(output, refCfg)
+	if !ok {
+		value = strings.TrimSpace(string(output))
+	}
+	if strings.TrimSpace(value) == "" {
+		return sourceResolveResult{Outcome: "source_unavailable", Message: "1Password CLI returned empty value."}
+	}
+	return sourceResolveResult{Outcome: "ready", Value: strings.TrimSpace(value)}
+}
+
+type onePasswordCLIPayload struct {
+	Value   string           `json:"value"`
+	Outcome string           `json:"outcome"`
+	Field   map[string]any   `json:"field"`
+	Fields  []map[string]any `json:"fields"`
+	Details struct {
+		Fields []map[string]any `json:"fields"`
+	} `json:"details"`
+}
+
+func onePasswordCLIValueFromJSON(output []byte, refCfg sourceRefConfig) (string, bool) {
+	var payload onePasswordCLIPayload
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(payload.Value) != "" {
+		return payload.Value, true
+	}
+	fieldName := strings.TrimSpace(refCfg.Field)
+	if value, ok := onePasswordFieldValue(payload.Field, fieldName); ok {
+		return value, true
+	}
+	for _, field := range append(payload.Fields, payload.Details.Fields...) {
+		if value, ok := onePasswordFieldValue(field, fieldName); ok {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func onePasswordFieldValue(field map[string]any, fieldName string) (string, bool) {
+	if field == nil {
+		return "", false
+	}
+	if fieldName != "" {
+		matched := false
+		for _, key := range []string{"id", "label", "name"} {
+			if text, ok := field[key].(string); ok && strings.EqualFold(strings.TrimSpace(text), fieldName) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return "", false
+		}
+	}
+	if text, ok := field["value"].(string); ok && strings.TrimSpace(text) != "" {
+		return text, true
+	}
+	return "", false
+}
+
+func onePasswordCLIOutcomeFromOutput(stdout, stderr []byte) string {
+	for _, output := range [][]byte{stdout, stderr} {
+		var payload onePasswordCLIPayload
+		if len(strings.TrimSpace(string(output))) > 0 && json.Unmarshal(output, &payload) == nil {
+			if outcome := normalizeOnePasswordCLIOutcome(payload.Outcome); outcome != "" {
+				return outcome
+			}
+		}
+		text := strings.ToLower(string(output))
+		switch {
+		case strings.Contains(text, "not signed in") || strings.Contains(text, "sign in") || strings.Contains(text, "not currently signed in"):
+			return "source_auth_required"
+		case strings.Contains(text, "session expired") || strings.Contains(text, "session has expired") || strings.Contains(text, "identity expired"):
+			return "identity_expired"
+		case strings.Contains(text, "permission denied") || strings.Contains(text, "access denied") || strings.Contains(text, "not authorized"):
+			return "policy_denied"
+		case strings.Contains(text, "not found") || strings.Contains(text, "does not exist") || strings.Contains(text, "field") && strings.Contains(text, "missing"):
+			return "missing_ref"
+		case strings.Contains(text, "invalid"):
+			return "invalid_ref"
+		}
+	}
+	return ""
+}
+
+func normalizeOnePasswordCLIOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "", "ready":
+		return strings.TrimSpace(outcome)
+	case "source_auth_required", "identity_expired", "policy_denied", "missing_ref", "source_unavailable", "invalid_ref":
+		return strings.TrimSpace(outcome)
+	default:
+		return "source_unavailable"
+	}
+}
+
+func onePasswordCLIOutcomeMessage(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "1Password CLI authentication is required."
+	case "identity_expired":
+		return "1Password CLI session expired."
+	case "policy_denied":
+		return "1Password CLI policy denied access."
+	case "missing_ref":
+		return "1Password CLI item or field was not found."
+	case "invalid_ref":
+		return "1Password CLI source mapping is invalid."
+	default:
+		return "1Password CLI source is unavailable."
 	}
 }
 

--- a/cmd/secretsbroker/source_adapters_test.go
+++ b/cmd/secretsbroker/source_adapters_test.go
@@ -252,6 +252,97 @@ func TestExecSourceStatusReportsContractCapabilities(t *testing.T) {
 	}
 }
 
+func TestOnePasswordCLIAdapterJSONProtocolSuccess(t *testing.T) {
+	cfg, refCfg := onePasswordCLIFixture(t, "success-json")
+	res := cfg.resolve("openclaw/op", refCfg)
+	if res.Outcome != "ready" || res.Value != "op-secret" {
+		t.Fatalf("1Password CLI result = %#v", res)
+	}
+}
+
+func TestOnePasswordCLIAdapterNormalizesFailuresWithoutLeakingOutput(t *testing.T) {
+	cases := []struct {
+		name        string
+		mode        string
+		wantOutcome string
+	}{
+		{name: "not signed in", mode: "auth-required", wantOutcome: "source_auth_required"},
+		{name: "expired session", mode: "identity-expired", wantOutcome: "identity_expired"},
+		{name: "policy denied", mode: "policy-denied", wantOutcome: "policy_denied"},
+		{name: "missing item", mode: "missing-item", wantOutcome: "missing_ref"},
+		{name: "missing field", mode: "missing-field", wantOutcome: "missing_ref"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, refCfg := onePasswordCLIFixture(t, tc.mode)
+			res := cfg.resolve("openclaw/op", refCfg)
+			if res.Outcome != tc.wantOutcome || res.Value != "" {
+				t.Fatalf("1Password CLI result = %#v", res)
+			}
+			assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message, "outcome": res.Outcome})
+		})
+	}
+}
+
+func TestOnePasswordCLIAdapterHandlesUnavailableTimeoutAndOutputLimit(t *testing.T) {
+	t.Run("unavailable cli", func(t *testing.T) {
+		trusted := t.TempDir()
+		source := sourceConfig{SourceID: "op-local", Kind: "onepassword-cli", Enabled: true, TrustedDirs: []string{trusted}}
+		res := source.resolve("openclaw/op", sourceRefConfig{Command: filepath.Join(trusted, "missing-op"), Path: "op://local/api/password"})
+		if res.Outcome != "source_unavailable" || res.Value != "" {
+			t.Fatalf("1Password CLI unavailable result = %#v", res)
+		}
+		assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		cfg, refCfg := onePasswordCLIFixture(t, "timeout")
+		refCfg.TimeoutMs = 50
+		res := cfg.resolve("openclaw/op", refCfg)
+		if res.Outcome != "source_unavailable" || res.Value != "" {
+			t.Fatalf("1Password CLI timeout result = %#v", res)
+		}
+		assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+	})
+
+	t.Run("output limit", func(t *testing.T) {
+		cfg, refCfg := onePasswordCLIFixture(t, "oversized")
+		refCfg.MaxStdoutBytes = 16
+		res := cfg.resolve("openclaw/op", refCfg)
+		if res.Outcome != "source_unavailable" || res.Value != "" {
+			t.Fatalf("1Password CLI oversized result = %#v", res)
+		}
+		assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+	})
+}
+
+func TestOnePasswordCLIAdapterRejectsInvalidMappingAndUntrustedCommand(t *testing.T) {
+	cfg, refCfg := onePasswordCLIFixture(t, "success-json")
+	refCfg.Path = " "
+	res := cfg.resolve("openclaw/op", refCfg)
+	if res.Outcome != "invalid_ref" {
+		t.Fatalf("missing path result = %#v", res)
+	}
+
+	cfg, refCfg = onePasswordCLIFixture(t, "success-json")
+	cfg.TrustedDirs = []string{filepath.Join(t.TempDir(), "trusted")}
+	res = cfg.resolve("openclaw/op", refCfg)
+	if res.Outcome != "policy_denied" {
+		t.Fatalf("untrusted command result = %#v", res)
+	}
+	assertNoSecretMaterialSurfaces(t, map[string]string{"message": res.Message})
+}
+
+func TestOnePasswordCLIStatusReportsContractCapabilities(t *testing.T) {
+	caps := capabilitiesForSourceKind("onepassword-cli")
+	for _, capability := range []string{"read", "reveal", "audit", "migration", "health"} {
+		assertContains(t, caps, capability)
+	}
+	for _, capability := range []string{"write/update", "rotate/reset", "policy", "value-search"} {
+		assertNotContains(t, caps, capability)
+	}
+}
+
 func TestEnvSourceStatusReportsContractCapabilities(t *testing.T) {
 	caps := capabilitiesForSourceKind("env")
 	for _, capability := range []string{"read", "reveal", "migration", "health"} {
@@ -293,6 +384,30 @@ func execSourceFixture(t *testing.T, mode string) (sourceConfig, sourceRefConfig
 	return source, refCfg
 }
 
+func onePasswordCLIFixture(t *testing.T, mode string) (sourceConfig, sourceRefConfig) {
+	t.Helper()
+	command, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := sourceConfig{
+		SourceID:            "op-local",
+		Kind:                "onepassword-cli",
+		Enabled:             true,
+		TrustedDirs:         []string{filepath.Dir(command)},
+		AllowSymlinkCommand: true,
+	}
+	refCfg := sourceRefConfig{
+		Command:        command,
+		Args:           []string{"-test.run=TestOnePasswordCLIHelperProcess", "--", mode},
+		Path:           "op://local/api/password",
+		Field:          "password",
+		TimeoutMs:      2000,
+		MaxStdoutBytes: 4096,
+	}
+	return source, refCfg
+}
+
 func TestExecSourceHelperProcess(t *testing.T) {
 	args := os.Args
 	separator := -1
@@ -324,6 +439,44 @@ func TestExecSourceHelperProcess(t *testing.T) {
 		os.Stdout.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
 		os.Stderr.WriteString(`SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE`)
 		os.Exit(2)
+	case "timeout":
+		time.Sleep(2 * time.Second)
+	}
+	os.Exit(0)
+}
+
+func TestOnePasswordCLIHelperProcess(t *testing.T) {
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		return
+	}
+	switch args[separator+1] {
+	case "success-json":
+		os.Stdout.WriteString(`{"value":"op-secret"}`)
+	case "auth-required":
+		os.Stderr.WriteString(`not signed in SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+		os.Exit(2)
+	case "identity-expired":
+		os.Stdout.WriteString(`{"outcome":"identity_expired","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"}`)
+		os.Exit(2)
+	case "policy-denied":
+		os.Stderr.WriteString(`permission denied SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE`)
+		os.Exit(2)
+	case "missing-item":
+		os.Stdout.WriteString(`{"outcome":"missing_ref","message":"SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE"}`)
+		os.Exit(2)
+	case "missing-field":
+		os.Stderr.WriteString(`field missing SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE`)
+		os.Exit(2)
+	case "oversized":
+		os.Stdout.WriteString(strings.Repeat("A", 64) + "SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE")
 	case "timeout":
 		time.Sleep(2 * time.Second)
 	}

--- a/cmd/secretsbroker/source_adapters_test.go
+++ b/cmd/secretsbroker/source_adapters_test.go
@@ -260,6 +260,43 @@ func TestOnePasswordCLIAdapterJSONProtocolSuccess(t *testing.T) {
 	}
 }
 
+func TestOnePasswordCLIAdapterDefaultArgsUseDocumentedCLIForms(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  sourceRefConfig
+		want []string
+	}{
+		{
+			name: "secret reference",
+			ref:  sourceRefConfig{Path: "op://local/api/password", Field: "password"},
+			want: []string{"read", "op://local/api/password"},
+		},
+		{
+			name: "item metadata json",
+			ref:  sourceRefConfig{Path: "api-item"},
+			want: []string{"item", "get", "api-item", "--format", "json"},
+		},
+		{
+			name: "item field json",
+			ref:  sourceRefConfig{Path: "api-item", Field: "password"},
+			want: []string{"item", "get", "api-item", "--fields", "label=password", "--format", "json"},
+		},
+		{
+			name: "custom args override defaults",
+			ref:  sourceRefConfig{Path: "api-item", Field: "password", Args: []string{"read", "op://custom/ref"}},
+			want: []string{"read", "op://custom/ref"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := onePasswordCLIArgs(tc.ref)
+			if strings.Join(got, "\x00") != strings.Join(tc.want, "\x00") {
+				t.Fatalf("args = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestOnePasswordCLIAdapterNormalizesFailuresWithoutLeakingOutput(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -100,6 +100,13 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 		if len(source.Refs) == 0 {
 			return normalizeSourceLifecycle("missing_ref")
 		}
+	case "onepassword-cli":
+		if len(source.Refs) == 0 {
+			return normalizeSourceLifecycle("missing_ref")
+		}
+		if !sourceHasCommandMapping(source) {
+			return normalizeSourceLifecycle("invalid_ref")
+		}
 	case "vault", "openbao":
 		if strings.TrimSpace(source.Address) == "" {
 			return normalizeSourceLifecycle("invalid_ref")
@@ -155,6 +162,12 @@ func capabilitiesForSourceKind(kind string) []string {
 			return append(adapterCapabilityNames(contract.Capabilities), "health")
 		}
 		return []string{"read", "reveal", "write/update", "audit", "migration", "health"}
+	case "onepassword-cli":
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "audit", "migration", "health"}
 	case "vault", "openbao":
 		return []string{"read", "health"}
 	default:


### PR DESCRIPTION
## Summary\n- adds the onepassword-cli source adapter behind the existing external adapter contract\n- normalizes auth/session/policy/missing/unavailable/timeout/invalid mapping states without echoing raw CLI output\n- registers 1Password CLI lifecycle/capability status and adds fake CLI fixture coverage\n- aligns default command forms with 1Password CLI docs: op read for secret references, op item get --fields label=... --format json for item field metadata\n\n## Validation\n- go test ./...\n- git diff --check\n- SERVICE_LASSO_HARNESS_BIN=C:\\projects\\service-lasso\\lasso-secretsbroker\\.harness\\bin\\service-lasso-harness.exe .\\scripts\\verify.ps1\n\nCloses #49