### PR TITLE
feat: add IPC transport policy foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The first bootstrap slice provides:
 - package/test/verify scripts following the service-template contract
 
 The first local encrypted store and batched resolve MVP is documented in `docs/local-store-resolve.md`. Portable master-key identity/unlock foundation is documented in `docs/portable-master-key.md`; the implemented initialize/unlock/import/re-wrap lifecycle is documented in `docs/master-key-lifecycle.md`; encrypted backup, restore, and key rotation are documented in `docs/backup-restore-rotation.md`; the recommended secure initialization and recovery-key model is documented in `docs/secure-initialization-recovery.md`. Local API token/session security is documented in `docs/local-api-security.md`, and signed scoped launch identity leases are documented in `docs/launch-identity-leases.md`. The provider/source registry model is documented in `docs/provider-source-registry.md`; the external source adapter contract is documented in `docs/external-adapter-contract.md`; env/file/exec source adapters are documented in `docs/env-file-exec-sources.md`; Vault/OpenBao source support is documented in `docs/vault-openbao-source.md`; AWS Secrets Manager source support is documented in `docs/aws-secrets-manager-source.md`. The headless admin CLI is documented in `docs/headless-admin-cli.md`; the first metadata-only MCP adapter is documented in `docs/mcp-adapter.md`. The initial generated secret write-back/capture policy is documented in `docs/writeback-policy.md`. The operational-control baseline for service-json policy assignment, audit, telemetry, events/filtering, and lockout is documented in `docs/operational-controls-baseline.md`. Advanced capability classification for MCP, Secrets Sync, HSM, FIPS, MFA, and automated credential rotation is documented in `docs/advanced-capabilities-roadmap.md`; the focused enterprise security readiness assessment is documented in `docs/enterprise-security-readiness.md`; the focused Secrets Sync design and GitHub Actions first-target plan is documented in `docs/secrets-sync-design.md`. The OpenClaw SecretRef exec resolver is documented in `docs/openclaw-secretref-resolver.md`. OS wrapper enrollment and durable policy storage are intentionally future issues. The initial local API/bootstrap contract is documented in `docs/local-api-bootstrap-contract.md`; lifecycle/source-auth state behavior is documented in `docs/lifecycle-states.md`. Cross-language Node/Go compatibility expectations and reusable fixture format are documented in `docs/parity-contract.md`, with baseline fixtures under `conformance/fixtures/`.
+The OS-authenticated local IPC transport foundation is documented in `docs/os-authenticated-ipc-transport.md`.
 
 ## Local development
 
