### PR TITLE
feat(sync): add metadata-only Secrets Sync dry-run

### DIFF
--- a/.work-agent/logs/issue-101/go-test-all-20260620T1049.log
+++ b/.work-agent/logs/issue-101/go-test-all-20260620T1049.log
@@ -1,0 +1,10 @@
+# go test ./...
+--- FAIL: TestOnePasswordCLIAdapterNormalizesFailuresWithoutLeakingOutput (12.41s)
+    --- FAIL: TestOnePasswordCLIAdapterNormalizesFailuresWithoutLeakingOutput/missing_item (5.06s)
+        source_adapters_test.go:317: 1Password CLI result = main.sourceResolveResult{Found:false, Value:"", SourceID:"", Outcome:"source_unavailable", Message:"1Password CLI timed out.", Lifecycle:main.SourceLifecycle{State:"", Outcome:"", NextAction:"", Retryable:false, RetryAfterMs:0}}
+    --- FAIL: TestOnePasswordCLIAdapterNormalizesFailuresWithoutLeakingOutput/missing_field (7.24s)
+        source_adapters_test.go:317: 1Password CLI result = main.sourceResolveResult{Found:false, Value:"", SourceID:"", Outcome:"source_unavailable", Message:"1Password CLI timed out.", Lifecycle:main.SourceLifecycle{State:"", Outcome:"", NextAction:"", Retryable:false, RetryAfterMs:0}}
+FAIL
+FAIL	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker	16.098s
+ok  	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker-resolve	(cached)
+FAIL

--- a/.work-agent/logs/issue-101/go-test-all-rerun-20260620T1054.log
+++ b/.work-agent/logs/issue-101/go-test-all-rerun-20260620T1054.log
@@ -1,0 +1,3 @@
+# go test ./... (rerun)
+ok  	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker	3.186s
+ok  	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker-resolve	(cached)

--- a/.work-agent/logs/issue-101/scripts-test-ps1-20260620T1055.log
+++ b/.work-agent/logs/issue-101/scripts-test-ps1-20260620T1055.log
@@ -1,0 +1,4 @@
+# powershell -File scripts/test.ps1
+ok  	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker	(cached)
+ok  	github.com/service-lasso/lasso-secretsbroker/cmd/secretsbroker-resolve	(cached)
+Secrets Broker tests passed (Windows)

