### PR TITLE
feat: enforce Unix socket peer credentials

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -294,11 +294,11 @@ func defaultCapabilities() CapabilitiesResponse {
 			"headless-admin-cli",
 			"metadata-only-mcp-adapter",
 			"os-ipc-transport-policy",
+			"unix-socket-peer-credential-checks",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",
 			"windows-named-pipe-listener",
-			"unix-socket-peer-credential-checks",
 		},
 		Outcomes: append([]string(nil), typedOutcomes...),
 	}

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -41,9 +41,21 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	assertContains(t, caps.Features, "readiness")
 	assertContains(t, caps.Features, "batched-resolve")
 	assertContains(t, caps.Features, "os-ipc-transport-policy")
+	assertContains(t, caps.Features, "unix-socket-peer-credential-checks")
 	assertContains(t, caps.FutureFeatures, "windows-named-pipe-listener")
 	assertContains(t, caps.Outcomes, "source_auth_required")
 	assertContains(t, caps.Outcomes, "policy_denied")
+}
+
+func TestUnixPeerUIDAuthorizationRequiresSameUID(t *testing.T) {
+	if !unixPeerUIDAuthorized(501, 501) {
+		t.Fatalf("same uid should be authorized")
+	}
+	for _, uid := range []int{-1, 0, 502} {
+		if unixPeerUIDAuthorized(uid, 501) {
+			t.Fatalf("peer uid %d should not be authorized for allowed uid 501", uid)
+		}
+	}
 }
 
 func TestServeTransportDefaultsToLoopbackHTTP(t *testing.T) {

--- a/cmd/secretsbroker/transport_auth_unix.go
+++ b/cmd/secretsbroker/transport_auth_unix.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+type unixPeerCredentialListener struct {
+	net.Listener
+	allowedUID int
+}
+
+func authenticatedUnixSocketListener(ln net.Listener) (net.Listener, error) {
+	if _, ok := ln.(*net.UnixListener); !ok {
+		return nil, fmt.Errorf("unix-socket transport listener is %T, want *net.UnixListener", ln)
+	}
+	if !unixPeerCredentialChecksAvailable() {
+		return nil, errUnixSocketRequiresPeerCredentials()
+	}
+	return &unixPeerCredentialListener{Listener: ln, allowedUID: os.Getuid()}, nil
+}
+
+func (l *unixPeerCredentialListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		if err := authorizeUnixPeerConn(conn, l.allowedUID); err != nil {
+			_ = conn.Close()
+			continue
+		}
+		return conn, nil
+	}
+}
+
+func authorizeUnixPeerConn(conn net.Conn, allowedUID int) error {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("unix-socket transport connection is %T, want *net.UnixConn", conn)
+	}
+	uid, _, _, err := unixPeerCredentials(unixConn)
+	if err != nil {
+		return err
+	}
+	if !unixPeerUIDAuthorized(uid, allowedUID) {
+		return fmt.Errorf("unix-socket transport rejected local peer uid %d", uid)
+	}
+	return nil
+}

--- a/cmd/secretsbroker/transport_auth_unix_test.go
+++ b/cmd/secretsbroker/transport_auth_unix_test.go
@@ -6,12 +6,15 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
 
 func TestUnixSocketListenerAcceptsSameUIDPeer(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "secretsbroker.sock")
+	path := filepath.Join(os.TempDir(), "sb-"+strconv.Itoa(os.Getpid())+".sock")
+	_ = os.Remove(path)
+	t.Cleanup(func() { _ = os.Remove(path) })
 	ln, cleanup, err := listenForTransport(serveTransportBinding{Kind: "unix-socket", Address: path})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/secretsbroker/transport_auth_unix_test.go
+++ b/cmd/secretsbroker/transport_auth_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUnixSocketListenerAcceptsSameUIDPeer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secretsbroker.sock")
+	ln, cleanup, err := listenForTransport(serveTransportBinding{Kind: "unix-socket", Address: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	defer ln.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %o, want 0600", got)
+	}
+
+	accepted := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			accepted <- err
+			return
+		}
+		_ = conn.Close()
+		accepted <- nil
+	}()
+
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+
+	select {
+	case err := <-accepted:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for same-UID unix socket peer")
+	}
+}

