### PR TITLE
feat(#47): align Vault/OpenBao adapter contract

### DIFF
--- a/cmd/secretsbroker/adapter_contract.go
+++ b/cmd/secretsbroker/adapter_contract.go
@@ -193,6 +193,10 @@ func adapterContractsByKind() map[string]AdapterContract {
 	for _, contract := range externalAdapterContracts() {
 		contracts[contract.Kind] = contract
 	}
+	if contract, ok := contracts["vault-openbao"]; ok {
+		contracts["vault"] = contract
+		contracts["openbao"] = contract
+	}
 	return contracts
 }
 

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -121,8 +121,8 @@ type migrationPlanResponse struct {
 func defaultProviderCapabilities() []providerCapability {
 	return []providerCapability{
 		{ProviderKind: "local-encrypted-store", DisplayName: "Local encrypted store", Supported: true, Capabilities: capabilitiesForSourceKind("local-encrypted-store"), Limitations: []string{"local-first development backend"}},
-		{ProviderKind: "vault", DisplayName: "Vault", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
-		{ProviderKind: "openbao", DisplayName: "OpenBao", Supported: true, Capabilities: []string{"read", "reveal", "health", "migration_source"}, Limitations: []string{"write and migration target apply require provider write adapter"}},
+		{ProviderKind: "vault", DisplayName: "Vault", Supported: true, Capabilities: capabilitiesForSourceKind("vault"), Limitations: []string{"remote write, rotation, policy apply, and migration target apply require a configured provider operation path"}},
+		{ProviderKind: "openbao", DisplayName: "OpenBao", Supported: true, Capabilities: capabilitiesForSourceKind("openbao"), Limitations: []string{"remote write, rotation, policy apply, and migration target apply require a configured provider operation path"}},
 		{ProviderKind: "env", DisplayName: "Environment variables", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 		{ProviderKind: "file", DisplayName: "File source", Supported: true, Capabilities: []string{"read", "health", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},
 		{ProviderKind: "exec", DisplayName: "Exec source", Supported: true, Capabilities: []string{"read", "reveal", "health", "audit", "migration_source"}, Limitations: []string{"read-only; cannot be migration target"}},

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -30,6 +30,11 @@ func TestProviderCapabilitiesAndStatusAreSafeMetadataOnly(t *testing.T) {
 		assertNotContains(t, localCapabilities, capability)
 	}
 	assertNoSecretMaterial(t, mustManagedJSON(t, capabilities), providerCredentialValue)
+	vaultCapabilities := providerCapabilitiesByKind("vault").Capabilities
+	for _, capability := range []string{"read", "reveal", "write/update", "rotate/reset", "policy", "audit", "migration", "health"} {
+		assertContains(t, vaultCapabilities, capability)
+	}
+	assertNotContains(t, vaultCapabilities, "value-search")
 
 	status := backend.providerConfigStatusResponse()
 	if status.Outcome != "ready" || len(status.Providers) != 2 {

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -527,14 +527,24 @@ func (s sourceConfig) resolveVault(refCfg sourceRefConfig) sourceResolveResult {
 		return sourceResolveResult{Outcome: "policy_denied", Message: "Vault/OpenBao policy denied access."}
 	case http.StatusNotFound:
 		return sourceResolveResult{Outcome: "missing_ref", Message: "Vault/OpenBao path or field was not found."}
+	case http.StatusBadRequest:
+		return sourceResolveResult{Outcome: "invalid_ref", Message: "Vault/OpenBao source mapping is invalid."}
+	case http.StatusTooManyRequests:
+		return sourceResolveResult{Outcome: "degraded", Message: "Vault/OpenBao source is degraded."}
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		if outcome := vaultOutcomeFromBody(res.Body, refCfg); outcome != "" {
+			if outcome == "locked" {
+				return sourceResolveResult{Outcome: "locked", Message: "Vault/OpenBao source is sealed."}
+			}
+			return sourceResolveResult{Outcome: outcome, Message: vaultOutcomeMessage(outcome)}
+		}
 		if vaultResponseSealed(res.Body, firstPositive(refCfg.MaxStdoutBytes, 65536)) {
 			return sourceResolveResult{Outcome: "locked", Message: "Vault/OpenBao source is sealed."}
 		}
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao source returned a non-success status."}
 	}
-	limit := int64(firstPositive(refCfg.MaxStdoutBytes, 65536))
+	limit := int64(firstPositive(refCfg.MaxStdoutBytes, firstPositive(refCfg.MaxBytes, 65536)))
 	body, err := io.ReadAll(io.LimitReader(res.Body, limit+1))
 	if err != nil || int64(len(body)) > limit {
 		return sourceResolveResult{Outcome: "source_unavailable", Message: "Vault/OpenBao response could not be read safely."}
@@ -550,6 +560,36 @@ func (s sourceConfig) resolveVault(refCfg sourceRefConfig) sourceResolveResult {
 	return sourceResolveResult{Outcome: "ready", Value: value}
 }
 
+type vaultPayload struct {
+	Outcome string `json:"outcome"`
+	Errors  []any  `json:"errors"`
+	Sealed  bool   `json:"sealed"`
+}
+
+func vaultOutcomeFromBody(body io.Reader, refCfg sourceRefConfig) string {
+	limit := int64(firstPositive(refCfg.MaxStdoutBytes, firstPositive(refCfg.MaxBytes, 65536)))
+	bytes, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil || int64(len(bytes)) > limit || len(strings.TrimSpace(string(bytes))) == 0 {
+		return ""
+	}
+	var payload vaultPayload
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return ""
+	}
+	if payload.Sealed {
+		return "locked"
+	}
+	if outcome := normalizeVaultOutcome(payload.Outcome); outcome != "" {
+		return outcome
+	}
+	for _, item := range payload.Errors {
+		if outcome := normalizeVaultOutcome(fmt.Sprint(item)); outcome != "" {
+			return outcome
+		}
+	}
+	return ""
+}
+
 func vaultResponseSealed(body io.Reader, maxBytes int) bool {
 	limit := int64(firstPositive(maxBytes, 65536))
 	bytes, err := io.ReadAll(io.LimitReader(body, limit+1))
@@ -562,6 +602,50 @@ func vaultResponseSealed(body io.Reader, maxBytes int) bool {
 	}
 	sealed, _ := payload["sealed"].(bool)
 	return sealed
+}
+
+func normalizeVaultOutcome(outcome string) string {
+	cleaned := strings.ToLower(strings.TrimSpace(outcome))
+	if cleaned == "" || cleaned == "ready" {
+		return strings.TrimSpace(outcome)
+	}
+	switch {
+	case strings.Contains(cleaned, "expired"), strings.Contains(cleaned, "source_auth_required"), strings.Contains(cleaned, "permission denied with invalid token"):
+		return "source_auth_required"
+	case strings.Contains(cleaned, "sealed"), strings.Contains(cleaned, "locked"):
+		return "locked"
+	case strings.Contains(cleaned, "permission denied"), strings.Contains(cleaned, "access denied"), strings.Contains(cleaned, "policy_denied"):
+		return "policy_denied"
+	case strings.Contains(cleaned, "not found"), strings.Contains(cleaned, "missing_ref"), strings.Contains(cleaned, "no value found"):
+		return "missing_ref"
+	case strings.Contains(cleaned, "rate limit"), strings.Contains(cleaned, "throttl"), strings.Contains(cleaned, "degraded"):
+		return "degraded"
+	case strings.Contains(cleaned, "invalid"), strings.Contains(cleaned, "invalid_ref"):
+		return "invalid_ref"
+	case strings.Contains(cleaned, "unavailable"), strings.Contains(cleaned, "timeout"), strings.Contains(cleaned, "connection"):
+		return "source_unavailable"
+	default:
+		return ""
+	}
+}
+
+func vaultOutcomeMessage(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "Vault/OpenBao authentication is required."
+	case "locked":
+		return "Vault/OpenBao source is sealed."
+	case "policy_denied":
+		return "Vault/OpenBao policy denied access."
+	case "missing_ref":
+		return "Vault/OpenBao path or field was not found."
+	case "invalid_ref":
+		return "Vault/OpenBao source mapping is invalid."
+	case "degraded":
+		return "Vault/OpenBao source is degraded."
+	default:
+		return "Vault/OpenBao source is unavailable."
+	}
 }
 
 func vaultField(payload map[string]any, field string) (string, bool) {

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -185,7 +185,11 @@ func capabilitiesForSourceKind(kind string) []string {
 		}
 		return []string{"read", "reveal", "audit", "migration", "health"}
 	case "vault", "openbao":
-		return []string{"read", "health"}
+		contract, ok := adapterContractForKind(kind)
+		if ok {
+			return append(adapterCapabilityNames(contract.Capabilities), "health")
+		}
+		return []string{"read", "reveal", "write/update", "rotate/reset", "policy", "audit", "migration", "health"}
 	default:
 		return []string{"health"}
 	}

--- a/cmd/secretsbroker/source_registry_test.go
+++ b/cmd/secretsbroker/source_registry_test.go
@@ -57,7 +57,28 @@ func TestSourceRegistryMapsVaultAuthStateWithoutTokenLeak(t *testing.T) {
 		t.Fatalf("vault source = %#v", vault)
 	}
 	assertContains(t, vault.Capabilities, "read")
+	assertContains(t, vault.Capabilities, "reveal")
+	assertContains(t, vault.Capabilities, "write/update")
+	assertContains(t, vault.Capabilities, "rotate/reset")
+	assertContains(t, vault.Capabilities, "policy")
+	assertContains(t, vault.Capabilities, "audit")
+	assertContains(t, vault.Capabilities, "migration")
+	assertContains(t, vault.Capabilities, "health")
+	assertNotContains(t, vault.Capabilities, "value-search")
 	assertContains(t, vault.Namespaces, "prod/*")
+	assertNoSecretMaterial(t, mustManagedJSON(t, registry), "MISSING_VAULT_TOKEN")
+}
+
+func TestVaultOpenBaoCapabilitiesUseAdapterContract(t *testing.T) {
+	for _, kind := range []string{"vault", "openbao"} {
+		t.Run(kind, func(t *testing.T) {
+			caps := capabilitiesForSourceKind(kind)
+			for _, capability := range []string{"read", "reveal", "write/update", "rotate/reset", "policy", "audit", "migration", "health"} {
+				assertContains(t, caps, capability)
+			}
+			assertNotContains(t, caps, "value-search")
+		})
+	}
 }
 
 func TestSourceStatusEndpointDoesNotRequireSecretToken(t *testing.T) {

--- a/cmd/secretsbroker/vault_source_test.go
+++ b/cmd/secretsbroker/vault_source_test.go
@@ -33,6 +33,8 @@ func TestVaultSourceAdapterStatusMapping(t *testing.T) {
 		{status: http.StatusUnauthorized, outcome: "source_auth_required"},
 		{status: http.StatusForbidden, outcome: "policy_denied"},
 		{status: http.StatusNotFound, outcome: "missing_ref"},
+		{status: http.StatusBadRequest, body: `{"errors":["invalid source mapping"]}`, outcome: "invalid_ref"},
+		{status: http.StatusTooManyRequests, body: `{"errors":["rate limit exceeded"]}`, outcome: "degraded"},
 		{status: http.StatusServiceUnavailable, body: `{"sealed":true}`, outcome: "locked"},
 		{status: http.StatusInternalServerError, outcome: "source_unavailable"},
 	}
@@ -50,6 +52,22 @@ func TestVaultSourceAdapterStatusMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVaultSourceOutcomeBodyMappingIsMetadataOnly(t *testing.T) {
+	secretMarker := "SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"outcome":"policy_denied","errors":["%s"]}`, secretMarker)
+	}))
+	defer server.Close()
+
+	source := sourceConfig{SourceID: "vault", Kind: "vault", Enabled: true, Address: server.URL, Token: "token"}
+	res := source.resolve("ref", sourceRefConfig{Path: "secret/data/ref", Field: "value"})
+	if res.Outcome != "policy_denied" || res.Value != "" {
+		t.Fatalf("outcome = %#v", res)
+	}
+	assertNoSecretMaterial(t, []byte(res.Message), secretMarker, "token")
 }
 
 func TestVaultSourceMissingTokenRequiresAuth(t *testing.T) {

--- a/docs/vault-openbao-source.md
+++ b/docs/vault-openbao-source.md
@@ -1,7 +1,7 @@
 # Vault and OpenBao Source Adapter
 
-Status: read-only MVP  
-Issue: #6
+Status: contract-backed adapter MVP
+Issue: #47
 
 ## Purpose
 
@@ -47,12 +47,23 @@ OpenBao uses the same API shape for this MVP:
 { "kind": "openbao" }
 ```
 
+## Capability and operation model
+
+Vault/OpenBao capability/status output follows the shared adapter contract in `docs/external-adapter-contract.md`:
+
+- `read` and `reveal` are implemented through bounded HTTP reads.
+- `write/update`, `rotate/reset`, `policy`, `audit`, and `migration` are advertised for provider planning and Service Admin capability checks.
+- Remote write, rotation, policy apply, and migration target apply still require a configured provider operation path before apply is allowed.
+- `value-search` is intentionally not advertised for Vault/OpenBao.
+
 ## Auth and backend state mapping
 
 - no token/token env missing -> `source_auth_required`
 - configured source without an address -> `invalid_ref` in source status
 - HTTP 401/403 -> `source_auth_required` or `policy_denied`
 - HTTP 404 -> `missing_ref`
+- HTTP 400 -> `invalid_ref`
+- HTTP 429 or explicit rate-limit/degraded response -> `degraded`
 - sealed response body (`{"sealed":true}` on a non-2xx response) -> `locked`
 - unreachable/5xx without sealed evidence -> `source_unavailable`
 - successful value -> `ready`


### PR DESCRIPTION
## Issue
Closes #47

## Summary
- Map `vault` and `openbao` source kinds to the shared `vault-openbao` adapter contract.
- Align source registry and provider capability output with the contract-backed Vault/OpenBao capability set.
- Normalize additional Vault/OpenBao failure states for invalid mappings, degraded/rate-limited responses, and metadata-only provider error bodies.
- Update Vault/OpenBao adapter docs to describe implemented read/reveal behavior and gated operation planning.

## Scope
- In scope: capability/status reporting, failure normalization, docs, and tests for Vault/OpenBao adapter metadata safety.
- Out of scope: remote write/rotate/policy/migration apply execution against a live Vault/OpenBao cluster.

## Spec / contract / fixture impact
- Updated: `docs/vault-openbao-source.md` to match `docs/external-adapter-contract.md`.
- Tests use `httptest` fixtures with fake values only.

## Service Lasso invariant impact
- Invariant: no raw secret values, provider tokens, or response bodies leak into status/diagnostics/tests.
- Preservation proof: metadata-only tests assert token/sentinel strings are absent from capability/status and error-message surfaces.

## Validation
- PASS `go test ./cmd/secretsbroker` - `.work-agent/logs/issue-47-20260608-1425/go-test-cmd-secretsbroker.log`
- PASS `go test ./...` - `.work-agent/logs/issue-47-20260608-1425/go-test-all-rerun.log`
- PASS `git diff --check` - `.work-agent/logs/issue-47-20260608-1425/git-diff-check-rerun.log`

## Approval trail
- Required: no special approval identified for this bounded adapter contract slice.
- Evidence: issue-backed branch and tests only; no real provider credentials used.

## Cleanup
- Branch remains pushed for PR review. Local cleanup after merge should return checkout to `main`.