@@ -94,6 +95,16 @@ $env:SECRETSBROKER_MASTER_KEY = "local-dev-key"
 $env:SECRETSBROKER_API_TOKEN = "local-api-token"
 go run .\cmd\secretsbroker serve --listen 127.0.0.1:17890
 ```
+
+Production-mode startup must use an OS IPC transport instead of loopback HTTP:
+
+```powershell
+$env:SECRETSBROKER_MODE = "production"
+$env:SECRETSBROKER_TRANSPORT = "auto"
+go run .\cmd\secretsbroker serve
+```
+
+On Windows this currently fails closed until named-pipe client identity checks are implemented. On Unix-like platforms, `auto` serves over a Unix socket.
 
 Check status:
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -294,9 +293,12 @@ func defaultCapabilities() CapabilitiesResponse {
 			"threshold-recovery-shares",
 			"headless-admin-cli",
 			"metadata-only-mcp-adapter",
+			"os-ipc-transport-policy",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",
+			"windows-named-pipe-listener",
+			"unix-socket-peer-credential-checks",
 		},
 		Outcomes: append([]string(nil), typedOutcomes...),
 	}
@@ -316,6 +318,10 @@ func printStatus(args []string) error {
 func serve(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	listen := fs.String("listen", getenvDefault("SECRETSBROKER_LISTEN", "127.0.0.1:17890"), "listen address")
+	mode := fs.String("mode", getenvDefault("SECRETSBROKER_MODE", "development"), "runtime mode: development or production")
+	transport := fs.String("transport", getenvDefault("SECRETSBROKER_TRANSPORT", "loopback-http"), "serve transport: loopback-http, unix-socket, windows-named-pipe, or auto")
+	unixSocket := fs.String("unix-socket", getenvDefault("SECRETSBROKER_UNIX_SOCKET", ""), "Unix socket path for unix-socket transport")
+	namedPipe := fs.String("named-pipe", getenvDefault("SECRETSBROKER_NAMED_PIPE", ""), "Windows named pipe path for windows-named-pipe transport")
 	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
 	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
 	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
@@ -361,14 +367,25 @@ func serve(args []string) error {
 	}
 	backend.sources = sources
 
-	ln, err := net.Listen("tcp", *listen)
+	binding, err := resolveServeTransport(serveTransportOptions{
+		Mode:       *mode,
+		Transport:  *transport,
+		Listen:     *listen,
+		UnixSocket: *unixSocket,
+		NamedPipe:  *namedPipe,
+	})
 	if err != nil {
 		return err
 	}
+	ln, cleanup, err := listenForTransport(binding)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	server := &http.Server{Handler: newHandler(stateView, backend, localAPISecurity{token: *apiToken}), ReadHeaderTimeout: 5 * time.Second}
 	go func() {
-		slog.Info("@secretsbroker listening", "addr", ln.Addr().String(), "state", *state)
+		slog.Info("@secretsbroker listening", "transport", binding.Kind, "addr", binding.DisplayAddress, "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server failed", "error", err)
 		}

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -40,8 +40,54 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	assertContains(t, caps.Endpoints, "GET /ready")
 	assertContains(t, caps.Features, "readiness")
 	assertContains(t, caps.Features, "batched-resolve")
+	assertContains(t, caps.Features, "os-ipc-transport-policy")
+	assertContains(t, caps.FutureFeatures, "windows-named-pipe-listener")
 	assertContains(t, caps.Outcomes, "source_auth_required")
 	assertContains(t, caps.Outcomes, "policy_denied")
+}
+
+func TestServeTransportDefaultsToLoopbackHTTP(t *testing.T) {
+	binding, err := resolveServeTransport(serveTransportOptions{Listen: "127.0.0.1:17890"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Kind != "loopback-http" || binding.Network != "tcp" || binding.Address != "127.0.0.1:17890" {
+		t.Fatalf("binding = %#v", binding)
+	}
+}
+
+func TestServeTransportRejectsNonLoopbackHTTP(t *testing.T) {
+	_, err := resolveServeTransport(serveTransportOptions{Transport: "loopback-http", Listen: "0.0.0.0:17890"})
+	if err == nil {
+		t.Fatalf("expected non-loopback listen rejection")
+	}
+}
+
+func TestProductionModeRejectsLoopbackHTTP(t *testing.T) {
+	_, err := resolveServeTransport(serveTransportOptions{Mode: "production", Transport: "loopback-http", Listen: "127.0.0.1:17890"})
+	if err == nil {
+		t.Fatalf("expected production loopback rejection")
+	}
+}
+
+func TestProductionAutoSelectsOSTransport(t *testing.T) {
+	binding, err := resolveServeTransport(serveTransportOptions{Mode: "production", Transport: "auto"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Kind != "windows-named-pipe" && binding.Kind != "unix-socket" {
+		t.Fatalf("production auto binding = %#v", binding)
+	}
+	if binding.Address == "" {
+		t.Fatalf("production auto address should be populated")
+	}
+}
+
+func TestWindowsNamedPipeRequiresPipeNamespace(t *testing.T) {
+	_, err := resolveServeTransport(serveTransportOptions{Transport: "windows-named-pipe", NamedPipe: `C:\tmp\not-a-pipe`})
+	if err == nil {
+		t.Fatalf("expected named pipe namespace rejection")
+	}
 }
 
 func TestReadyEndpointDistinguishesLivenessFromReadiness(t *testing.T) {

--- a/cmd/secretsbroker/transport.go
+++ b/cmd/secretsbroker/transport.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type serveTransportOptions struct {
+	Mode       string
+	Transport  string
+	Listen     string
+	UnixSocket string
+	NamedPipe  string
+}
+
+type serveTransportBinding struct {
+	Kind           string
+	Network        string
+	Address        string
+	DisplayAddress string
+}
+
+func resolveServeTransport(opts serveTransportOptions) (serveTransportBinding, error) {
+	mode := normalizeServeMode(opts.Mode)
+	kind := normalizeTransportKind(opts.Transport, mode)
+	switch kind {
+	case "loopback-http":
+		listen := strings.TrimSpace(opts.Listen)
+		if listen == "" {
+			listen = "127.0.0.1:17890"
+		}
+		if err := validateLoopbackListen(listen); err != nil {
+			return serveTransportBinding{}, err
+		}
+		if mode == "production" {
+			return serveTransportBinding{}, errors.New("production mode requires unix-socket or windows-named-pipe transport; loopback-http is development/bootstrap only")
+		}
+		return serveTransportBinding{Kind: kind, Network: "tcp", Address: listen, DisplayAddress: listen}, nil
+	case "unix-socket":
+		path := strings.TrimSpace(opts.UnixSocket)
+		if path == "" {
+			path = defaultUnixSocketPath()
+		}
+		return serveTransportBinding{Kind: kind, Network: "unix", Address: filepath.Clean(path), DisplayAddress: filepath.Clean(path)}, nil
+	case "windows-named-pipe":
+		path := strings.TrimSpace(opts.NamedPipe)
+		if path == "" {
+			path = defaultNamedPipePath()
+		}
+		if !strings.HasPrefix(strings.ToLower(path), `\\.\pipe\`) {
+			return serveTransportBinding{}, fmt.Errorf("windows named pipe path must start with \\\\.\\pipe\\")
+		}
+		return serveTransportBinding{Kind: kind, Network: "windows-named-pipe", Address: path, DisplayAddress: path}, nil
+	default:
+		return serveTransportBinding{}, fmt.Errorf("unsupported serve transport %q", opts.Transport)
+	}
+}
+
+func normalizeServeMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "dev", "development", "bootstrap", "local":
+		return "development"
+	case "prod", "production":
+		return "production"
+	default:
+		return "development"
+	}
+}
+
+func normalizeTransportKind(kind, mode string) string {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	if kind == "" || kind == "auto" {
+		if normalizeServeMode(mode) == "production" {
+			if runtime.GOOS == "windows" {
+				return "windows-named-pipe"
+			}
+			return "unix-socket"
+		}
+		return "loopback-http"
+	}
+	return kind
+}
+
+func validateLoopbackListen(listen string) error {
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("loopback-http listen address must include host and port: %w", err)
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("loopback-http listen address must bind to 127.0.0.1, ::1, or localhost; got %q", host)
+	}
+	return nil
+}
+
+func defaultUnixSocketPath() string {
+	return filepath.Join(os.TempDir(), "service-lasso-secretsbroker.sock")
+}
+
+func defaultNamedPipePath() string {
+	return `\\.\pipe\service-lasso-secretsbroker`
+}

--- a/cmd/secretsbroker/transport_errors.go
+++ b/cmd/secretsbroker/transport_errors.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func errUnsupportedTransport(kind string) error {
+	return fmt.Errorf("unsupported serve transport %q", kind)
+}
+
+func errUnixSocketUnsupported() error {
+	return fmt.Errorf("unix-socket transport is only available on Unix-like platforms")
+}
+
+func errWindowsNamedPipeUnsupported() error {
+	return fmt.Errorf("windows-named-pipe transport is only available on Windows")
+}
+
+func errWindowsNamedPipeRequiresIdentityChecks() error {
+	return fmt.Errorf("windows-named-pipe transport is configured but not yet enabled; listener must enforce local client identity checks before serving secret-bearing APIs")
+}

--- a/cmd/secretsbroker/transport_listen_unix.go
+++ b/cmd/secretsbroker/transport_listen_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+)
+
+func listenForTransport(binding serveTransportBinding) (net.Listener, func(), error) {
+	switch binding.Kind {
+	case "loopback-http":
+		ln, err := net.Listen(binding.Network, binding.Address)
+		return ln, func() {}, err
+	case "unix-socket":
+		_ = os.Remove(binding.Address)
+		ln, err := net.Listen("unix", binding.Address)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		_ = os.Chmod(binding.Address, 0o600)
+		return ln, func() { _ = os.Remove(binding.Address) }, nil
+	case "windows-named-pipe":
+		return nil, func() {}, errWindowsNamedPipeUnsupported()
+	default:
+		return nil, func() {}, errUnsupportedTransport(binding.Kind)
+	}
+}

--- a/cmd/secretsbroker/transport_listen_windows.go
+++ b/cmd/secretsbroker/transport_listen_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import "net"
+
+func listenForTransport(binding serveTransportBinding) (net.Listener, func(), error) {
+	switch binding.Kind {
+	case "loopback-http":
+		ln, err := net.Listen(binding.Network, binding.Address)
+		return ln, func() {}, err
+	case "unix-socket":
+		return nil, func() {}, errUnixSocketUnsupported()
+	case "windows-named-pipe":
+		return nil, func() {}, errWindowsNamedPipeRequiresIdentityChecks()
+	default:
+		return nil, func() {}, errUnsupportedTransport(binding.Kind)
+	}
+}

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -31,7 +31,7 @@ Development/bootstrap compatibility transport:
 
 - loopback HTTP bound to `127.0.0.1`
 
-The initial daemon exposes loopback HTTP. Named pipe/Unix socket transports should preserve the same request/response schema.
+The daemon exposes loopback HTTP for development/bootstrap and now has explicit transport selection for production mode. Production mode rejects loopback HTTP and selects the OS IPC transport with `--transport auto`; Unix-like platforms can serve over a Unix socket, while Windows named-pipe serving remains fail-closed until local client identity checks are implemented. Named pipe/Unix socket transports preserve the same request/response schema. See `docs/os-authenticated-ipc-transport.md`.
 
 ## Cross-cutting response rules
 

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -229,6 +229,8 @@ Preferred transports:
 - Unix socket with filesystem permissions and peer credential checks where available
 - loopback HTTP only for development/bootstrap compatibility
 
+The first #31 foundation is now implemented as an explicit transport policy. `secretsbroker serve` accepts `--mode`, `--transport`, `--unix-socket`, and `--named-pipe`; production mode rejects loopback HTTP rather than falling back silently. See `docs/os-authenticated-ipc-transport.md` for the current supported behavior and remaining named-pipe/peer-credential work.
+
 Planned session model:
 
 - short-lived scoped sessions/tokens

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -1,0 +1,71 @@
+# OS-Authenticated IPC Transport
+
+Status: foundation slice  
+Issue: #31
+
+## Purpose
+
+Loopback HTTP remains useful for development and bootstrap, but production secret-bearing traffic should move to an OS-authenticated local IPC boundary:
+
+- Windows named pipe with local client identity checks.
+- Unix socket with owner-only filesystem permissions and peer credential checks where available.
+- Loopback HTTP bound to `127.0.0.1`, `::1`, or `localhost` only for development/bootstrap compatibility.
+
+## Current implementation
+
+The daemon now has explicit transport selection:
+
+```powershell
+secretsbroker serve --transport loopback-http --listen 127.0.0.1:17890
+secretsbroker serve --mode production --transport auto
+secretsbroker serve --transport unix-socket --unix-socket /tmp/service-lasso-secretsbroker.sock
+secretsbroker serve --transport windows-named-pipe --named-pipe \\.\pipe\service-lasso-secretsbroker
+```
+
+Equivalent environment variables:
+
+```text
+SECRETSBROKER_MODE=development|production
+SECRETSBROKER_TRANSPORT=auto|loopback-http|unix-socket|windows-named-pipe
+SECRETSBROKER_LISTEN=127.0.0.1:17890
+SECRETSBROKER_UNIX_SOCKET=/tmp/service-lasso-secretsbroker.sock
+SECRETSBROKER_NAMED_PIPE=\\.\pipe\service-lasso-secretsbroker
+```
+
+Implemented behavior:
+
+- `loopback-http` rejects non-loopback bind addresses.
+- `production` mode rejects `loopback-http`.
+- `auto` chooses `loopback-http` in development mode.
+- `auto` chooses the platform IPC transport in production mode: Windows named pipe on Windows, Unix socket elsewhere.
+- Unix-like platforms can serve HTTP over a Unix socket and set the socket path to owner-only mode.
+- Windows named-pipe configuration is parsed and validated, but serving fails closed until the listener enforces local client identity checks.
+
+## Production gate
+
+The broker must not silently fall back to loopback HTTP in production mode. If the requested IPC listener cannot enforce the required local identity boundary, startup fails before serving secret-bearing APIs.
+
+## Windows named-pipe requirements
+
+Before enabling the Windows named-pipe listener:
+
+- The pipe path must be under `\\.\pipe\`.
+- The pipe security descriptor must limit access to the current user, local administrators, and LocalSystem as appropriate for the Service Lasso launcher model.
+- The listener must identify the connected local client process or user token before accepting secret-bearing requests.
+- Identity metadata must be safe: no access tokens, environment values, command lines, or raw credentials in responses, logs, or audit events.
+- Tests must cover unauthorized client rejection and safe error output.
+
+## Unix socket requirements
+
+Current Unix socket support is a first serving path. Closure-grade production work still needs peer credential checks where the platform exposes them. Until then, the socket path is owner-only and production startup uses the Unix socket instead of loopback HTTP, but validation must not claim full peer identity enforcement.
+
+## Compatibility
+
+Existing bootstrap clients can keep using:
+
+```powershell
+secretsbroker serve --listen 127.0.0.1:17890
+```
+
+Secret-bearing HTTP endpoints still require the local API token and existing launch identity checks. The IPC work changes the process boundary; it does not remove endpoint authentication or policy checks.
+

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -1,6 +1,6 @@
 # OS-Authenticated IPC Transport
 
-Status: foundation slice  
+Status: foundation slice
 Issue: #31
 
 ## Purpose
@@ -68,4 +68,3 @@ secretsbroker serve --listen 127.0.0.1:17890
 ```
 
 Secret-bearing HTTP endpoints still require the local API token and existing launch identity checks. The IPC work changes the process boundary; it does not remove endpoint authentication or policy checks.
