### PR TITLE
feat(events): refine broker event filtering contract

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -345,6 +345,7 @@ func runAdminEvents(args []string, out io.Writer) error {
 	until := fs.String("until", "", "RFC3339 upper time bound")
 	serviceID := fs.String("service-id", "", "service id filter")
 	providerID := fs.String("provider-id", "", "provider id filter")
+	sourceID := fs.String("source-id", "", "source id filter")
 	operation := fs.String("operation", "", "operation filter")
 	outcome := fs.String("outcome", "", "outcome filter")
 	severity := fs.String("severity", "", "severity filter")
@@ -365,6 +366,7 @@ func runAdminEvents(args []string, out io.Writer) error {
 		"until":      *until,
 		"serviceId":  *serviceID,
 		"providerId": *providerID,
+		"sourceId":   *sourceID,
 		"operation":  *operation,
 		"outcome":    *outcome,
 		"severity":   *severity,

--- a/cmd/secretsbroker/events.go
+++ b/cmd/secretsbroker/events.go
@@ -60,6 +60,7 @@ type eventFilters struct {
 	Until      *time.Time
 	ServiceID  string
 	ProviderID string
+	SourceID   string
 	Operation  string
 	Outcome    string
 	Severity   string
@@ -121,6 +122,8 @@ func eventFamily(audit auditEvent) string {
 		return "audit_unavailable"
 	}
 	switch {
+	case audit.Operation == "local_api_auth" && audit.Outcome != "ready":
+		return "auth_failure"
 	case audit.Operation == "lockout_clear":
 		return "lockout_cleared"
 	case strings.Contains(audit.Operation, "lockout"):
@@ -129,14 +132,22 @@ func eventFamily(audit auditEvent) string {
 		return "policy_decision"
 	case audit.Operation == "source_lifecycle" && audit.Outcome == "ready":
 		return "source_recovered"
-	case audit.Operation == "source_lifecycle":
+	case audit.Operation == "source_lifecycle" && audit.Outcome == "source_auth_required":
 		return "source_auth_required"
+	case audit.Operation == "source_lifecycle":
+		return "source_unavailable"
 	case strings.HasPrefix(audit.Operation, "provider_") && audit.Outcome == "ready":
 		return "provider_recovered"
+	case strings.HasPrefix(audit.Operation, "provider_") && audit.Outcome == "source_auth_required":
+		return "source_auth_required"
 	case strings.HasPrefix(audit.Operation, "provider_"):
 		return "provider_unavailable"
 	case audit.Operation == "management_reveal":
 		return "management_reveal"
+	case strings.Contains(audit.Operation, "rotation"):
+		return "rotation_action"
+	case strings.Contains(audit.Operation, "delete"):
+		return "delete_action"
 	case strings.HasPrefix(audit.Operation, "management_"):
 		return "management_apply"
 	case strings.HasPrefix(audit.Operation, "key_"):
@@ -251,6 +262,7 @@ func parseEventFilters(values url.Values) (eventFilters, error) {
 	}
 	filters.ServiceID = scrubAuditField(values.Get("serviceId"))
 	filters.ProviderID = scrubAuditField(values.Get("providerId"))
+	filters.SourceID = scrubAuditField(values.Get("sourceId"))
 	filters.Operation = scrubAuditField(values.Get("operation"))
 	filters.Outcome = scrubAuditField(values.Get("outcome"))
 	filters.Severity = scrubAuditField(values.Get("severity"))
@@ -333,6 +345,9 @@ func eventMatchesFilters(event operationalEvent, filters eventFilters) bool {
 		return false
 	}
 	if filters.ProviderID != "" && event.ProviderID != filters.ProviderID {
+		return false
+	}
+	if filters.SourceID != "" && event.SourceID != filters.SourceID {
 		return false
 	}
 	if filters.Operation != "" && event.Operation != filters.Operation {

--- a/cmd/secretsbroker/events_test.go
+++ b/cmd/secretsbroker/events_test.go
@@ -104,6 +104,55 @@ func TestOperationalEventsEndpointPaginationAndInvalidFilters(t *testing.T) {
 	}
 }
 
+func TestOperationalEventFamiliesAndSourceFilter(t *testing.T) {
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	events := []auditEvent{
+		{TS: backend.now(), Operation: "local_api_auth", Outcome: "unauthorized", ServiceID: "@operator", RequestID: "req-auth"},
+		{TS: backend.now().Add(time.Second), Operation: "source_lifecycle", Outcome: "source_auth_required", SourceID: "vault-prod", Ref: ref, ServiceID: "api", RequestID: "req-source-auth"},
+		{TS: backend.now().Add(2 * time.Second), Operation: "source_lifecycle", Outcome: "ready", SourceID: "vault-prod", Ref: ref, ServiceID: "api", RequestID: "req-source-ready"},
+		{TS: backend.now().Add(3 * time.Second), Operation: "provider_config_validate", Outcome: "source_auth_required", ProviderID: "vault-prod", ServiceID: "@serviceadmin", RequestID: "req-provider-auth"},
+		{TS: backend.now().Add(4 * time.Second), Operation: "credential_rotation_dry_run", Outcome: "dry_run_ready", Ref: ref, ServiceID: "@serviceadmin", RequestID: "req-rotation"},
+		{TS: backend.now().Add(5 * time.Second), Operation: "management_delete_apply", Outcome: "applied", Ref: ref, ServiceID: "@serviceadmin", RequestID: "req-delete"},
+	}
+	for _, event := range events {
+		if err := backend.writeAuditEvent(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := map[string]string{
+		"req-auth":          "auth_failure",
+		"req-source-auth":   "source_auth_required",
+		"req-source-ready":  "source_recovered",
+		"req-provider-auth": "source_auth_required",
+		"req-rotation":      "rotation_action",
+		"req-delete":        "delete_action",
+	}
+	res, err := buildEventsResponse(backend.eventPath, eventFilters{Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range res.Events {
+		if want, ok := cases[event.RequestID]; ok && event.Family != want {
+			t.Fatalf("%s family = %q, want %q", event.RequestID, event.Family, want)
+		}
+	}
+
+	filtered, err := buildEventsResponse(backend.eventPath, eventFilters{Limit: 20, SourceID: "vault-prod", Family: "source_auth_required"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Events) != 1 || filtered.Events[0].RequestID != "req-source-auth" || filtered.Events[0].SourceID != "vault-prod" {
+		t.Fatalf("source filtered events = %#v", filtered.Events)
+	}
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, operationalEventSecretValue, ref)
+}
+
 func TestAdminEventsCLIReadsMetadataOnlyEvents(t *testing.T) {
 	backend := testBackend(t)
 	ref := "services/api/runtime/API_TOKEN"
@@ -117,5 +166,19 @@ func TestAdminEventsCLIReadsMetadataOnlyEvents(t *testing.T) {
 	assertNoSecretMaterial(t, out.Bytes(), operationalEventSecretValue, "test-master-key", ref)
 	if !strings.Contains(out.String(), "events") || !strings.Contains(out.String(), "audit_recorded") {
 		t.Fatalf("events CLI output missing expected metadata: %s", out.String())
+	}
+}
+
+func TestAdminEventsCLIFiltersBySourceID(t *testing.T) {
+	backend := testBackend(t)
+	_ = backend.writeAuditEvent(auditEvent{TS: backend.now(), Operation: "source_lifecycle", SourceID: "vault-prod", Outcome: "source_auth_required", Ref: "services/api/runtime/API_TOKEN"})
+	_ = backend.writeAuditEvent(auditEvent{TS: backend.now(), Operation: "source_lifecycle", SourceID: "env-dev", Outcome: "source_auth_required", Ref: "services/api/runtime/API_TOKEN"})
+
+	var out bytes.Buffer
+	if err := executeAdmin([]string{"events", "list", "--events", backend.eventPath, "--source-id", "vault-prod", "--family", "source_auth_required", "--limit", "10"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"sourceId": "vault-prod"`) || strings.Contains(out.String(), `"sourceId": "env-dev"`) {
+		t.Fatalf("source-id filter output = %s", out.String())
 	}
 }

--- a/docs/headless-admin-cli.md
+++ b/docs/headless-admin-cli.md
@@ -122,6 +122,14 @@ secretsbroker admin audit export --audit .\data\secretsbroker-audit.jsonl --oper
 
 Audit export returns operation/ref/outcome/timestamp/request metadata only. Audit events must not contain raw values.
 
+### Operational events
+
+```powershell
+secretsbroker admin events list --family source_auth_required --source-id vault-prod --limit 25
+```
+
+Operational events are bounded, metadata-only records derived from broker audit metadata. Filters include time window, service id, provider id, source id, operation, outcome, severity, family, safe ref prefix, and ref hash. Event output must not contain raw secret values, provider credentials, API tokens, recovery material, or raw provider response bodies.
+
 ### Unlock/import/re-wrap
 
 Master-key lifecycle commands are part of the same headless operator workflow and are documented in `docs/master-key-lifecycle.md`:

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -134,18 +134,21 @@ Events represent operator-relevant state transitions and decisions. The broker s
 Event families:
 
 - `policy_decision`
+- `auth_failure`
 - `audit_recorded` / `audit_unavailable`
 - `source_auth_required` / `source_recovered`
 - `provider_unavailable` / `provider_recovered`
 - `lockout_started` / `lockout_cleared`
 - `management_reveal`
 - `management_apply`
+- `rotation_action`
+- `delete_action`
 - `key_lifecycle`
 - `backup_restore`
 
 Filtering requirements:
 
-- Filters support time window, service id, provider id, operation, outcome, severity, event family, and ref prefix/hash.
+- Filters support time window, service id, provider id, source id, operation, outcome, severity, event family, and ref prefix/hash.
 - Filters have bounded limits and deterministic pagination.
 - Invalid filters fail safely with typed errors.
 - Value search and credential search are not event-filter features.
@@ -153,10 +156,11 @@ Filtering requirements:
 Implemented first slice:
 
 - Audit metadata now feeds a bounded local operational event store with deterministic retention of the most recent 200 events.
-- GET /v1/events returns metadata-only events with filters for since, until, serviceId, providerId, operation, outcome, severity, family, refPrefix, and refHash.
-- secretsbroker admin events list exposes the same bounded event reader for headless administration.
+- GET /v1/events returns metadata-only events with filters for since, until, serviceId, providerId, sourceId, operation, outcome, severity, family, refPrefix, and refHash.
+- secretsbroker admin events list exposes the same bounded event reader for headless administration, including `--source-id`.
 - Event responses expose safe ref prefixes and refHash; they do not include raw refs, raw values, provider credentials, tokens, private keys, cookies, passwords, environment values, provider response bodies, or credential search results.
 - Event filters use bounded page sizes with cursor pagination, and invalid filters return typed invalid_event_filter errors.
+- Auth failures, provider/source failures, lockout-like conditions, rotation/delete actions, and source health changes are represented by explicit event families so Service Admin and notification sinks can filter without parsing operation names.
 
 ## Lockout model
 
@@ -230,7 +234,7 @@ Implemented management clear slice:
 | Policy assignment | Show effective allowed refs/namespaces per service and explain denied operations without exposing values. |
 | Audit logging | Show audit availability/status, export metadata-only audit events, and block dangerous apply/reveal flows when audit is unavailable. |
 | Telemetry | Show broker health and operational counters without raw refs or secret values. |
-| Events/filtering | Provide event filters for service, provider, operation, outcome, severity, and time range. |
+| Events/filtering | Provide event filters for service, provider, source, operation, outcome, severity, family, and time range. Track UI follow-up in [lasso-serviceadmin#118](https://github.com/service-lasso/lasso-serviceadmin/issues/118). |
 | Lockout | Show active lockouts, retry windows, affected scopes, and audited clear action when supported. |
 
 ## Test requirements


### PR DESCRIPTION
## Issue
Closes #93

## Summary
- Adds `sourceId` as a first-class event filter for `GET /v1/events` and `secretsbroker admin events list --source-id`.
- Refines operational event family classification for auth failures, source/provider auth states, source recovery/unavailability, rotation actions, and delete-style actions.
- Updates the operational controls and headless CLI docs for the finalized metadata-only event/filtering contract.

## Scope
- In scope: bounded metadata-only event query semantics, CLI parity, event family tests, source-id filter tests, docs.
- Out of scope: Service Admin UI implementation and streaming/notification sinks; UI follow-up remains linked in docs as `service-lasso/lasso-serviceadmin#118`.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md` and `docs/headless-admin-cli.md`.
- Contract change: `sourceId` is now accepted as an event filter and the CLI exposes `--source-id`.
- Fixtures: not required; behavior is covered by Go tests around the event store and CLI.

## Service Lasso invariant impact
- Invariant: event/audit surfaces stay metadata-only and never expose raw secret values, raw refs, provider tokens, credentials, or recovery material.
- Preservation proof: new tests cover redaction and source filtering; existing secret leak assertions continue to pass.

## Validation
- PASS `go test ./...` — `ok github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker 2.914s`; resolver package cached.
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `Secrets Broker tests passed (Windows)`.
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1` — created `dist\secretsbroker-win32.zip`.
- PASS `node scripts\demo-verify-canonical.mjs` from `service-lasso/service-lasso` — canonical LAN demo reachable and healthy; Service Admin HTTP 200, runtime health HTTP 200/status ok, `@secretsbroker` healthy on current release pin `2026.6.8-f7a35b1`.

Evidence logs saved under `.work-agent/logs/cron-755b8bea-20260619T112512+1000-issue93/`.

## Approval trail
- Required: yes, normal PR review/merge policy.
- Evidence: branch pushed from scheduled developer worker; start comment is on #93.

## Cleanup
- Branch: `dev/issue-93-events-filtering`.
- Local repo should remain on the issue branch until PR validation completes; no unrelated files changed.
- Demo note: canonical demo is healthy but still release-backed on `@secretsbroker` tag `2026.6.8-f7a35b1`; this PR branch is not deployed to the release-backed canonical demo until merge/release/pin update.