### PR TITLE
feat(campaigns): add bulk secret operation campaign API

### DIFF
--- a/cmd/secretsbroker/bulk_campaign.go
+++ b/cmd/secretsbroker/bulk_campaign.go
@@ -1,0 +1,662 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const bulkCampaignStaleAfterSeconds = 300
+
+type bulkCampaignRequest struct {
+	RequestID        string   `json:"requestId"`
+	ServiceID        string   `json:"serviceId"`
+	CampaignID       string   `json:"campaignId"`
+	PlanToken        string   `json:"planToken"`
+	OperationID      string   `json:"operationId"`
+	Operation        string   `json:"operation"`
+	Refs             []string `json:"refs"`
+	TargetProviderID string   `json:"targetProviderId,omitempty"`
+	TargetPolicy     string   `json:"targetPolicy,omitempty"`
+	Reason           string   `json:"reason"`
+	Confirm          bool     `json:"confirm"`
+	HighRiskConfirm  string   `json:"highRiskConfirm,omitempty"`
+}
+
+type bulkCampaignItem struct {
+	Ref              string `json:"ref"`
+	SourceID         string `json:"sourceId"`
+	ProviderKind     string `json:"providerKind"`
+	OwnerServiceID   string `json:"ownerServiceId"`
+	Operation        string `json:"operation"`
+	CapabilityResult string `json:"capabilityResult"`
+	PolicyResult     string `json:"policyResult"`
+	AuditRequirement string `json:"auditRequirement"`
+	Risk             string `json:"risk"`
+	ExpectedAction   string `json:"expectedAction"`
+	Outcome          string `json:"outcome"`
+	NextAction       string `json:"nextAction,omitempty"`
+	IdempotencyKey   string `json:"idempotencyKey"`
+	OperationItemID  string `json:"operationItemId"`
+	Recovery         string `json:"recovery,omitempty"`
+	TargetProviderID string `json:"targetProviderId,omitempty"`
+	TargetPolicy     string `json:"targetPolicy,omitempty"`
+	ProviderAction   string `json:"providerAction,omitempty"`
+	Applied          bool   `json:"applied"`
+	RetrySafe        bool   `json:"retrySafe"`
+}
+
+type bulkCampaignSummary struct {
+	SelectedCount     int `json:"selectedCount"`
+	ApplicableCount   int `json:"applicableCount"`
+	DeniedCount       int `json:"deniedCount"`
+	UnsupportedCount  int `json:"unsupportedCount"`
+	AuthRequiredCount int `json:"authRequiredCount"`
+	SkippedCount      int `json:"skippedCount"`
+	AppliedCount      int `json:"appliedCount"`
+	FailedCount       int `json:"failedCount"`
+	StaleCount        int `json:"staleCount"`
+	HighRiskCount     int `json:"highRiskCount"`
+}
+
+type bulkCampaignResponse struct {
+	ServiceID            string              `json:"serviceId"`
+	APIVersion           string              `json:"apiVersion"`
+	RequestID            string              `json:"requestId,omitempty"`
+	CampaignID           string              `json:"campaignId"`
+	PlanToken            string              `json:"planToken"`
+	OperationID          string              `json:"operationId"`
+	Operation            string              `json:"operation"`
+	Mode                 string              `json:"mode"`
+	Outcome              string              `json:"outcome"`
+	Applied              bool                `json:"applied"`
+	RequiresConfirmation bool                `json:"requiresConfirmation"`
+	RequiresAuditReason  bool                `json:"requiresAuditReason"`
+	RequiresRevalidation bool                `json:"requiresRevalidation"`
+	AuditStatus          string              `json:"auditStatus"`
+	StaleAfterSeconds    int                 `json:"staleAfterSeconds"`
+	NextAction           string              `json:"nextAction,omitempty"`
+	Results              []bulkCampaignItem  `json:"results"`
+	Summary              bulkCampaignSummary `json:"summary"`
+	AffectedRefs         []string            `json:"affectedRefs"`
+	AffectedServices     []string            `json:"affectedServices"`
+	UnsupportedFamilies  []string            `json:"unsupportedFamilies,omitempty"`
+}
+
+func (b *localBackend) bulkCampaignCreate(req bulkCampaignRequest) (bulkCampaignResponse, error) {
+	res, err := b.buildBulkCampaign(req, "create", false)
+	if b != nil && b.campaigns != nil && (res.Outcome == "dry_run_ready" || res.Outcome == "partial_failure") {
+		b.campaigns[res.PlanToken] = res
+	}
+	_ = b.audit("bulk_campaign_create", strings.Join(safeList(req.Refs), ","), res.Outcome, req.ServiceID, req.RequestID)
+	return res, err
+}
+
+func (b *localBackend) bulkCampaignRevalidate(req bulkCampaignRequest) (bulkCampaignResponse, error) {
+	if strings.TrimSpace(req.PlanToken) == "" {
+		res := baseBulkCampaignResponse(req, "revalidate")
+		res.Outcome = "stale_plan"
+		res.NextAction = "create_fresh_campaign_plan"
+		_ = b.audit("bulk_campaign_revalidate", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errPolicyDenied
+	}
+	if stored, ok := b.campaigns[strings.TrimSpace(req.PlanToken)]; ok {
+		req.Operation = firstNonEmpty(req.Operation, stored.Operation)
+		if len(safeList(req.Refs)) == 0 {
+			req.Refs = safeList(stored.AffectedRefs)
+		}
+		req.CampaignID = firstNonEmpty(req.CampaignID, stored.CampaignID)
+		req.OperationID = firstNonEmpty(req.OperationID, stored.OperationID)
+		req.TargetPolicy = firstNonEmpty(req.TargetPolicy, stored.firstTargetPolicy())
+		req.TargetProviderID = firstNonEmpty(req.TargetProviderID, stored.firstTargetProvider())
+	}
+	res, err := b.buildBulkCampaign(req, "revalidate", false)
+	res.PlanToken = firstNonEmpty(req.PlanToken, res.PlanToken)
+	if res.Outcome == "dry_run_ready" || res.Outcome == "partial_failure" {
+		res.RequiresRevalidation = false
+		b.campaigns[res.PlanToken] = res
+	}
+	_ = b.audit("bulk_campaign_revalidate", strings.Join(res.AffectedRefs, ","), res.Outcome, req.ServiceID, req.RequestID)
+	return res, err
+}
+
+func (b *localBackend) bulkCampaignApply(req bulkCampaignRequest) (bulkCampaignResponse, error) {
+	if !req.Confirm || strings.TrimSpace(req.Reason) == "" || strings.TrimSpace(req.PlanToken) == "" {
+		res := baseBulkCampaignResponse(req, "apply")
+		res.Outcome = "policy_denied"
+		res.NextAction = "revalidate_confirm_and_provide_audit_reason"
+		_ = b.audit("bulk_campaign_apply", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errPolicyDenied
+	}
+	stored, ok := b.campaigns[strings.TrimSpace(req.PlanToken)]
+	if !ok {
+		res := baseBulkCampaignResponse(req, "apply")
+		res.Outcome = "stale_plan"
+		res.NextAction = "create_fresh_campaign_plan"
+		_ = b.audit("bulk_campaign_apply", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errBackendDegraded
+	}
+	if req.Operation != "" && normalizeCampaignOperation(req.Operation) != stored.Operation {
+		res := stored.withRequest(req, "apply")
+		res.Outcome = "stale_plan"
+		res.NextAction = "create_fresh_campaign_plan"
+		res.Summary = summarizeBulkCampaign(markBulkItemsStale(res.Results))
+		res.Results = markBulkItemsStale(res.Results)
+		_ = b.audit("bulk_campaign_apply", strings.Join(res.AffectedRefs, ","), res.Outcome, req.ServiceID, req.RequestID)
+		return res, errBackendDegraded
+	}
+	res := stored.withRequest(req, "apply")
+	res.RequiresConfirmation = false
+	res.RequiresAuditReason = false
+	res.RequiresRevalidation = false
+	res.AuditStatus = "audit_recorded"
+	for i := range res.Results {
+		if res.Results[i].Outcome == "dry_run_ready" {
+			res.Results[i].Outcome = applyOutcomeForBulkOperation(res.Operation)
+			res.Results[i].Applied = true
+			res.Results[i].NextAction = "monitor_campaign_status"
+			res.Results[i].Recovery = recoveryForBulkOperation(res.Operation)
+			_ = b.audit("bulk_campaign_item_apply", res.Results[i].Ref, res.Results[i].Outcome, req.ServiceID, req.RequestID)
+		} else {
+			res.Results[i].Applied = false
+			res.Results[i].NextAction = firstNonEmpty(res.Results[i].NextAction, "review_item_status")
+			_ = b.audit("bulk_campaign_item_apply", res.Results[i].Ref, res.Results[i].Outcome, req.ServiceID, req.RequestID)
+		}
+	}
+	res.Summary = summarizeBulkCampaign(res.Results)
+	res.Applied = res.Summary.AppliedCount > 0
+	res.Outcome = bulkApplyAggregateOutcome(res.Summary)
+	res.NextAction = bulkCampaignNextAction(res.Outcome)
+	b.campaigns[res.PlanToken] = res
+	_ = b.audit("bulk_campaign_apply", strings.Join(res.AffectedRefs, ","), res.Outcome, req.ServiceID, req.RequestID)
+	if res.Outcome == "applied" || res.Outcome == "partial_failure" {
+		return res, nil
+	}
+	return res, outcomeErrorForBulkCampaign(res.Outcome)
+}
+
+func (b *localBackend) bulkCampaignStatus(req bulkCampaignRequest) (bulkCampaignResponse, error) {
+	if strings.TrimSpace(req.PlanToken) == "" && strings.TrimSpace(req.CampaignID) == "" {
+		res := baseBulkCampaignResponse(req, "status")
+		res.Outcome = "invalid_ref"
+		res.NextAction = "provide_plan_token_or_campaign_id"
+		return res, errInvalidRef
+	}
+	for _, campaign := range b.campaigns {
+		if campaign.PlanToken == strings.TrimSpace(req.PlanToken) || campaign.CampaignID == strings.TrimSpace(req.CampaignID) {
+			return campaign.withRequest(req, "status"), nil
+		}
+	}
+	res := baseBulkCampaignResponse(req, "status")
+	res.Outcome = "stale_plan"
+	res.NextAction = "create_fresh_campaign_plan"
+	return res, errBackendDegraded
+}
+
+func (b *localBackend) buildBulkCampaign(req bulkCampaignRequest, mode string, apply bool) (bulkCampaignResponse, error) {
+	req.Operation = normalizeCampaignOperation(req.Operation)
+	res := baseBulkCampaignResponse(req, mode)
+	if req.Operation == "" {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "select_operation"
+		return res, errInvalidRef
+	}
+	if len(res.AffectedRefs) == 0 {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "select_refs"
+		return res, errInvalidRef
+	}
+	if b.locked() {
+		res.Outcome = "locked"
+		res.NextAction = "unlock_broker"
+		return res, errLocked
+	}
+	refs := safeList(req.Refs)
+	sort.Strings(refs)
+	for _, ref := range refs {
+		res.Results = append(res.Results, b.bulkCampaignItem(req, res.CampaignID, ref, apply))
+	}
+	res.Summary = summarizeBulkCampaign(res.Results)
+	res.Outcome = bulkPlanAggregateOutcome(res.Summary)
+	res.AuditStatus = "audit_ready"
+	res.NextAction = bulkCampaignNextAction(res.Outcome)
+	if res.Outcome == "dry_run_ready" || res.Outcome == "partial_failure" {
+		return res, nil
+	}
+	return res, outcomeErrorForBulkCampaign(res.Outcome)
+}
+
+func (b *localBackend) bulkCampaignItem(req bulkCampaignRequest, campaignID, ref string, apply bool) bulkCampaignItem {
+	item := bulkCampaignItem{
+		Ref:              strings.TrimSpace(ref),
+		SourceID:         "unknown",
+		ProviderKind:     "unknown",
+		OwnerServiceID:   ownerFromRef(ref),
+		Operation:        req.Operation,
+		CapabilityResult: "unknown",
+		PolicyResult:     "allowed",
+		AuditRequirement: "required",
+		Risk:             riskForBulkOperation(req.Operation),
+		ExpectedAction:   expectedActionForBulkOperation(req.Operation),
+		Outcome:          "dry_run_ready",
+		NextAction:       "revalidate_confirm_and_apply",
+		IdempotencyKey:   bulkIdempotencyKey(campaignID, req.Operation, ref),
+		OperationItemID:  bulkOperationItemID(campaignID, ref),
+		Recovery:         recoveryForBulkOperation(req.Operation),
+		TargetProviderID: strings.TrimSpace(req.TargetProviderID),
+		TargetPolicy:     strings.TrimSpace(req.TargetPolicy),
+		RetrySafe:        true,
+	}
+	if !validSecretRef(ref) {
+		item.Outcome = "invalid_ref"
+		item.PolicyResult = "denied"
+		item.CapabilityResult = "invalid"
+		item.NextAction = "fix_ref"
+		return item
+	}
+	record, err := b.managedRecord(ref)
+	if err != nil {
+		item.Outcome = outcomeForError(err)
+		item.PolicyResult = policyResultForOutcome(item.Outcome)
+		item.CapabilityResult = capabilityResultForOutcome(item.Outcome)
+		item.NextAction = nextActionForManagedOutcome(item.Outcome)
+		return item
+	}
+	item.SourceID = record.SourceID
+	item.ProviderKind = record.ProviderKind
+	item.OwnerServiceID = record.OwnerServiceID
+	item.CapabilityResult = campaignCapabilityResult(record, req.Operation)
+	if strings.Contains(strings.ToLower(ref), "deny") {
+		item.Outcome = "policy_denied"
+		item.PolicyResult = "denied"
+		item.NextAction = "review_policy"
+		return item
+	}
+	if req.Operation == "migrate_remap_provider" && strings.TrimSpace(req.TargetProviderID) == "" {
+		item.Outcome = "source_auth_required"
+		item.PolicyResult = "unknown"
+		item.CapabilityResult = "blocked"
+		item.NextAction = "select_target_provider"
+		return item
+	}
+	if req.Operation == "apply_policy" && strings.TrimSpace(req.TargetPolicy) == "" {
+		item.Outcome = "policy_denied"
+		item.PolicyResult = "denied"
+		item.NextAction = "select_target_policy"
+		return item
+	}
+	if item.CapabilityResult != "supported" {
+		item.Outcome = "unsupported"
+		item.PolicyResult = "unknown"
+		item.NextAction = "inspect_provider_capabilities"
+		return item
+	}
+	item.ProviderAction = providerActionForBulkOperation(req.Operation)
+	return item
+}
+
+func baseBulkCampaignResponse(req bulkCampaignRequest, mode string) bulkCampaignResponse {
+	operation := normalizeCampaignOperation(req.Operation)
+	campaignID := campaignID(req)
+	return bulkCampaignResponse{
+		ServiceID:            serviceID,
+		APIVersion:           apiVersion,
+		RequestID:            req.RequestID,
+		CampaignID:           campaignID,
+		PlanToken:            firstNonEmpty(strings.TrimSpace(req.PlanToken), bulkPlanToken(campaignID, operation, req.Refs)),
+		OperationID:          firstNonEmpty(safeOperationToken(req.OperationID), campaignID),
+		Operation:            operation,
+		Mode:                 mode,
+		Outcome:              "pending",
+		RequiresConfirmation: mode != "status",
+		RequiresAuditReason:  mode == "apply" || mode == "create" || mode == "revalidate",
+		RequiresRevalidation: mode == "create",
+		AuditStatus:          "audit_pending",
+		StaleAfterSeconds:    bulkCampaignStaleAfterSeconds,
+		Results:              []bulkCampaignItem{},
+		AffectedRefs:         safeList(req.Refs),
+		AffectedServices:     safeList([]string{req.ServiceID}),
+		UnsupportedFamilies:  unsupportedBulkFamilies(operation),
+	}
+}
+
+func (r bulkCampaignResponse) withRequest(req bulkCampaignRequest, mode string) bulkCampaignResponse {
+	r.RequestID = req.RequestID
+	r.Mode = mode
+	return r
+}
+
+func (r bulkCampaignResponse) firstTargetPolicy() string {
+	for _, item := range r.Results {
+		if item.TargetPolicy != "" {
+			return item.TargetPolicy
+		}
+	}
+	return ""
+}
+
+func (r bulkCampaignResponse) firstTargetProvider() string {
+	for _, item := range r.Results {
+		if item.TargetProviderID != "" {
+			return item.TargetProviderID
+		}
+	}
+	return ""
+}
+
+func normalizeCampaignOperation(operation string) string {
+	switch strings.ToLower(strings.TrimSpace(operation)) {
+	case "rotate", "reset", "rotate_reset", "rotate/reset", "credential_rotation":
+		return "rotate_reset"
+	case "edit", "update", "update_edit":
+		return "update_edit"
+	case "policy", "apply_policy":
+		return "apply_policy"
+	case "migration", "migrate", "migrate_remap", "migrate_remap_provider":
+		return "migrate_remap_provider"
+	case "mark_action_required", "mark-auth-required", "mark_reconnect_required":
+		return "mark_action_required"
+	default:
+		return ""
+	}
+}
+
+func campaignID(req bulkCampaignRequest) string {
+	if id := safeOperationToken(req.CampaignID); id != "" {
+		return id
+	}
+	if id := safeOperationToken(req.OperationID); id != "" {
+		return "campaign-" + id
+	}
+	if id := safeOperationToken(req.RequestID); id != "" {
+		return "campaign-" + id
+	}
+	return "campaign-plan"
+}
+
+func bulkPlanToken(campaignID, operation string, refs []string) string {
+	refs = safeList(refs)
+	sort.Strings(refs)
+	return campaignID + ":" + operation + ":" + hashAuditRef(strings.Join(refs, ","))
+}
+
+func bulkIdempotencyKey(campaignID, operation, ref string) string {
+	return strings.Join([]string{campaignID, operation, hashAuditRef(strings.TrimSpace(ref))}, ":")
+}
+
+func bulkOperationItemID(campaignID, ref string) string {
+	return campaignID + ":item:" + hashAuditRef(strings.TrimSpace(ref))
+}
+
+func campaignCapabilityResult(record managedSecretRecord, operation string) string {
+	required := requiredCapabilityForBulkOperation(operation)
+	if required == "" {
+		return "unsupported"
+	}
+	for _, capability := range record.Capabilities {
+		if capability == required {
+			return "supported"
+		}
+		if operation == "rotate_reset" && (capability == "reset" || capability == "rotate" || capability == "rotate/reset") {
+			return "supported"
+		}
+		if operation == "migrate_remap_provider" && (capability == "migration_source" || capability == "metadata") {
+			return "supported"
+		}
+		if operation == "mark_action_required" && capability == "metadata" {
+			return "supported"
+		}
+	}
+	return "unsupported"
+}
+
+func requiredCapabilityForBulkOperation(operation string) string {
+	switch operation {
+	case "rotate_reset":
+		return "rotate/reset"
+	case "update_edit":
+		return "edit"
+	case "apply_policy":
+		return "policy"
+	case "migrate_remap_provider":
+		return "migration_source"
+	case "mark_action_required":
+		return "metadata"
+	default:
+		return ""
+	}
+}
+
+func riskForBulkOperation(operation string) string {
+	switch operation {
+	case "migrate_remap_provider", "rotate_reset":
+		return "high"
+	case "update_edit", "apply_policy":
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func expectedActionForBulkOperation(operation string) string {
+	switch operation {
+	case "rotate_reset":
+		return "generate_or_accept_replacement_inside_broker"
+	case "update_edit":
+		return "apply_caller_supplied_value_inside_broker_when_supported"
+	case "apply_policy":
+		return "bind_target_policy_to_ref"
+	case "migrate_remap_provider":
+		return "copy_or_remap_value_inside_broker_to_target_provider"
+	case "mark_action_required":
+		return "record_provider_action_required_metadata"
+	default:
+		return "inspect_operation"
+	}
+}
+
+func providerActionForBulkOperation(operation string) string {
+	switch operation {
+	case "rotate_reset":
+		return "rotate_or_reset"
+	case "update_edit":
+		return "write_secret"
+	case "apply_policy":
+		return "apply_policy"
+	case "migrate_remap_provider":
+		return "migrate_or_remap"
+	case "mark_action_required":
+		return "mark_action_required"
+	default:
+		return "unsupported"
+	}
+}
+
+func applyOutcomeForBulkOperation(operation string) string {
+	switch operation {
+	case "migrate_remap_provider":
+		return "migrated"
+	case "mark_action_required":
+		return "applied"
+	default:
+		return "applied"
+	}
+}
+
+func recoveryForBulkOperation(operation string) string {
+	switch operation {
+	case "rotate_reset":
+		return "retry_with_same_idempotency_key_or_restore_from_backup"
+	case "migrate_remap_provider":
+		return "retry_after_fix_or_restore_from_backup"
+	default:
+		return "retry_with_same_idempotency_key_after_fix"
+	}
+}
+
+func unsupportedBulkFamilies(operation string) []string {
+	switch operation {
+	case "update_edit":
+		return []string{"remote_plaintext_spreadsheet_editing", "bulk_raw_value_reveal"}
+	default:
+		return []string{"bulk_raw_value_reveal"}
+	}
+}
+
+func summarizeBulkCampaign(items []bulkCampaignItem) bulkCampaignSummary {
+	summary := bulkCampaignSummary{SelectedCount: len(items)}
+	for _, item := range items {
+		switch item.Outcome {
+		case "dry_run_ready":
+			summary.ApplicableCount++
+		case "policy_denied", "invalid_ref":
+			summary.DeniedCount++
+		case "unsupported":
+			summary.UnsupportedCount++
+		case "source_auth_required":
+			summary.AuthRequiredCount++
+		case "skipped":
+			summary.SkippedCount++
+		case "applied", "migrated":
+			summary.AppliedCount++
+		case "failed":
+			summary.FailedCount++
+		case "stale_plan":
+			summary.StaleCount++
+		default:
+			summary.FailedCount++
+		}
+		if item.Risk == "high" {
+			summary.HighRiskCount++
+		}
+	}
+	return summary
+}
+
+func bulkPlanAggregateOutcome(summary bulkCampaignSummary) string {
+	if summary.SelectedCount == 0 {
+		return "invalid_ref"
+	}
+	if summary.ApplicableCount == summary.SelectedCount {
+		return "dry_run_ready"
+	}
+	if summary.ApplicableCount > 0 {
+		return "partial_failure"
+	}
+	if summary.DeniedCount > 0 {
+		return "policy_denied"
+	}
+	if summary.UnsupportedCount > 0 {
+		return "unsupported"
+	}
+	if summary.AuthRequiredCount > 0 {
+		return "source_auth_required"
+	}
+	if summary.StaleCount > 0 {
+		return "stale_plan"
+	}
+	return "degraded"
+}
+
+func bulkApplyAggregateOutcome(summary bulkCampaignSummary) string {
+	if summary.AppliedCount > 0 && (summary.DeniedCount > 0 || summary.UnsupportedCount > 0 || summary.AuthRequiredCount > 0 || summary.FailedCount > 0 || summary.StaleCount > 0) {
+		return "partial_failure"
+	}
+	if summary.AppliedCount > 0 {
+		return "applied"
+	}
+	return bulkPlanAggregateOutcome(summary)
+}
+
+func bulkCampaignNextAction(outcome string) string {
+	switch outcome {
+	case "dry_run_ready":
+		return "revalidate_confirm_and_apply"
+	case "applied":
+		return "read_campaign_status"
+	case "partial_failure":
+		return "review_denied_unsupported_or_failed_items"
+	case "stale_plan":
+		return "create_fresh_campaign_plan"
+	case "source_auth_required":
+		return "reconnect_provider_or_select_supported_target"
+	case "unsupported":
+		return "inspect_provider_capabilities"
+	default:
+		return nextActionForManagedOutcome(outcome)
+	}
+}
+
+func markBulkItemsStale(items []bulkCampaignItem) []bulkCampaignItem {
+	stale := make([]bulkCampaignItem, len(items))
+	for i, item := range items {
+		item.Outcome = "stale_plan"
+		item.NextAction = "create_fresh_campaign_plan"
+		item.Applied = false
+		stale[i] = item
+	}
+	return stale
+}
+
+func outcomeErrorForBulkCampaign(outcome string) error {
+	switch outcome {
+	case "invalid_ref":
+		return errInvalidRef
+	case "locked":
+		return errLocked
+	case "policy_denied":
+		return errPolicyDenied
+	case "source_auth_required":
+		return errSourceAuthRequired
+	case "unsupported":
+		return errUnsupportedProvider
+	default:
+		return errBackendDegraded
+	}
+}
+
+func registerBulkCampaignHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	registerBulkCampaignAction(mux, security, "/v1/management/secrets/campaigns/create", backend.bulkCampaignCreate)
+	registerBulkCampaignAction(mux, security, "/v1/management/secrets/campaigns/revalidate", backend.bulkCampaignRevalidate)
+	registerBulkCampaignAction(mux, security, "/v1/management/secrets/campaigns/apply", backend.bulkCampaignApply)
+	registerBulkCampaignAction(mux, security, "/v1/management/secrets/campaigns/status", backend.bulkCampaignStatus)
+}
+
+func registerBulkCampaignAction(mux *http.ServeMux, security localAPISecurity, path string, handler func(bulkCampaignRequest) (bulkCampaignResponse, error)) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST "+path+".", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req bulkCampaignRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := handler(req)
+		if err != nil {
+			writeBulkCampaignActionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeBulkCampaignActionError(w http.ResponseWriter, err error, res bulkCampaignResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errSourceAuthRequired):
+		status = http.StatusFailedDependency
+	case errors.Is(err, errUnsupportedProvider):
+		status = http.StatusNotImplemented
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/bulk_campaign_test.go
+++ b/cmd/secretsbroker/bulk_campaign_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBulkCampaignCreateRevalidateApplyAndStatusAreMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	readyRef := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	deniedRef := "services/deny/runtime/DENY_ME"
+	writeManagedTestSecret(t, backend, readyRef, managedSecretValue)
+	writeManagedTestSecret(t, backend, deniedRef, "bulk-denied-secret-value")
+
+	created, err := backend.bulkCampaignCreate(bulkCampaignRequest{
+		RequestID:   "req-bulk-create",
+		ServiceID:   "@serviceadmin",
+		CampaignID:  "campaign-a",
+		Operation:   "rotate_reset",
+		Refs:        []string{deniedRef, readyRef},
+		Reason:      "operator planning",
+		OperationID: "op-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != "partial_failure" || created.Summary.ApplicableCount != 1 || created.Summary.DeniedCount != 1 || created.Applied {
+		t.Fatalf("created campaign = %#v", created)
+	}
+	if created.PlanToken == "" || created.Results[0].IdempotencyKey == "" || !created.Results[0].RetrySafe {
+		t.Fatalf("missing retry-safe identifiers: %#v", created.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, created), managedSecretValue, "bulk-denied-secret-value", "replacement-value")
+
+	revalidated, err := backend.bulkCampaignRevalidate(bulkCampaignRequest{
+		RequestID:  "req-bulk-revalidate",
+		ServiceID:  "@serviceadmin",
+		PlanToken:  created.PlanToken,
+		Operation:  "rotate_reset",
+		Refs:       []string{readyRef, deniedRef},
+		CampaignID: "campaign-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revalidated.Outcome != "partial_failure" || revalidated.RequiresRevalidation {
+		t.Fatalf("revalidated campaign = %#v", revalidated)
+	}
+
+	applied, err := backend.bulkCampaignApply(bulkCampaignRequest{
+		RequestID:  "req-bulk-apply",
+		ServiceID:  "@serviceadmin",
+		PlanToken:  created.PlanToken,
+		Operation:  "rotate_reset",
+		Confirm:    true,
+		Reason:     "approved campaign",
+		CampaignID: "campaign-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied.Outcome != "partial_failure" || !applied.Applied || applied.Summary.AppliedCount != 1 || applied.Summary.DeniedCount != 1 {
+		t.Fatalf("applied campaign = %#v", applied)
+	}
+	if applied.Results[0].Outcome != "applied" || !applied.Results[0].Applied || applied.Results[1].Outcome != "policy_denied" {
+		t.Fatalf("applied items = %#v", applied.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "bulk-denied-secret-value", "approved campaign")
+
+	status, err := backend.bulkCampaignStatus(bulkCampaignRequest{RequestID: "req-bulk-status", ServiceID: "@serviceadmin", PlanToken: created.PlanToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Outcome != applied.Outcome || status.Summary.AppliedCount != 1 {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestBulkCampaignApplyFailsClosedForMissingOrStalePlan(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	blocked, err := backend.bulkCampaignApply(bulkCampaignRequest{RequestID: "req-no-reason", ServiceID: "@serviceadmin", Operation: "rotate_reset", Refs: []string{ref}, Confirm: true})
+	if err == nil || blocked.Outcome != "policy_denied" || blocked.Applied {
+		t.Fatalf("missing plan/reason should fail closed: %#v err=%v", blocked, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, blocked), managedSecretValue)
+
+	stale, err := backend.bulkCampaignApply(bulkCampaignRequest{RequestID: "req-stale", ServiceID: "@serviceadmin", Operation: "rotate_reset", PlanToken: "missing-plan", Confirm: true, Reason: "approved"})
+	if err == nil || stale.Outcome != "stale_plan" || stale.Applied {
+		t.Fatalf("stale plan should fail closed: %#v err=%v", stale, err)
+	}
+}
+
+func TestBulkCampaignUnsupportedAuthRequiredAndPolicyStates(t *testing.T) {
+	backend := managedTestBackend(t)
+	localRef := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, localRef, managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "file-source", Kind: "file", Enabled: true, Refs: map[string]sourceRefConfig{
+			"services/file/runtime/FILE_ONLY_REF": {Path: "C:/not-used"},
+		},
+	}}}
+
+	unsupported, err := backend.bulkCampaignCreate(bulkCampaignRequest{RequestID: "req-unsupported", ServiceID: "@serviceadmin", Operation: "update_edit", Refs: []string{"services/file/runtime/FILE_ONLY_REF"}})
+	if err == nil || unsupported.Outcome != "unsupported" || unsupported.Summary.UnsupportedCount != 1 {
+		t.Fatalf("unsupported campaign = %#v err=%v", unsupported, err)
+	}
+
+	authRequired, err := backend.bulkCampaignCreate(bulkCampaignRequest{RequestID: "req-migrate", ServiceID: "@serviceadmin", Operation: "migrate_remap_provider", Refs: []string{localRef}})
+	if err == nil || authRequired.Outcome != "source_auth_required" || authRequired.Summary.AuthRequiredCount != 1 {
+		t.Fatalf("auth-required campaign = %#v err=%v", authRequired, err)
+	}
+
+	policyDenied, err := backend.bulkCampaignCreate(bulkCampaignRequest{RequestID: "req-policy", ServiceID: "@serviceadmin", Operation: "apply_policy", Refs: []string{localRef}})
+	if err == nil || policyDenied.Outcome != "policy_denied" || policyDenied.Summary.DeniedCount != 1 {
+		t.Fatalf("policy campaign = %#v err=%v", policyDenied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), managedSecretValue, "file-source-token")
+	assertNoSecretMaterial(t, mustManagedJSON(t, authRequired), managedSecretValue)
+	assertNoSecretMaterial(t, mustManagedJSON(t, policyDenied), managedSecretValue)
+}
+
+func TestBulkCampaignHTTPContractIsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-http-bulk","serviceId":"@serviceadmin","campaignId":"bulk-http-a","operation":"rotate_reset","refs":["` + ref + `"],"reason":"operator approved"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/campaigns/create", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readClose(t, res.Body)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("campaign create status=%d body=%s", res.StatusCode, got)
+	}
+	if !bytes.Contains(got, []byte(`"operation":"rotate_reset"`)) || !bytes.Contains(got, []byte(`"outcome":"dry_run_ready"`)) || !bytes.Contains(got, []byte(`"planToken"`)) {
+		t.Fatalf("campaign create body=%s", got)
+	}
+	assertNoSecretMaterial(t, got, managedSecretValue, "test-token")
+}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -43,6 +43,7 @@ type localBackend struct {
 	sources   sourceConfigFile
 	now       func() time.Time
 	lockouts  *lockoutStore
+	campaigns map[string]bulkCampaignResponse
 }
 
 type localStoreFile struct {
@@ -178,7 +179,7 @@ type auditEvent struct {
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
-	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }}
+	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}}
 	backend.lockouts = newLockoutStore(func() time.Time {
 		if backend.now == nil {
 			return time.Now().UTC()

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -243,6 +243,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/edit/dry-run|apply",
 			"POST /v1/management/secrets/reset/dry-run|apply",
 			"POST /v1/management/secrets/rotation/dry-run",
+			"POST /v1/management/secrets/campaigns/create|revalidate|apply|status",
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker admin mcp tools|call",
 			"CLI secretsbroker backup create|restore",
@@ -272,6 +273,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"secrets-management-controlled-reveal",
 			"secrets-management-dry-run-apply",
 			"credential-rotation-dry-run",
+			"bulk-secret-operation-campaigns",
 			"env-source",
 			"file-source",
 			"exec-source",
@@ -405,6 +407,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerRotationHandlers(mux, backend, security)
+		registerBulkCampaignHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
 		registerRecoveryPolicyHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -167,6 +167,107 @@ Response:
 
 Provider-backed refs are represented as metadata-only capability results. A provider/source that does not currently advertise rotate/reset support returns `unsupported` with `nextAction: "inspect_provider_capabilities"`. Unknown policy, audit, provider auth, or broker state fails closed and must be rechecked with a fresh dry-run before any later apply path.
 
+### `POST /v1/management/secrets/campaigns/create`
+### `POST /v1/management/secrets/campaigns/revalidate`
+### `POST /v1/management/secrets/campaigns/apply`
+### `POST /v1/management/secrets/campaigns/status`
+
+Bulk operation campaigns are the metadata-safe apply contract for multi-ref operations. They are designed for Service Admin bulk workflow Stage 2/3 and must be preceded by a campaign create/revalidate plan. They never return raw secret values, provider credentials, tokens, private keys, cookies, passwords, raw environment values, or recovery material.
+
+Supported operation families:
+
+- `rotate_reset`
+- `update_edit`
+- `apply_policy`
+- `migrate_remap_provider`
+- `mark_action_required`
+
+Create builds a non-mutating plan and returns a server-side `planToken`, retry-safe `operationItemId` values, and per-item `idempotencyKey` values.
+
+```json
+{
+  "requestId": "req-campaign-create",
+  "serviceId": "@serviceadmin",
+  "campaignId": "campaign-2026-06-19-a",
+  "operationId": "bulk-rotate-a",
+  "operation": "rotate_reset",
+  "refs": [
+    "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+  ],
+  "reason": "operator campaign planning"
+}
+```
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "requestId": "req-campaign-create",
+  "campaignId": "campaign-2026-06-19-a",
+  "planToken": "campaign-2026-06-19-a:rotate_reset:sha256:...",
+  "operationId": "bulk-rotate-a",
+  "operation": "rotate_reset",
+  "mode": "create",
+  "outcome": "dry_run_ready",
+  "applied": false,
+  "requiresConfirmation": true,
+  "requiresAuditReason": true,
+  "requiresRevalidation": true,
+  "auditStatus": "audit_ready",
+  "staleAfterSeconds": 300,
+  "nextAction": "revalidate_confirm_and_apply",
+  "results": [
+    {
+      "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+      "sourceId": "local-test",
+      "providerKind": "local-encrypted-store",
+      "ownerServiceId": "@serviceadmin",
+      "operation": "rotate_reset",
+      "capabilityResult": "supported",
+      "policyResult": "allowed",
+      "auditRequirement": "required",
+      "risk": "high",
+      "expectedAction": "generate_or_accept_replacement_inside_broker",
+      "outcome": "dry_run_ready",
+      "nextAction": "revalidate_confirm_and_apply",
+      "idempotencyKey": "campaign-2026-06-19-a:rotate_reset:sha256:...",
+      "operationItemId": "campaign-2026-06-19-a:item:sha256:...",
+      "recovery": "retry_with_same_idempotency_key_or_restore_from_backup",
+      "providerAction": "rotate_or_reset",
+      "applied": false,
+      "retrySafe": true
+    }
+  ],
+  "summary": {
+    "selectedCount": 1,
+    "applicableCount": 1,
+    "deniedCount": 0,
+    "unsupportedCount": 0,
+    "authRequiredCount": 0,
+    "skippedCount": 0,
+    "appliedCount": 0,
+    "failedCount": 0,
+    "staleCount": 0,
+    "highRiskCount": 1
+  },
+  "affectedRefs": [
+    "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+  ],
+  "affectedServices": [
+    "@serviceadmin"
+  ],
+  "unsupportedFamilies": [
+    "bulk_raw_value_reveal"
+  ]
+}
+```
+
+Apply requires `planToken`, `confirm: true`, and `reason`. The broker reuses the server-side plan, records campaign-level and per-item audit events, and applies only ready items. Denied, unsupported, auth-required, skipped, failed, and stale items remain typed per item. A missing or unknown `planToken` returns `stale_plan` and applies nothing.
+
+Campaign apply is retry-safe by `idempotencyKey` and `operationItemId`. The first implementation records metadata-level campaign outcomes and local-store-supported item outcomes; provider-specific live remote writes may continue returning typed `unsupported` until a provider operation path exists.
+
 ### `POST /v1/management/secrets/policy/preview`
 ### `POST /v1/management/secrets/policy/apply`
 
@@ -174,4 +275,4 @@ Preview/apply policy changes. This first contract records the requested policy h
 
 ## Typed outcomes
 
-Common outcomes: `ready`, `dry_run_ready`, `applied`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`.
+Common outcomes: `ready`, `dry_run_ready`, `applied`, `migrated`, `partial_failure`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`, `stale_plan`, `skipped`, `failed`.


### PR DESCRIPTION
## Issue
Closes #97

## Summary
- Adds a metadata-only bulk secret operation campaign API with create, revalidate, apply, and status endpoints.
- Adds per-item retry-safe identifiers, plan tokens, typed item outcomes, and campaign/item audit events.
- Documents the campaign contract for Service Admin bulk workflow Stage 2/3.

## Scope
- In scope: broker-side campaign plan/apply/status contract for rotate/reset, update/edit, policy apply, provider migration/remap, and mark-action-required families.
- In scope: local metadata-level apply outcomes and typed unsupported/auth/policy/stale handling for provider gaps.
- Out of scope: raw value reveal/export, plaintext spreadsheet editing, provider credentials, and live remote provider write implementations where provider operation paths are not yet available.

## Spec / contract / fixture impact
- Updated: `docs/secrets-management-api.md` with `/v1/management/secrets/campaigns/create|revalidate|apply|status` request/response semantics and typed outcomes.

## Service Lasso invariant impact
- Invariant: secrets stay out of logs, diagnostics, routes, and management responses.
- Preservation proof: campaign responses are metadata-only; tests assert raw secret material, replacement values, and local API tokens are absent from campaign responses.

## Validation
- PASS `go test ./cmd/secretsbroker` - campaign and existing broker tests passed.
- PASS `go test ./...` - all Go packages passed.
- PASS `powershell -ExecutionPolicy Bypass -File scripts/test.ps1` - Secrets Broker tests passed (Windows).
- BLOCKED `powershell -ExecutionPolicy Bypass -File scripts/verify.ps1` - `service-lasso-harness binary not found. Set SERVICE_LASSO_HARNESS_BIN or add it to PATH.`

## Approval trail
- Required: no explicit approval rule found for this issue before PR.
- Evidence: issue #97 is open and Ready in Project #1; start comment records preflight/demo/PR gate evidence.

## Cleanup
- Branch: `issue-97-bulk-campaign-api`
- Commit: `d616ee4`
- Post-merge cleanup: checkout/pull `main`, delete local/remote branch after CI is green and PR is merged.