--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -61,6 +61,8 @@ func executeAdmin(args []string, out io.Writer) error {
 		return runAdminProviders(args[1:], out)
 	case "migration":
 		return runAdminMigration(args[1:], out)
+	case "sync":
+		return runAdminSync(args[1:], out)
 	case "recovery":
 		return runAdminRecovery(args[1:], out)
 	case "audit":
@@ -242,6 +244,82 @@ func runAdminMigration(args []string, out io.Writer) error {
 	default:
 		return fmt.Errorf("unknown admin migration command %q", sub)
 	}
+}
+
+func runAdminSync(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin sync command %q", "")
+	}
+	if args[0] != "dry-run" {
+		return fmt.Errorf("unknown admin sync command %q", args[0])
+	}
+	fs, opts := newAdminFlagSet("admin sync dry-run")
+	requestID := fs.String("request-id", "", "request id")
+	service := fs.String("service-id", "@operator", "requesting service/operator id")
+	operationID := fs.String("operation-id", "", "operation id")
+	destinationID := fs.String("destination-id", "", "sync destination id")
+	destinationKind := fs.String("destination-kind", "github-actions", "sync destination kind")
+	owner := fs.String("owner", "", "GitHub owner or organization")
+	repository := fs.String("repository", "", "GitHub repository")
+	environment := fs.String("environment", "", "GitHub environment")
+	secretsLocation := fs.String("secrets-location", "repository", "GitHub secrets location: repository, environment, or organization")
+	visibility := fs.String("visibility", "", "GitHub organization secret visibility metadata")
+	enterpriseURL := fs.String("enterprise-url", "", "GitHub Enterprise URL metadata")
+	authModel := fs.String("auth-model", "github-app", "destination auth model")
+	credentialRef := fs.String("credential-ref", "", "destination credential ref/handle")
+	credentialValue := fs.String("credential-value", "", "plaintext credential value; rejected")
+	nameTemplate := fs.String("name-template", "SERVICE_LASSO_{{ refBase | upper }}", "destination secret name template")
+	collisionPolicy := fs.String("collision-policy", "fail_if_unmanaged", "destination collision policy")
+	deletePolicy := fs.String("delete-policy", "delete_managed_destination_secret", "destination delete behavior")
+	reason := fs.String("reason", "", "audit reason")
+	refs := multiFlag{}
+	policyRefs := multiFlag{}
+	selectedRepos := multiFlag{}
+	fs.Var(&refs, "ref", "secret ref; repeatable")
+	fs.Var(&policyRefs, "policy-ref", "allowed management policy ref/pattern; repeatable")
+	fs.Var(&selectedRepos, "selected-repository", "selected repository metadata for organization secrets; repeatable")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	backend, _, err := backendFromAdminOptions(opts)
+	if err != nil {
+		return err
+	}
+	req := syncDryRunRequest{
+		RequestID:       *requestID,
+		ServiceID:       *service,
+		OperationID:     *operationID,
+		Refs:            []string(refs),
+		DestinationID:   *destinationID,
+		Reason:          *reason,
+		CredentialValue: *credentialValue,
+		Secrets:         &serviceSecretsPolicy{Manage: []string(policyRefs)},
+		Destination: syncDestinationConfig{
+			DestinationID:   *destinationID,
+			Kind:            *destinationKind,
+			Enabled:         true,
+			CredentialRef:   *credentialRef,
+			AuthModel:       *authModel,
+			NameTemplate:    *nameTemplate,
+			CollisionPolicy: *collisionPolicy,
+			DeletePolicy:    *deletePolicy,
+			Scope: syncDestinationScope{
+				Owner:                *owner,
+				Repository:           *repository,
+				Environment:          *environment,
+				SecretsLocation:      *secretsLocation,
+				Visibility:           *visibility,
+				SelectedRepositories: []string(selectedRepos),
+				EnterpriseURL:        *enterpriseURL,
+			},
+		},
+	}
+	res, err := backend.syncDryRun(req)
+	if err != nil {
+		_ = encodeAdminJSON(out, res)
+		return err
+	}
+	return encodeAdminJSON(out, res)
 }
 
 func runAdminRecovery(args []string, out io.Writer) error {

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -244,11 +244,12 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/reset/dry-run|apply",
 			"POST /v1/management/secrets/rotation/dry-run",
 			"POST /v1/management/secrets/campaigns/create|revalidate|apply|status",
+			"POST /v1/management/secrets/sync/dry-run",
 			"POST /v1/management/secrets/policy/preview|apply",
 			"CLI secretsbroker admin mcp tools|call",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate|recovery generate|recovery import",
-			"CLI secretsbroker admin status|secrets|providers|migration|recovery|audit|events",
+			"CLI secretsbroker admin status|secrets|providers|migration|sync|recovery|audit|events",
 		},
 		Features: []string{
 			"liveness",
@@ -274,6 +275,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"secrets-management-dry-run-apply",
 			"credential-rotation-dry-run",
 			"bulk-secret-operation-campaigns",
+			"metadata-only-secrets-sync-dry-run",
 			"env-source",
 			"file-source",
 			"exec-source",
@@ -408,6 +410,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerRotationHandlers(mux, backend, security)
 		registerBulkCampaignHandlers(mux, backend, security)
+		registerSyncDryRunHandlers(mux, backend, security)
 		registerProviderConfigMigrationHandlers(mux, backend, security)
 		registerRecoveryPolicyHandlers(mux, backend, security)
 		registerTelemetryHandlers(mux, backend)

--- a/cmd/secretsbroker/sync_dry_run.go
+++ b/cmd/secretsbroker/sync_dry_run.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const syncDryRunStaleAfterSeconds = 300
+
+type syncDryRunRequest struct {
+	RequestID       string                `json:"requestId"`
+	ServiceID       string                `json:"serviceId"`
+	OperationID     string                `json:"operationId"`
+	Refs            []string              `json:"refs"`
+	DestinationID   string                `json:"destinationId"`
+	Destination     syncDestinationConfig `json:"destination,omitempty"`
+	Reason          string                `json:"reason"`
+	Secrets         *serviceSecretsPolicy `json:"secrets,omitempty"`
+	CredentialValue string                `json:"credentialValue,omitempty"`
+	DriftState      string                `json:"driftState,omitempty"`
+	CollisionState  string                `json:"collisionState,omitempty"`
+}
+
+type syncDestinationConfig struct {
+	DestinationID   string               `json:"destinationId"`
+	Kind            string               `json:"kind"`
+	DisplayName     string               `json:"displayName,omitempty"`
+	Enabled         bool                 `json:"enabled"`
+	Scope           syncDestinationScope `json:"scope"`
+	CredentialRef   string               `json:"credentialRef,omitempty"`
+	AuthModel       string               `json:"authModel,omitempty"`
+	NameTemplate    string               `json:"nameTemplate,omitempty"`
+	Granularity     string               `json:"granularity,omitempty"`
+	CollisionPolicy string               `json:"collisionPolicy,omitempty"`
+	DeletePolicy    string               `json:"deletePolicy,omitempty"`
+	State           string               `json:"state,omitempty"`
+	Outcome         string               `json:"outcome,omitempty"`
+	AuditStatus     string               `json:"auditStatus,omitempty"`
+}
+
+type syncDestinationScope struct {
+	Owner                string   `json:"owner,omitempty"`
+	Repository           string   `json:"repository,omitempty"`
+	Environment          string   `json:"environment,omitempty"`
+	SecretsLocation      string   `json:"secretsLocation,omitempty"`
+	Visibility           string   `json:"visibility,omitempty"`
+	SelectedRepositories []string `json:"selectedRepositories,omitempty"`
+	EnterpriseURL        string   `json:"enterpriseUrl,omitempty"`
+}
+
+type syncDryRunItem struct {
+	Ref                string `json:"ref"`
+	RefHash            string `json:"refHash"`
+	SourceID           string `json:"sourceId"`
+	ProviderKind       string `json:"providerKind"`
+	OwnerServiceID     string `json:"ownerServiceId"`
+	DestinationName    string `json:"destinationName"`
+	Capability         string `json:"capability"`
+	CapabilityResult   string `json:"capabilityResult"`
+	PolicyResult       string `json:"policyResult"`
+	AuditRequirement   string `json:"auditRequirement"`
+	Risk               string `json:"risk"`
+	DriftState         string `json:"driftState"`
+	DeleteBehavior     string `json:"deleteBehavior"`
+	ExpectedAction     string `json:"expectedAction"`
+	Outcome            string `json:"outcome"`
+	NextAction         string `json:"nextAction"`
+	IdempotencyKey     string `json:"idempotencyKey"`
+	DestinationScope   string `json:"destinationScope,omitempty"`
+	DestinationOutcome string `json:"destinationOutcome,omitempty"`
+}
+
+type syncDryRunSummary struct {
+	SelectedCount           int `json:"selectedCount"`
+	ReadyCount              int `json:"readyCount"`
+	DeniedCount             int `json:"deniedCount"`
+	UnsupportedCount        int `json:"unsupportedCount"`
+	BlockedCount            int `json:"blockedCount"`
+	HighRiskCount           int `json:"highRiskCount"`
+	DriftUnknownCount       int `json:"driftUnknownCount"`
+	AuthRequiredCount       int `json:"authRequiredCount"`
+	AuditUnavailableCount   int `json:"auditUnavailableCount"`
+	UnmanagedCollisionCount int `json:"unmanagedCollisionCount"`
+}
+
+type syncDryRunResponse struct {
+	ServiceID            string                `json:"serviceId"`
+	APIVersion           string                `json:"apiVersion"`
+	RequestID            string                `json:"requestId,omitempty"`
+	OperationID          string                `json:"operationId"`
+	Operation            string                `json:"operation"`
+	Mode                 string                `json:"mode"`
+	Outcome              string                `json:"outcome"`
+	Applied              bool                  `json:"applied"`
+	RequiresConfirmation bool                  `json:"requiresConfirmation"`
+	AuditStatus          string                `json:"auditStatus"`
+	StaleAfterSeconds    int                   `json:"staleAfterSeconds"`
+	NextAction           string                `json:"nextAction"`
+	Destination          syncDestinationConfig `json:"destination"`
+	Results              []syncDryRunItem      `json:"results"`
+	Summary              syncDryRunSummary     `json:"summary"`
+	AffectedRefs         []string              `json:"affectedRefs"`
+	AffectedServices     []string              `json:"affectedServices"`
+}
+
+func (b *localBackend) syncDryRun(req syncDryRunRequest) (syncDryRunResponse, error) {
+	req.Refs = safeList(req.Refs)
+	dest := normalizeSyncDestination(req)
+	res := syncDryRunResponse{
+		ServiceID:            serviceID,
+		APIVersion:           apiVersion,
+		RequestID:            req.RequestID,
+		OperationID:          firstNonEmpty(safeOperationToken(req.OperationID), "sync-plan-"+hashAuditRef(strings.Join(req.Refs, ","))),
+		Operation:            "secrets_sync",
+		Mode:                 "dry-run",
+		Outcome:              "pending",
+		Applied:              false,
+		RequiresConfirmation: true,
+		AuditStatus:          "audit_ready",
+		StaleAfterSeconds:    syncDryRunStaleAfterSeconds,
+		NextAction:           "confirm_with_operation_id_audit_reason_and_fresh_plan",
+		Destination:          dest,
+		Results:              []syncDryRunItem{},
+		AffectedRefs:         req.Refs,
+		AffectedServices:     safeList([]string{req.ServiceID}),
+	}
+	if len(req.Refs) == 0 {
+		res.Outcome = "invalid_ref"
+		res.NextAction = "select_refs"
+		_ = b.audit("secrets_sync_dry_run", "", res.Outcome, req.ServiceID, req.RequestID)
+		return res, errInvalidRef
+	}
+	if b.locked() {
+		res.Outcome = "locked"
+		res.NextAction = "unlock_broker"
+		_ = b.audit("secrets_sync_dry_run", strings.Join(req.Refs, ","), res.Outcome, req.ServiceID, req.RequestID)
+		return res, errLocked
+	}
+	refs := append([]string(nil), req.Refs...)
+	sort.Strings(refs)
+	for _, ref := range refs {
+		res.Results = append(res.Results, b.syncDryRunItem(req, dest, res.OperationID, ref))
+	}
+	res.Summary = summarizeSyncDryRun(res.Results)
+	res.Outcome = syncDryRunAggregateOutcome(res.Summary)
+	res.NextAction = syncDryRunNextAction(res.Outcome)
+	_ = b.audit("secrets_sync_dry_run", strings.Join(res.AffectedRefs, ","), res.Outcome, req.ServiceID, req.RequestID)
+	if res.Outcome == "dry_run_ready" || res.Outcome == "partial_failure" {
+		return res, nil
+	}
+	return res, syncDryRunError(res.Outcome)
+}
+
+func (b *localBackend) syncDryRunItem(req syncDryRunRequest, dest syncDestinationConfig, operationID, ref string) syncDryRunItem {
+	item := syncDryRunItem{
+		Ref:                strings.TrimSpace(ref),
+		RefHash:            hashAuditRef(strings.TrimSpace(ref)),
+		SourceID:           "unknown",
+		ProviderKind:       "unknown",
+		OwnerServiceID:     ownerFromRef(ref),
+		DestinationName:    syncDestinationName(dest.NameTemplate, ref),
+		Capability:         "sync/write",
+		CapabilityResult:   "supported",
+		PolicyResult:       "allowed",
+		AuditRequirement:   "required",
+		Risk:               "high",
+		DriftState:         firstNonEmpty(normalizeSyncDrift(req.DriftState), "unknown"),
+		DeleteBehavior:     firstNonEmpty(dest.DeletePolicy, "delete_managed_destination_secret"),
+		ExpectedAction:     "encrypt_and_create_or_update_github_actions_secret",
+		Outcome:            "dry_run_ready",
+		NextAction:         "confirm_with_operation_id_audit_reason_and_fresh_plan",
+		IdempotencyKey:     syncIdempotencyKey(operationID, ref),
+		DestinationScope:   syncDestinationScopeLabel(dest.Scope),
+		DestinationOutcome: firstNonEmpty(dest.Outcome, "ready"),
+	}
+	if !validSecretRef(ref) {
+		item.Outcome = "invalid_ref"
+		item.PolicyResult = "denied"
+		item.CapabilityResult = "invalid"
+		item.NextAction = "fix_ref"
+		return item
+	}
+	record, err := b.managedRecord(ref)
+	if err != nil {
+		item.Outcome = outcomeForError(err)
+		item.PolicyResult = policyResultForOutcome(item.Outcome)
+		item.CapabilityResult = capabilityResultForOutcome(item.Outcome)
+		item.NextAction = syncNextActionForOutcome(item.Outcome)
+		return item
+	}
+	item.SourceID = record.SourceID
+	item.ProviderKind = record.ProviderKind
+	item.OwnerServiceID = record.OwnerServiceID
+	if !syncSourceCapabilitySupported(record) {
+		item.Outcome = "unsupported"
+		item.CapabilityResult = "unsupported"
+		item.PolicyResult = "unknown"
+		item.NextAction = "inspect_source_capabilities"
+		return item
+	}
+	if decision := evaluateSyncPolicy(req, ref); decision.Outcome != "allowed" {
+		item.Outcome = "policy_denied"
+		item.PolicyResult = decision.Outcome
+		item.NextAction = decision.NextAction
+		return item
+	}
+	if strings.TrimSpace(req.CredentialValue) != "" {
+		item.Outcome = "policy_denied"
+		item.PolicyResult = "denied"
+		item.NextAction = "replace_plaintext_destination_credential_with_credential_ref"
+		return item
+	}
+	if dest.Kind != "github-actions" {
+		item.Outcome = "unsupported"
+		item.CapabilityResult = "unsupported"
+		item.PolicyResult = "unknown"
+		item.NextAction = "select_supported_destination_kind"
+		return item
+	}
+	if !dest.Enabled || dest.State != "configured" || strings.TrimSpace(dest.CredentialRef) == "" {
+		item.Outcome = "destination_auth_required"
+		item.CapabilityResult = "blocked"
+		item.PolicyResult = "unknown"
+		item.NextAction = "configure_destination_credential_ref"
+		return item
+	}
+	if dest.AuditStatus == "audit_unavailable" {
+		item.Outcome = "audit_unavailable"
+		item.CapabilityResult = "blocked"
+		item.PolicyResult = "unknown"
+		item.NextAction = "restore_audit_before_sync"
+		return item
+	}
+	if strings.TrimSpace(req.CollisionState) == "unmanaged_collision" {
+		item.Outcome = "unmanaged_collision"
+		item.CapabilityResult = "blocked"
+		item.NextAction = "review_destination_secret_ownership"
+		return item
+	}
+	return item
+}
+
+func normalizeSyncDestination(req syncDryRunRequest) syncDestinationConfig {
+	dest := req.Destination
+	dest.DestinationID = firstNonEmpty(dest.DestinationID, req.DestinationID)
+	dest.Kind = firstNonEmpty(strings.TrimSpace(dest.Kind), "github-actions")
+	dest.DisplayName = firstNonEmpty(dest.DisplayName, dest.DestinationID)
+	dest.AuthModel = firstNonEmpty(dest.AuthModel, "github-app")
+	dest.NameTemplate = firstNonEmpty(dest.NameTemplate, "SERVICE_LASSO_{{ refBase | upper }}")
+	dest.Granularity = firstNonEmpty(dest.Granularity, "secret-ref")
+	dest.CollisionPolicy = firstNonEmpty(dest.CollisionPolicy, "fail_if_unmanaged")
+	dest.DeletePolicy = firstNonEmpty(dest.DeletePolicy, "delete_managed_destination_secret")
+	dest.State = firstNonEmpty(dest.State, "configured")
+	dest.Outcome = firstNonEmpty(dest.Outcome, "ready")
+	dest.AuditStatus = firstNonEmpty(dest.AuditStatus, "audit_available")
+	if strings.TrimSpace(dest.DestinationID) != "" && !dest.Enabled {
+		dest.Enabled = true
+	}
+	dest.Scope.SelectedRepositories = safeList(dest.Scope.SelectedRepositories)
+	return dest
+}
+
+func evaluateSyncPolicy(req syncDryRunRequest, ref string) secretPolicyDecision {
+	if strings.Contains(strings.ToLower(ref), "deny") {
+		return secretPolicyDecision{ServiceID: req.ServiceID, Operation: "manage", Ref: ref, Outcome: "denied", NextAction: "review_policy", ReasonCode: "policy_name_denied"}
+	}
+	return evaluateServiceSecretsPolicy(req.ServiceID, "manage", ref, req.Secrets)
+}
+
+func syncSourceCapabilitySupported(record managedSecretRecord) bool {
+	for _, capability := range record.Capabilities {
+		switch capability {
+		case "reveal", "read", "metadata":
+			return true
+		}
+	}
+	return false
+}
+
+func syncDestinationName(template, ref string) string {
+	base := refName(ref)
+	safe := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' {
+			return r - 32
+		}
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '_'
+	}, base)
+	safe = strings.Trim(safe, "_")
+	if safe == "" {
+		safe = "SECRET"
+	}
+	template = firstNonEmpty(template, "SERVICE_LASSO_{{ refBase | upper }}")
+	return strings.ReplaceAll(template, "{{ refBase | upper }}", safe)
+}
+
+func syncDestinationScopeLabel(scope syncDestinationScope) string {
+	switch strings.TrimSpace(scope.SecretsLocation) {
+	case "environment":
+		return strings.Join(safeList([]string{"environment", scope.Owner, scope.Repository, scope.Environment}), "/")
+	case "organization":
+		return strings.Join(safeList([]string{"organization", scope.Owner, scope.Visibility}), "/")
+	default:
+		return strings.Join(safeList([]string{"repository", scope.Owner, scope.Repository}), "/")
+	}
+}
+
+func syncIdempotencyKey(operationID, ref string) string {
+	return strings.Join([]string{safeOperationToken(operationID), hashAuditRef(strings.TrimSpace(ref))}, ":")
+}
+
+func normalizeSyncDrift(value string) string {
+	switch strings.TrimSpace(value) {
+	case "not_checked", "unknown", "missing", "managed_current", "managed_stale", "destination_changed_metadata", "unmanaged_collision":
+		return strings.TrimSpace(value)
+	default:
+		return "unknown"
+	}
+}
+
+func summarizeSyncDryRun(items []syncDryRunItem) syncDryRunSummary {
+	summary := syncDryRunSummary{SelectedCount: len(items)}
+	for _, item := range items {
+		switch item.Outcome {
+		case "dry_run_ready":
+			summary.ReadyCount++
+		case "policy_denied", "invalid_ref":
+			summary.DeniedCount++
+		case "unsupported":
+			summary.UnsupportedCount++
+		case "destination_auth_required", "source_auth_required":
+			summary.AuthRequiredCount++
+			summary.BlockedCount++
+		case "audit_unavailable":
+			summary.AuditUnavailableCount++
+			summary.BlockedCount++
+		case "unmanaged_collision":
+			summary.UnmanagedCollisionCount++
+			summary.BlockedCount++
+		default:
+			summary.BlockedCount++
+		}
+		if item.Risk == "high" {
+			summary.HighRiskCount++
+		}
+		if item.DriftState == "unknown" {
+			summary.DriftUnknownCount++
+		}
+	}
+	return summary
+}
+
+func syncDryRunAggregateOutcome(summary syncDryRunSummary) string {
+	if summary.SelectedCount == 0 {
+		return "invalid_ref"
+	}
+	if summary.ReadyCount == summary.SelectedCount {
+		return "dry_run_ready"
+	}
+	if summary.ReadyCount > 0 {
+		return "partial_failure"
+	}
+	if summary.DeniedCount > 0 {
+		return "policy_denied"
+	}
+	if summary.UnsupportedCount > 0 {
+		return "unsupported"
+	}
+	if summary.AuthRequiredCount > 0 {
+		return "destination_auth_required"
+	}
+	if summary.AuditUnavailableCount > 0 {
+		return "audit_unavailable"
+	}
+	if summary.UnmanagedCollisionCount > 0 {
+		return "unmanaged_collision"
+	}
+	return "degraded"
+}
+
+func syncDryRunNextAction(outcome string) string {
+	switch outcome {
+	case "dry_run_ready":
+		return "confirm_with_operation_id_audit_reason_and_fresh_plan"
+	case "partial_failure":
+		return "review_denied_unsupported_or_blocked_items"
+	case "destination_auth_required":
+		return "configure_destination_credential_ref"
+	case "audit_unavailable":
+		return "restore_audit_before_sync"
+	case "unmanaged_collision":
+		return "review_destination_secret_ownership"
+	case "unsupported":
+		return "select_supported_destination_kind"
+	default:
+		return syncNextActionForOutcome(outcome)
+	}
+}
+
+func syncNextActionForOutcome(outcome string) string {
+	switch outcome {
+	case "destination_auth_required":
+		return "configure_destination_credential_ref"
+	case "destination_unavailable":
+		return "inspect_destination_status"
+	case "audit_unavailable":
+		return "restore_audit_before_sync"
+	case "unsupported":
+		return "select_supported_destination_kind"
+	case "unmanaged_collision":
+		return "review_destination_secret_ownership"
+	default:
+		return nextActionForManagedOutcome(outcome)
+	}
+}
+
+func syncDryRunError(outcome string) error {
+	switch outcome {
+	case "invalid_ref":
+		return errInvalidRef
+	case "locked":
+		return errLocked
+	case "policy_denied":
+		return errPolicyDenied
+	case "unsupported":
+		return errUnsupportedProvider
+	case "destination_auth_required", "source_auth_required":
+		return errSourceAuthRequired
+	default:
+		return errBackendDegraded
+	}
+}
+
+func registerSyncDryRunHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/management/secrets/sync/dry-run", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST /v1/management/secrets/sync/dry-run.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req syncDryRunRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := backend.syncDryRun(req)
+		if err != nil {
+			writeSyncDryRunError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeSyncDryRunError(w http.ResponseWriter, err error, res syncDryRunResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errPolicyDenied):
+		status = http.StatusForbidden
+	case errors.Is(err, errSourceAuthRequired):
+		status = http.StatusFailedDependency
+	case errors.Is(err, errUnsupportedProvider):
+		status = http.StatusNotImplemented
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/sync_dry_run_test.go
+++ b/cmd/secretsbroker/sync_dry_run_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSecretsSyncDryRunReadyContractIsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	res, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:     "req-sync-ready",
+		ServiceID:     "@serviceadmin",
+		OperationID:   "sync-plan-a",
+		Refs:          []string{ref},
+		DestinationID: "github-actions-service-lasso",
+		Reason:        "CI runner needs metadata-only plan",
+		Secrets:       &serviceSecretsPolicy{Manage: []string{"services/@serviceadmin/*"}},
+		Destination: syncDestinationConfig{
+			DestinationID: "github-actions-service-lasso",
+			Kind:          "github-actions",
+			Enabled:       true,
+			CredentialRef: "providers/github/service-lasso-sync/app",
+			AuthModel:     "github-app",
+			Scope: syncDestinationScope{
+				Owner:           "service-lasso",
+				Repository:      "service-lasso",
+				Environment:     "demo",
+				SecretsLocation: "environment",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "dry_run_ready" || res.Applied || !res.RequiresConfirmation || res.Summary.ReadyCount != 1 || res.Summary.HighRiskCount != 1 {
+		t.Fatalf("sync dry-run response = %#v", res)
+	}
+	if len(res.Results) != 1 || res.Results[0].DestinationName != "SERVICE_LASSO_SESSION_SIGNING_KEY" || res.Results[0].IdempotencyKey == "" || res.Results[0].RefHash == "" {
+		t.Fatalf("sync dry-run item = %#v", res.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "test-master-key", "CI runner needs metadata-only plan", "providers/github/service-lasso-sync/app-private-key")
+}
+
+func TestSecretsSyncDryRunFailsClosedForPolicyAuthAuditCollisionAndNoLeak(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+
+	denied, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:     "req-sync-denied",
+		ServiceID:     "@serviceadmin",
+		Refs:          []string{ref},
+		DestinationID: "github-actions-service-lasso",
+		Secrets:       &serviceSecretsPolicy{Manage: []string{"services/other/*"}},
+		Destination:   readySyncDestination(),
+	})
+	if !errors.Is(err, errPolicyDenied) || denied.Outcome != "policy_denied" || denied.Summary.DeniedCount != 1 {
+		t.Fatalf("policy denied sync = %#v err=%v", denied, err)
+	}
+
+	authRequired, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:     "req-sync-auth",
+		ServiceID:     "@serviceadmin",
+		Refs:          []string{ref},
+		DestinationID: "github-actions-service-lasso",
+		Secrets:       &serviceSecretsPolicy{Manage: []string{"services/@serviceadmin/*"}},
+		Destination: syncDestinationConfig{
+			DestinationID: "github-actions-service-lasso",
+			Kind:          "github-actions",
+			Enabled:       true,
+			Scope:         syncDestinationScope{Owner: "service-lasso", Repository: "service-lasso", SecretsLocation: "repository"},
+		},
+	})
+	if !errors.Is(err, errSourceAuthRequired) || authRequired.Outcome != "destination_auth_required" || authRequired.Summary.AuthRequiredCount != 1 {
+		t.Fatalf("auth required sync = %#v err=%v", authRequired, err)
+	}
+
+	auditUnavailableDest := readySyncDestination()
+	auditUnavailableDest.AuditStatus = "audit_unavailable"
+	auditUnavailable, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:     "req-sync-audit",
+		ServiceID:     "@serviceadmin",
+		Refs:          []string{ref},
+		DestinationID: "github-actions-service-lasso",
+		Secrets:       &serviceSecretsPolicy{Manage: []string{"services/@serviceadmin/*"}},
+		Destination:   auditUnavailableDest,
+	})
+	if err == nil || auditUnavailable.Outcome != "audit_unavailable" || auditUnavailable.Summary.AuditUnavailableCount != 1 {
+		t.Fatalf("audit unavailable sync = %#v err=%v", auditUnavailable, err)
+	}
+
+	collision, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:      "req-sync-collision",
+		ServiceID:      "@serviceadmin",
+		Refs:           []string{ref},
+		DestinationID:  "github-actions-service-lasso",
+		Secrets:        &serviceSecretsPolicy{Manage: []string{"services/@serviceadmin/*"}},
+		Destination:    readySyncDestination(),
+		CollisionState: "unmanaged_collision",
+	})
+	if err == nil || collision.Outcome != "unmanaged_collision" || collision.Summary.UnmanagedCollisionCount != 1 {
+		t.Fatalf("collision sync = %#v err=%v", collision, err)
+	}
+
+	plaintextCredential, err := backend.syncDryRun(syncDryRunRequest{
+		RequestID:       "req-sync-plain-credential",
+		ServiceID:       "@serviceadmin",
+		Refs:            []string{ref},
+		DestinationID:   "github-actions-service-lasso",
+		Secrets:         &serviceSecretsPolicy{Manage: []string{"services/@serviceadmin/*"}},
+		Destination:     readySyncDestination(),
+		CredentialValue: "ghp_plaintext_token_value",
+	})
+	if !errors.Is(err, errPolicyDenied) || plaintextCredential.Outcome != "policy_denied" {
+		t.Fatalf("plaintext credential sync = %#v err=%v", plaintextCredential, err)
+	}
+
+	for _, payload := range [][]byte{mustManagedJSON(t, denied), mustManagedJSON(t, authRequired), mustManagedJSON(t, auditUnavailable), mustManagedJSON(t, collision), mustManagedJSON(t, plaintextCredential)} {
+		assertNoSecretMaterial(t, payload, managedSecretValue, "ghp_plaintext_token_value", "SecretString", "encrypted_value_payload", "private-key")
+	}
+}
+
+func TestSecretsSyncDryRunHTTPAndCLIContractAreMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body := []byte(`{"requestId":"req-http-sync","serviceId":"@serviceadmin","operationId":"sync-plan-http","refs":["` + ref + `"],"destinationId":"github-actions-service-lasso","secrets":{"manage":["services/@serviceadmin/*"]},"destination":{"destinationId":"github-actions-service-lasso","kind":"github-actions","enabled":true,"credentialRef":"providers/github/service-lasso-sync/app","scope":{"owner":"service-lasso","repository":"service-lasso","secretsLocation":"repository"}},"credentialValue":"ghp_plaintext_token_value"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/sync/dry-run", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-token")
+	httpRes, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readClose(t, httpRes.Body)
+	if httpRes.StatusCode != http.StatusForbidden {
+		t.Fatalf("sync dry-run status=%d body=%s", httpRes.StatusCode, got)
+	}
+	assertNoSecretMaterial(t, got, managedSecretValue, "test-token", "ghp_plaintext_token_value")
+
+	var safe bytes.Buffer
+	err = executeAdmin([]string{
+		"sync", "dry-run",
+		"--ref", ref,
+		"--service-id", "@serviceadmin",
+		"--policy-ref", "services/@serviceadmin/*",
+		"--destination-id", "github-actions-service-lasso",
+		"--owner", "service-lasso",
+		"--repository", "service-lasso",
+		"--secrets-location", "repository",
+		"--credential-ref", "providers/github/service-lasso-sync/app",
+		"--store", backend.storePath,
+		"--audit", backend.auditPath,
+		"--master-key", "test-master-key",
+	}, &safe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, safe.Bytes(), managedSecretValue, "test-master-key")
+	if !bytes.Contains(safe.Bytes(), []byte(`"operation": "secrets_sync"`)) || !bytes.Contains(safe.Bytes(), []byte(`"outcome": "dry_run_ready"`)) {
+		t.Fatalf("CLI sync dry-run body=%s", safe.String())
+	}
+
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, auditBytes, managedSecretValue, "ghp_plaintext_token_value", "test-token")
+	if !strings.Contains(string(auditBytes), "secrets_sync_dry_run") {
+		t.Fatalf("audit missing sync dry run: %s", auditBytes)
+	}
+}
+
+func readySyncDestination() syncDestinationConfig {
+	return syncDestinationConfig{
+		DestinationID: "github-actions-service-lasso",
+		Kind:          "github-actions",
+		Enabled:       true,
+		CredentialRef: "providers/github/service-lasso-sync/app",
+		AuthModel:     "github-app",
+		Scope:         syncDestinationScope{Owner: "service-lasso", Repository: "service-lasso", SecretsLocation: "repository"},
+	}
+}
+
+func TestSecretsSyncDryRunRepresentsGitHubScopes(t *testing.T) {
+	for _, scope := range []syncDestinationScope{
+		{Owner: "service-lasso", Repository: "service-lasso", SecretsLocation: "repository"},
+		{Owner: "service-lasso", Repository: "service-lasso", Environment: "demo", SecretsLocation: "environment"},
+		{Owner: "service-lasso", SecretsLocation: "organization", Visibility: "selected", SelectedRepositories: []string{"service-lasso"}, EnterpriseURL: "https://github.example.invalid"},
+	} {
+		dest := readySyncDestination()
+		dest.Scope = scope
+		normalized := normalizeSyncDestination(syncDryRunRequest{DestinationID: dest.DestinationID, Destination: dest})
+		if normalized.Scope.SecretsLocation == "" || normalized.Kind != "github-actions" {
+			t.Fatalf("normalized scope = %#v", normalized)
+		}
+		if syncDestinationScopeLabel(normalized.Scope) == "" {
+			t.Fatalf("empty scope label for %#v", normalized.Scope)
+		}
+	}
+}

--- a/docs/headless-admin-cli.md
+++ b/docs/headless-admin-cli.md
@@ -96,6 +96,23 @@ secretsbroker admin migration dry-run `
 
 Migration dry-run is metadata-only. Apply requires `--confirm`, `--operation-id`, and `--reason` and still does not print raw values.
 
+### Secrets Sync dry-run
+
+```powershell
+secretsbroker admin sync dry-run `
+  --ref services/@serviceadmin/runtime/API_TOKEN `
+  --policy-ref services/@serviceadmin/* `
+  --destination-id github-actions-service-lasso `
+  --owner service-lasso `
+  --repository service-lasso `
+  --secrets-location environment `
+  --environment demo `
+  --credential-ref providers/github/service-lasso-sync/app `
+  --operation-id sync-plan-2026-06-20-a
+```
+
+Secrets Sync dry-run is metadata-only and does not write to GitHub or any other destination. It returns destination scope/status metadata, per-ref policy/capability/audit/drift/delete-risk outcomes, idempotency keys, and next action guidance. Plaintext destination credentials are rejected; use `--credential-ref` only.
+
 ### Recovery policy metadata
 
 ```powershell

--- a/docs/secrets-sync-design.md
+++ b/docs/secrets-sync-design.md
@@ -155,6 +155,22 @@ Request:
 }
 ```
 
+The implementation also accepts an optional metadata-only `destination` object for headless/local dry-run callers that do not yet have a persisted destination registry. This object may include destination id, kind, auth model, credential ref, name template, granularity, collision/delete policy, audit status, and GitHub scope metadata. It must not contain private keys, tokens, REST request bodies, encrypted secret payloads, or plaintext secret values. Any plaintext `credentialValue` input is rejected and is not echoed.
+
+Headless CLI equivalent:
+
+```powershell
+secretsbroker admin sync dry-run `
+  --ref services/api/runtime/API_TOKEN `
+  --policy-ref services/api/* `
+  --destination-id github-actions-service-lasso `
+  --owner service-lasso `
+  --repository service-lasso `
+  --secrets-location environment `
+  --environment demo `
+  --credential-ref providers/github/service-lasso-sync/app
+```
+
 Response:
 
 ```json


### PR DESCRIPTION
## Issue
Closes #101

## Summary
- Adds `POST /v1/management/secrets/sync/dry-run` for provider-neutral, metadata-only Secrets Sync planning.
- Adds `secretsbroker admin sync dry-run` with GitHub Actions destination scope metadata and credential-ref-only safety behavior.
- Adds dry-run response structs for destination metadata, per-ref policy/capability/audit/drift/delete outcomes, idempotency keys, and aggregate summary counts.
- Rejects plaintext destination credential input without echoing it and keeps responses/audit/logs metadata-only.

## Scope
- In scope: metadata-only dry-run contract, GitHub Actions destination representation, CLI entry point, HTTP handler, capability/docs updates, redaction/fail-closed tests.
- Out of scope: live GitHub writes/deletes, app installation-token minting, PAT storage UI, background reconciliation, import/bidirectional sync.

## Spec / contract / fixture impact
- Updated: `docs/secrets-sync-design.md` and `docs/headless-admin-cli.md`.
- API added: `POST /v1/management/secrets/sync/dry-run`.
- CLI added: `secretsbroker admin sync dry-run`.

## Nash invariant impact
- Invariant: no raw secret values, destination credentials, private keys, tokens, encrypted payloads, REST request bodies, or raw provider responses leave the broker value path.
- Preservation proof: tests assert no leakage for ready, policy denied, destination auth required, audit unavailable, unmanaged collision, plaintext credential rejection, HTTP, CLI, and audit surfaces.

## Validation
- PASS `go test ./cmd/secretsbroker -run "TestSecretsSyncDryRun|TestAdminCLI"` — focused suite passed locally before full validation.
- FAIL then PASS `go test ./...` — first run hit a transient unrelated 1Password CLI helper timeout; rerun passed. Logs:
  - `.work-agent/logs/issue-101/go-test-all-20260620T1049.log`
  - `.work-agent/logs/issue-101/go-test-all-rerun-20260620T1054.log`
- PASS `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/test.ps1` — `.work-agent/logs/issue-101/scripts-test-ps1-20260620T1055.log`
- PASS canonical preflight before branch work:
  - Service Admin `http://192.168.1.53:17700/` HTTP 200
  - Runtime `http://192.168.1.53:17883/api/health` HTTP 200/status ok

## Approval trail
- Required: normal PR review/merge rules.
- Evidence: this PR and linked issue comment trail.

## Demo / release gate
- This changes `lasso-secretsbroker`, a demo-consumed service repo, but no merge/release has occurred in this PR creation step.
- Release-to-demo gate remains pending after merge/release: publish/consume the exact new tag or commit in the core demo manifest, recycle canonical demo on port `17883`, and run `npm run demo:verify-canonical` before issue closure.

## Cleanup
- Branch: `issue-101-sync-dry-run`
- Commit: `0163418`
- Local cleanup remains pending until PR merge/release/demo pin flow completes.
