### PR TITLE
fix: expose safe resolve policy denial metadata

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -188,11 +188,14 @@ type resolveResponse struct {
 }
 
 type resolveResult struct {
-	Ref      string          `json:"ref"`
-	Outcome  string          `json:"outcome"`
-	Value    string          `json:"value,omitempty"`
-	Metadata *SecretMetadata `json:"metadata,omitempty"`
-	Message  string          `json:"message,omitempty"`
+	Ref          string          `json:"ref"`
+	Outcome      string          `json:"outcome"`
+	Value        string          `json:"value,omitempty"`
+	Metadata     *SecretMetadata `json:"metadata,omitempty"`
+	Message      string          `json:"message,omitempty"`
+	PolicyResult string          `json:"policyResult,omitempty"`
+	NextAction   string          `json:"nextAction,omitempty"`
+	ReasonCode   string          `json:"reasonCode,omitempty"`
 }
 
 type auditEvent struct {
@@ -777,9 +780,12 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 			result.Message = "Secret ref is invalid."
 		case req.Secrets != nil && evaluateServiceSecretsPolicy(req.ServiceID, "resolve", ref, req.Secrets).Outcome != "allowed":
 			decision := evaluateServiceSecretsPolicy(req.ServiceID, "resolve", ref, req.Secrets)
-			_ = b.audit("policy_decision", ref, decision.Outcome, req.ServiceID, req.RequestID)
+			_ = b.auditPolicyDecision(ref, decision, req.RequestID)
 			result.Outcome = "policy_denied"
 			result.Message = "Service secret policy denied resolve."
+			result.PolicyResult = decision.Outcome
+			result.NextAction = decision.NextAction
+			result.ReasonCode = decision.ReasonCode
 		case b.locked():
 			result.Outcome = "locked"
 			result.Message = "Secrets Broker local store is locked."
@@ -853,6 +859,10 @@ func (b *localBackend) saveStore(store localStoreFile) error {
 
 func (b *localBackend) audit(operation, ref, outcome, requestServiceID, requestID string) error {
 	return b.writeAuditEvent(auditEvent{TS: b.now(), Operation: operation, Ref: ref, Outcome: outcome, ServiceID: requestServiceID, RequestID: requestID})
+}
+
+func (b *localBackend) auditPolicyDecision(ref string, decision secretPolicyDecision, requestID string) error {
+	return b.writeAuditEvent(auditEvent{TS: b.now(), Operation: "policy_decision", Ref: ref, Outcome: decision.Outcome, ServiceID: decision.ServiceID, RequestID: requestID, ReasonCode: decision.ReasonCode})
 }
 
 func (b *localBackend) auditSourceLifecycle(ref string, result sourceResolveResult, requestServiceID, requestID string) error {

--- a/cmd/secretsbroker/policy_test.go
+++ b/cmd/secretsbroker/policy_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 )
@@ -68,11 +69,22 @@ func TestResolveHonorsManifestPolicyWithoutLeakingValue(t *testing.T) {
 	if res.Results[1].Outcome != "policy_denied" || res.Results[1].Value != "" {
 		t.Fatalf("denied result = %#v", res.Results[1])
 	}
+	if res.Results[1].PolicyResult != "denied" || res.Results[1].ReasonCode != "policy_no_match" || res.Results[1].NextAction != "add_service_secret_policy_assignment" {
+		t.Fatalf("denied policy metadata = %#v", res.Results[1])
+	}
 	encoded, err := json.Marshal(res.Results[1])
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertNoSecretMaterial(t, encoded, deniedValue)
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, auditBytes, deniedValue)
+	if !strings.Contains(string(auditBytes), `"operation":"policy_decision"`) || !strings.Contains(string(auditBytes), `"reasonCode":"policy_no_match"`) {
+		t.Fatalf("audit missing policy decision reason: %s", auditBytes)
+	}
 }
 
 func TestWritebackHonorsManifestPolicyWithoutLeakingValue(t *testing.T) {

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -299,9 +299,11 @@ Response:
     },
     {
       "ref": "openclaw/telegram/bot_token",
-      "outcome": "source_auth_required",
-      "message": "Telegram source needs reconnect before this ref can be resolved.",
-      "nextAction": "reconnect_source"
+      "outcome": "policy_denied",
+      "message": "Service secret policy denied resolve.",
+      "policyResult": "denied",
+      "nextAction": "add_service_secret_policy_assignment",
+      "reasonCode": "policy_no_match"
     }
   ]
 }