--- a/cmd/secretsbroker/transport_errors.go
+++ b/cmd/secretsbroker/transport_errors.go
@@ -10,6 +10,10 @@ func errUnixSocketUnsupported() error {
 	return fmt.Errorf("unix-socket transport is only available on Unix-like platforms")
 }
 
+func errUnixSocketRequiresPeerCredentials() error {
+	return fmt.Errorf("unix-socket transport requires OS peer credential checks before serving secret-bearing APIs")
+}
+
 func errWindowsNamedPipeUnsupported() error {
 	return fmt.Errorf("windows-named-pipe transport is only available on Windows")
 }

--- a/cmd/secretsbroker/transport_listen_unix.go
+++ b/cmd/secretsbroker/transport_listen_unix.go
@@ -18,6 +18,13 @@ func listenForTransport(binding serveTransportBinding) (net.Listener, func(), er
 		if err != nil {
 			return nil, func() {}, err
 		}
+		rawLn := ln
+		ln, err = authenticatedUnixSocketListener(rawLn)
+		if err != nil {
+			_ = rawLn.Close()
+			_ = os.Remove(binding.Address)
+			return nil, func() {}, err
+		}
 		_ = os.Chmod(binding.Address, 0o600)
 		return ln, func() { _ = os.Remove(binding.Address) }, nil
 	case "windows-named-pipe":

--- a/cmd/secretsbroker/transport_peercred.go
+++ b/cmd/secretsbroker/transport_peercred.go
@@ -1,0 +1,5 @@
+package main
+
+func unixPeerUIDAuthorized(peerUID, allowedUID int) bool {
+	return peerUID >= 0 && peerUID == allowedUID
+}

--- a/cmd/secretsbroker/transport_peercred_bsd.go
+++ b/cmd/secretsbroker/transport_peercred_bsd.go
@@ -1,0 +1,35 @@
+//go:build darwin || freebsd
+
+package main
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func unixPeerCredentialChecksAvailable() bool {
+	return true
+}
+
+func unixPeerCredentials(conn *net.UnixConn) (uid int, gid int, pid int, err error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	var cred *unix.Xucred
+	var controlErr error
+	if err := raw.Control(func(fd uintptr) {
+		cred, controlErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	}); err != nil {
+		return -1, -1, -1, err
+	}
+	if controlErr != nil {
+		return -1, -1, -1, controlErr
+	}
+	gid = -1
+	if cred.Ngroups > 0 {
+		gid = int(cred.Groups[0])
+	}
+	return int(cred.Uid), gid, -1, nil
+}

--- a/cmd/secretsbroker/transport_peercred_linux.go
+++ b/cmd/secretsbroker/transport_peercred_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package main
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func unixPeerCredentialChecksAvailable() bool {
+	return true
+}
+
+func unixPeerCredentials(conn *net.UnixConn) (uid int, gid int, pid int, err error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	var cred *unix.Ucred
+	var controlErr error
+	if err := raw.Control(func(fd uintptr) {
+		cred, controlErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return -1, -1, -1, err
+	}
+	if controlErr != nil {
+		return -1, -1, -1, controlErr
+	}
+	return int(cred.Uid), int(cred.Gid), int(cred.Pid), nil
+}

--- a/cmd/secretsbroker/transport_peercred_unsupported_unix.go
+++ b/cmd/secretsbroker/transport_peercred_unsupported_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows && !linux && !darwin && !freebsd
+
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func unixPeerCredentialChecksAvailable() bool {
+	return false
+}
+
+func unixPeerCredentials(conn *net.UnixConn) (uid int, gid int, pid int, err error) {
+	return -1, -1, -1, fmt.Errorf("unix peer credential checks are not implemented for this platform")
+}

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -38,7 +38,7 @@ Implemented behavior:
 - `production` mode rejects `loopback-http`.
 - `auto` chooses `loopback-http` in development mode.
 - `auto` chooses the platform IPC transport in production mode: Windows named pipe on Windows, Unix socket elsewhere.
-- Unix-like platforms can serve HTTP over a Unix socket and set the socket path to owner-only mode.
+- Unix-like platforms can serve HTTP over a Unix socket, set the socket path to owner-only mode, and check OS peer credentials before passing a connection to the HTTP server. Linux uses `SO_PEERCRED`; macOS/FreeBSD use `LOCAL_PEERCRED`.
 - Windows named-pipe configuration is parsed and validated, but serving fails closed until the listener enforces local client identity checks.
 
 ## Production gate
@@ -57,7 +57,12 @@ Before enabling the Windows named-pipe listener:
 
 ## Unix socket requirements
 
-Current Unix socket support is a first serving path. Closure-grade production work still needs peer credential checks where the platform exposes them. Until then, the socket path is owner-only and production startup uses the Unix socket instead of loopback HTTP, but validation must not claim full peer identity enforcement.
+Current Unix socket support enforces same-UID peer credentials on platforms where Go exposes the required OS APIs:
+
+- Linux: `SO_PEERCRED`.
+- macOS and FreeBSD: `LOCAL_PEERCRED`.
+
+Unsupported Unix-like platforms fail closed before serving secret-bearing APIs until an equivalent peer-credential check is implemented. The socket path remains owner-only, and endpoint token/session/launch-identity checks still apply on top of the IPC boundary.
 
 ## Compatibility
 

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/service-lasso/lasso-secretsbroker
 
 go 1.24.0
 
-require filippo.io/age v1.3.1
+require (
+	filippo.io/age v1.3.1
+	golang.org/x/sys v0.38.0
+)
 
 require (
 	filippo.io/hpke v0.4.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 )


### PR DESCRIPTION
## Issue
Closes part of #31

## Summary
- Enforce same-UID OS peer credential checks before Unix-socket connections reach the Secrets Broker HTTP server.
- Add Linux `SO_PEERCRED` and macOS/FreeBSD `LOCAL_PEERCRED` credential lookup implementations.
- Fail closed on unsupported Unix platforms and keep Windows named-pipe serving gated until identity checks exist.
- Update IPC transport docs and capabilities to reflect Unix peer-credential support.

## Scope
- In scope: Unix socket peer credential enforcement, platform credential lookup, fail-closed unsupported Unix behavior, tests/docs.
- Out of scope: Windows named-pipe listener implementation, cross-user authorization policy beyond same UID, release/demo pinning until after merge.

## Spec / contract / fixture impact
- Updated: `docs/os-authenticated-ipc-transport.md` to document Linux/macOS/FreeBSD peer credential behavior and unsupported Unix fail-closed behavior.
- Updated capabilities: moved `unix-socket-peer-credential-checks` from future to current features.

## Service Lasso invariant impact
- Invariant: secret-bearing broker APIs must not move to a weaker production boundary.
- Preservation proof: production loopback remains rejected; Windows named-pipe still fails closed; Unix socket now validates OS peer credentials before serving requests and keeps endpoint token/session/launch-identity checks layered above IPC.

## Validation
- PASS `go test ./cmd/secretsbroker` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-31-ipc-transport-next\go-test-cmd-secretsbroker-2.log`
- PASS `go test ./...` — `...\go-test-all-2.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `...\go-build-commands-2.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `...\scripts-test-ps1-2.log`
- PASS `git diff --check` — `...\git-diff-check-2.log`
- PASS Linux test-binary compile `GOOS=linux GOARCH=amd64 go test -c ./cmd/secretsbroker` — `...\go-test-compile-linux-amd64-2.log`
- PASS macOS test-binary compile `GOOS=darwin GOARCH=amd64 go test -c ./cmd/secretsbroker` — `...\go-test-compile-darwin-amd64-2.log`
- PASS/fail-closed smoke `go run ./cmd/secretsbroker serve --mode production --transport auto` on Windows exits non-zero at named-pipe identity gate — `...\production-auto-fails-closed-windows-2.log`
- PASS canonical preflight before branch: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: normal maintainer/review policy before merge.
- Evidence: PR checks/review to be evaluated by GitHub before merge.

## Cleanup
- Branch: `agent/issue-31-ipc-peer-credentials`
- Post-merge gate: publish/release `lasso-secretsbroker`, update the core `@secretsbroker` pin to the exact release/commit, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected vs installed/live tag before claiming #31 demo-current for this slice.