-


### PR DESCRIPTION
## Issue
Refs #31

## Summary
- Add explicit `secretsbroker serve` transport selection for `loopback-http`, `unix-socket`, `windows-named-pipe`, and production `auto`.
- Fail closed when production mode attempts to use loopback HTTP, and when Windows named-pipe serving is configured before local client identity checks are implemented.
- Add a Unix socket listener path for Unix-like platforms and document remaining peer credential work.

## Scope
- In scope: transport config/policy foundation, loopback bind validation, production-mode gating, Unix socket listener support, docs/tests.
- Out of scope: full Windows named-pipe listener and client identity checks; this PR intentionally exposes that as a fail-closed follow-up rather than serving unsafe secret-bearing APIs.

## Spec / contract / fixture impact
- Updated: `docs/os-authenticated-ipc-transport.md`, `docs/local-api-security.md`, `docs/local-api-bootstrap-contract.md`, `README.md`.
- Not changed: API version and endpoint request/response schemas.

## Service Lasso invariant impact
- Invariant: secret-bearing APIs must not fall open or expose raw secret material.
- Preservation proof: production loopback is rejected before serving, Windows named-pipe mode fails closed until identity checks are implemented, and existing endpoint auth remains unchanged.

## Validation
- PASS `go test ./cmd/secretsbroker` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-ipc-transport/go-test-cmd-secretsbroker-2.log`
- PASS `go test ./...` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-ipc-transport/go-test-all.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-ipc-transport/scripts-test-ps1.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-ipc-transport/go-build-commands.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-ipc-transport/git-diff-check.log`
- PASS/fail-closed smoke `go run .\cmd\secretsbroker serve --mode production --transport loopback-http --listen 127.0.0.1:17890` exited non-zero with the expected production loopback rejection — `production-loopback-fails-closed.log`
- PASS/fail-closed smoke `go run .\cmd\secretsbroker serve --mode production --transport auto` on Windows exited non-zero with the expected named-pipe identity-check gate — `production-auto-fails-closed-windows.log`

## Approval trail
- Required: normal PR review/merge authorization.
- Evidence: selected from Project #1 issue #31 after preflight and open PR gate documentation.

## Cleanup
- Branch cleanup after merge. Release-to-demo gate applies after merge/release because this changes a demo-consumed service package; publish/pin/recycle/verify before claiming #31 done or demo-current.