@@ -311,7 +313,8 @@ Rules:
 
 - Values are present only for refs allowed by policy and only on resolve endpoints.
 - Missing/denied/invalid/auth-required entries use per-result outcomes.
-- Audit records must redact secret values.
+- Resolve policy denials include only safe metadata: `policyResult`, `nextAction`, and `reasonCode`.
+- Policy decision and resolve audit records must redact secret values and credential material.
 
 ## Planned write-back contract
 

--- a/docs/local-store-resolve.md
+++ b/docs/local-store-resolve.md
@@ -190,8 +190,11 @@ Response:
     },
     {
       "ref": "openclaw/telegram/bot_token",
-      "outcome": "missing_ref",
-      "message": "Secret ref was not found."
+      "outcome": "policy_denied",
+      "message": "Service secret policy denied resolve.",
+      "policyResult": "denied",
+      "nextAction": "add_service_secret_policy_assignment",
+      "reasonCode": "policy_no_match"
     }
   ]
 }
@@ -203,9 +206,10 @@ Rules:
 - Batch response reports per-ref outcomes.
 - Missing refs use `missing_ref`, not generic failure.
 - Invalid refs use `invalid_ref`.
+- Denied refs use `policy_denied` with safe policy metadata only: `policyResult`, `nextAction`, and `reasonCode`.
 - Locked store uses `locked` per requested ref.
 - `value` is present only when outcome is `ready`.
-- Audit logs redact values.
+- Policy decisions and resolve outcomes are audited with metadata only. Audit logs redact values.
 
 ## Ref validation
 


### PR DESCRIPTION
## Issue
Closes #30

## Summary
- Adds safe policy metadata (`policyResult`, `nextAction`, `reasonCode`) to per-ref resolve results when policy denies a ref.
- Records policy-decision audit events with the evaluator reason code.
- Updates resolve contract docs and tests metadata-only denial/audit behavior.

## Scope
- In scope: resolve denial response metadata, policy-decision audit reason codes, docs/tests for the local resolve contract.
- Out of scope: new policy file formats, provider-specific authorization changes, release packaging.

## Spec / contract / fixture impact
- Updated: `docs/local-store-resolve.md`, `docs/local-api-bootstrap-contract.md`.
- Fixture changes not required; no conformance fixture shape existed for the new optional denial metadata.

## Nash invariant impact
- Invariant: denied secret refs must not expose plaintext or credential material.
- Preservation proof: policy denial still omits `value`; tests assert denied response and audit output do not contain the denied secret value.

## Validation
- PASS `go test ./cmd/secretsbroker` — `C:\projects\service-lasso\.work-agent\logs\issue-30\go-test-cmd-secretsbroker.log`
- PASS `go test ./...` — `C:\projects\service-lasso\.work-agent\logs\issue-30\go-test-all.log`
- PASS canonical demo preflight/recovery `npm run demo:verify-canonical` exit 0 — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-20260622-0500\demo-verify-canonical-final.log`

## Approval trail
- Required: no explicit approval requirement found before opening PR.
- Evidence: issue is Ready on Project #1; branch created from clean `main`.

## Cleanup
- Branch: `issue-30-resolve-policy-metadata` pushed.
- Post-merge: release/tag and core demo manifest pin are required before claiming issue completion because `lasso-secretsbroker` is demo-consumed.