### PR TITLE
feat: add Secrets Broker OTel telemetry preview

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -250,7 +250,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"CLI secretsbroker admin mcp tools|call",
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate|recovery generate|recovery import",
-			"CLI secretsbroker admin status|secrets|providers|migration|sync|recovery|audit|events",
+			"CLI secretsbroker admin status|secrets|providers|migration|sync|recovery|audit|telemetry|events",
 		},
 		Features: []string{
 			"liveness",
@@ -266,6 +266,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"provider-config-status",
 			"provider-config-validation",
 			"redacted-telemetry",
+			"otel-telemetry-preview",
 			"bounded-operational-events",
 			"scoped-local-api-lockout",
 			"audited-lockout-clear",

--- a/cmd/secretsbroker/telemetry.go
+++ b/cmd/secretsbroker/telemetry.go
@@ -1,20 +1,76 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"regexp"
 	"sort"
+	"strings"
 	"time"
 )
 
+const secretsBrokerTelemetryContractVersion = "service-lasso.secretsbroker.telemetry-preview.v1"
+
 type telemetryResponse struct {
+	ContractVersion    string                       `json:"contractVersion"`
 	ServiceID          string                       `json:"serviceId"`
 	APIVersion         string                       `json:"apiVersion"`
 	Outcome            string                       `json:"outcome"`
 	GeneratedAt        time.Time                    `json:"generatedAt"`
+	Exporter           telemetryExporterPreview     `json:"exporter"`
+	Resource           telemetryResourcePreview     `json:"resource"`
+	Redaction          telemetryAttributePolicy     `json:"redaction"`
+	ExportPreview      telemetryExportPreview       `json:"exportPreview"`
 	Counters           telemetryCounters            `json:"counters"`
 	DurationHistograms []telemetryDurationHistogram `json:"durationHistograms"`
+	Signals            []telemetrySignalPreview     `json:"signals"`
 	Safety             telemetrySafety              `json:"safety"`
+}
+
+type telemetryExporterPreview struct {
+	Status                string `json:"status"`
+	Protocol              string `json:"protocol"`
+	EndpointConfigured    bool   `json:"endpointConfigured"`
+	EndpointValueReturned bool   `json:"endpointValueReturned"`
+	HeadersValueReturned  bool   `json:"headersValueReturned"`
+	HeadersConfigured     bool   `json:"headersConfigured"`
+	BodyValueReturned     bool   `json:"bodyValueReturned"`
+	Reason                string `json:"reason"`
+}
+
+type telemetryResourcePreview struct {
+	ServiceName       string `json:"serviceName"`
+	ServiceNamespace  string `json:"serviceNamespace"`
+	ServiceInstanceID string `json:"serviceInstanceId"`
+}
+
+type telemetryAttributePolicy struct {
+	Mode                  string   `json:"mode"`
+	RedactedValue         string   `json:"redactedValue"`
+	AllowedAttributes     []string `json:"allowedAttributes"`
+	ForbiddenFieldClasses []string `json:"forbiddenFieldClasses"`
+	PatternClasses        []string `json:"patternClasses"`
+	OmittedFieldExamples  []string `json:"omittedFieldExamples"`
+}
+
+type telemetryExportPreview struct {
+	Mode                  string   `json:"mode"`
+	Status                string   `json:"status"`
+	Protocol              string   `json:"protocol"`
+	ContentType           string   `json:"contentType"`
+	SignalCount           int      `json:"signalCount"`
+	EndpointConfigured    bool     `json:"endpointConfigured"`
+	EndpointValueReturned bool     `json:"endpointValueReturned"`
+	HeadersValueReturned  bool     `json:"headersValueReturned"`
+	BodyValueReturned     bool     `json:"bodyValueReturned"`
+	AllowedAttributeCount int      `json:"allowedAttributeCount"`
+	DroppedFieldClasses   []string `json:"droppedFieldClasses"`
+	SafeEnvelopeFields    []string `json:"safeEnvelopeFields"`
+	Reason                string   `json:"reason"`
 }
 
 type telemetryCounters struct {
@@ -57,6 +113,15 @@ type telemetryDurationHistogram struct {
 	Buckets   map[string]int `json:"buckets"`
 }
 
+type telemetrySignalPreview struct {
+	Kind          string         `json:"kind"`
+	Name          string         `json:"name"`
+	TraceID       string         `json:"traceId"`
+	SpanID        string         `json:"spanId"`
+	CorrelationID string         `json:"correlationId"`
+	Attributes    map[string]any `json:"attributes"`
+}
+
 type telemetrySafety struct {
 	LowCardinalityLabels  bool `json:"lowCardinalityLabels"`
 	ValueMaterialIncluded bool `json:"valueMaterialIncluded"`
@@ -64,13 +129,18 @@ type telemetrySafety struct {
 
 func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
 	res := telemetryResponse{
+		ContractVersion:    secretsBrokerTelemetryContractVersion,
 		ServiceID:          serviceID,
 		APIVersion:         apiVersion,
 		Outcome:            "ready",
 		GeneratedAt:        time.Now().UTC(),
+		Exporter:           telemetryExporterStatusFromEnv(),
+		Resource:           telemetryResourcePreview{ServiceName: "secretsbroker", ServiceNamespace: "service-lasso", ServiceInstanceID: "local-broker"},
+		Redaction:          secretsBrokerTelemetryAttributePolicy(),
 		DurationHistograms: []telemetryDurationHistogram{},
 		Safety:             telemetrySafety{LowCardinalityLabels: true, ValueMaterialIncluded: false},
 	}
+	res.ExportPreview = telemetryExportPreviewFromEnv(res.Exporter, 0, res.Redaction)
 	if backend == nil {
 		res.Outcome = "degraded"
 		return res, errBackendDegraded
@@ -88,6 +158,8 @@ func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
 	res.Counters.AuditRecords = auditRecordCounters(audit.Events)
 	res.Counters.SourceStates = sourceStateCounters(defaultSourceRegistry(backend).Sources)
 	res.Counters.ProviderStates = providerStateCounters(backend.providerConfigStatusResponse().Providers)
+	res.Signals = buildTelemetrySignals(res.Counters)
+	res.ExportPreview = telemetryExportPreviewFromEnv(res.Exporter, len(res.Signals), res.Redaction)
 	return res, nil
 }
 
@@ -211,4 +283,222 @@ func stateCounterLess(a, b telemetryStateCounter) bool {
 		return a.State < b.State
 	}
 	return a.Outcome < b.Outcome
+}
+
+func secretsBrokerTelemetryAttributePolicy() telemetryAttributePolicy {
+	return telemetryAttributePolicy{
+		Mode:          "allowlist",
+		RedactedValue: "[REDACTED]",
+		AllowedAttributes: []string{
+			"broker.audit.status",
+			"broker.lockout.active_count",
+			"broker.operation",
+			"broker.operation.count",
+			"broker.operation.outcome",
+			"broker.policy.outcome",
+			"broker.provider.id",
+			"broker.provider.outcome",
+			"broker.provider.state",
+			"broker.source.id",
+			"broker.source.outcome",
+			"broker.source.state",
+			"service.api_version",
+			"service.id",
+			"service.namespace",
+			"service.version",
+		},
+		ForbiddenFieldClasses: []string{
+			"raw secret values",
+			"provider credentials and tokens",
+			"cookies and authorization headers",
+			"signing key material and recovery material",
+			"raw request or response bodies",
+			"environment values",
+			"provider response bodies",
+			"raw refs and raw config values",
+		},
+		PatternClasses: []string{
+			"bearer tokens",
+			"GitHub-style tokens",
+			"AWS access keys",
+			"signing-key blocks",
+			"basic-auth URLs",
+			"sensitive key-value pairs",
+			"Service Lasso secret regression sentinels",
+		},
+		OmittedFieldExamples: []string{
+			"value",
+			"credentialValue",
+			"authorization",
+			"cookie",
+			"requestBody",
+			"responseBody",
+			"providerResponse",
+			"env",
+			"ref",
+			"config",
+		},
+	}
+}
+
+func telemetryExporterStatusFromEnv() telemetryExporterPreview {
+	enabled := envBoolDefault("SECRETSBROKER_OTEL_ENABLED", false)
+	endpointConfigured := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")) != ""
+	headersConfigured := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")) != ""
+	status := "disabled"
+	reason := "OTLP export is disabled by default; set SECRETSBROKER_OTEL_ENABLED and OTEL_EXPORTER_OTLP_ENDPOINT to prepare a dry-run envelope."
+	if enabled && endpointConfigured {
+		status = "configured"
+		reason = "OTLP export is configured for preview only; /v1/telemetry does not send telemetry."
+	}
+	return telemetryExporterPreview{
+		Status:                status,
+		Protocol:              "otlp-http",
+		EndpointConfigured:    endpointConfigured,
+		EndpointValueReturned: false,
+		HeadersConfigured:     headersConfigured,
+		HeadersValueReturned:  false,
+		BodyValueReturned:     false,
+		Reason:                reason,
+	}
+}
+
+func telemetryExportPreviewFromEnv(exporter telemetryExporterPreview, signalCount int, policy telemetryAttributePolicy) telemetryExportPreview {
+	mode := "disabled"
+	reason := "The preview endpoint did not send telemetry."
+	if exporter.Status == "configured" && strings.EqualFold(strings.TrimSpace(os.Getenv("SECRETSBROKER_OTEL_EXPORT_MODE")), "dry-run") {
+		mode = "dry_run"
+		reason = "Dry-run OTLP export envelope is ready; the broker does not send telemetry from this preview API."
+	}
+	return telemetryExportPreview{
+		Mode:                  mode,
+		Status:                "not_sent",
+		Protocol:              "otlp-http",
+		ContentType:           "application/json",
+		SignalCount:           signalCount,
+		EndpointConfigured:    exporter.EndpointConfigured,
+		EndpointValueReturned: false,
+		HeadersValueReturned:  false,
+		BodyValueReturned:     false,
+		AllowedAttributeCount: len(policy.AllowedAttributes),
+		DroppedFieldClasses:   append([]string(nil), policy.ForbiddenFieldClasses...),
+		SafeEnvelopeFields:    []string{"resource", "signals.kind", "signals.name", "signals.traceId", "signals.spanId", "signals.correlationId", "signals.attributes"},
+		Reason:                reason,
+	}
+}
+
+func buildTelemetrySignals(counters telemetryCounters) []telemetrySignalPreview {
+	signals := []telemetrySignalPreview{
+		telemetrySignal("metric", "secretsbroker.lockout.active", map[string]any{
+			"broker.lockout.active_count": counters.ActiveLockouts,
+		}),
+	}
+	for _, counter := range counters.Operations {
+		signals = append(signals, telemetrySignal("metric", "secretsbroker.operation.count", map[string]any{
+			"broker.operation":         counter.Operation,
+			"broker.operation.outcome": counter.Outcome,
+			"broker.operation.count":   counter.Count,
+		}))
+	}
+	for _, counter := range counters.PolicyDecisions {
+		signals = append(signals, telemetrySignal("metric", "secretsbroker.policy.decision.count", map[string]any{
+			"broker.policy.outcome":  counter.Outcome,
+			"broker.operation.count": counter.Count,
+		}))
+	}
+	for _, counter := range counters.ProviderStates {
+		signals = append(signals, telemetrySignal("metric", "secretsbroker.provider.state", map[string]any{
+			"broker.provider.id":      counter.ID,
+			"broker.provider.state":   counter.State,
+			"broker.provider.outcome": counter.Outcome,
+			"broker.operation.count":  counter.Count,
+		}))
+	}
+	for _, counter := range counters.SourceStates {
+		signals = append(signals, telemetrySignal("metric", "secretsbroker.source.state", map[string]any{
+			"broker.source.id":       counter.ID,
+			"broker.source.state":    counter.State,
+			"broker.source.outcome":  counter.Outcome,
+			"broker.operation.count": counter.Count,
+		}))
+	}
+	for _, counter := range counters.AuditRecords {
+		signals = append(signals, telemetrySignal("metric", "secretsbroker.audit.record.count", map[string]any{
+			"broker.audit.status":      counter.AuditStatus,
+			"broker.operation.outcome": counter.Outcome,
+			"broker.operation.count":   counter.Count,
+		}))
+	}
+	return signals
+}
+
+func telemetrySignal(kind string, name string, attrs map[string]any) telemetrySignalPreview {
+	return telemetrySignalPreview{
+		Kind:          kind,
+		Name:          name,
+		TraceID:       telemetryHash("trace:"+name, 32),
+		SpanID:        telemetryHash("span:"+name, 16),
+		CorrelationID: "sl-" + telemetryHash("correlation:"+name, 16),
+		Attributes:    sanitizeTelemetryAttributes(attrs),
+	}
+}
+
+func telemetryHash(value string, length int) string {
+	sum := sha256.Sum256([]byte("service-lasso:secretsbroker:telemetry:" + value))
+	hexValue := hex.EncodeToString(sum[:])
+	if length > len(hexValue) {
+		return hexValue
+	}
+	return hexValue[:length]
+}
+
+func sanitizeTelemetryAttributes(attrs map[string]any) map[string]any {
+	policy := secretsBrokerTelemetryAttributePolicy()
+	allowed := map[string]bool{}
+	for _, key := range policy.AllowedAttributes {
+		allowed[key] = true
+	}
+	clean := map[string]any{}
+	for key, value := range attrs {
+		if !allowed[key] {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			clean[key] = redactTelemetryString(typed)
+		case int, int64, float64, bool:
+			clean[key] = typed
+		default:
+			clean[key] = redactTelemetryString(toTelemetryString(typed))
+		}
+	}
+	return clean
+}
+
+func toTelemetryString(value any) string {
+	if value == nil {
+		return ""
+	}
+	clean := strings.ToValidUTF8(fmt.Sprint(value), "")
+	clean = strings.ReplaceAll(clean, "\x00", "")
+	clean = strings.ReplaceAll(clean, "\n", " ")
+	clean = strings.ReplaceAll(clean, "\r", " ")
+	return strings.TrimSpace(clean)
+}
+
+func redactTelemetryString(value string) string {
+	redacted := strings.TrimSpace(value)
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9._~+/-]{12,}`),
+		regexp.MustCompile(`gh[pousr]_[A-Za-z0-9_]{20,}`),
+		regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+		regexp.MustCompile(`https?://[^\s/:]+:[^\s/@]{6,}@`),
+		regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----`),
+		regexp.MustCompile(`SERVICE_LASSO_FAKE_[A-Z0-9_]*(SECRET|TOKEN|PASSWORD|CREDENTIAL)[A-Z0-9_]*_DO_NOT_USE`),
+		regexp.MustCompile(`(?i)\b(api[_-]?key|auth|authorization|bearer|cookie|credential|env|password|private[_-]?key|secret|token)\b\s*[:=]\s*("[^"]+"|'[^']+'|[^\s,;]+)`),
+	}
+	for _, pattern := range patterns {
+		redacted = pattern.ReplaceAllString(redacted, "[REDACTED]")
+	}
+	return redacted
 }

--- a/cmd/secretsbroker/telemetry_test.go
+++ b/cmd/secretsbroker/telemetry_test.go
@@ -91,9 +91,82 @@ func TestTelemetryEndpointAndAdminCLIAreMetadataOnly(t *testing.T) {
 	}
 }
 
+func TestTelemetryOTelPreviewIsDryRunAndRedacted(t *testing.T) {
+	t.Setenv("SECRETSBROKER_OTEL_ENABLED", "1")
+	t.Setenv("SECRETSBROKER_OTEL_EXPORT_MODE", "dry-run")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.example.invalid/v1/traces?token=SERVICE_LASSO_FAKE_OTEL_TOKEN_DO_NOT_USE")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer ghp_fakeTelemetryHeaderToken1234567890")
+
+	backend := testBackend(t)
+	ref := "services/api/runtime/API_TOKEN"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: telemetrySecretValue}); err != nil {
+		t.Fatal(err)
+	}
+	_ = backend.audit("provider_validate", "providers/vault/token", "source_auth_required", "@operator", "req-provider")
+
+	res, err := buildTelemetryResponse(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(
+		t,
+		encoded,
+		telemetrySecretValue,
+		ref,
+		"providers/vault/token",
+		"SERVICE_LASSO_FAKE_OTEL_TOKEN_DO_NOT_USE",
+		"ghp_fakeTelemetryHeaderToken1234567890",
+	)
+	if res.ContractVersion != secretsBrokerTelemetryContractVersion {
+		t.Fatalf("contract version = %q", res.ContractVersion)
+	}
+	if res.Exporter.Status != "configured" || !res.Exporter.EndpointConfigured || !res.Exporter.HeadersConfigured {
+		t.Fatalf("exporter = %#v", res.Exporter)
+	}
+	if res.Exporter.EndpointValueReturned || res.Exporter.HeadersValueReturned || res.Exporter.BodyValueReturned {
+		t.Fatalf("exporter leaked returned values: %#v", res.Exporter)
+	}
+	if res.ExportPreview.Mode != "dry_run" || res.ExportPreview.Status != "not_sent" || res.ExportPreview.SignalCount != len(res.Signals) {
+		t.Fatalf("export preview = %#v signals=%d", res.ExportPreview, len(res.Signals))
+	}
+	if res.ExportPreview.EndpointValueReturned || res.ExportPreview.HeadersValueReturned || res.ExportPreview.BodyValueReturned {
+		t.Fatalf("export preview leaked returned values: %#v", res.ExportPreview)
+	}
+	if !hasSignal(res.Signals, "secretsbroker.operation.count") || !hasSignal(res.Signals, "secretsbroker.audit.record.count") {
+		t.Fatalf("missing OTel-shaped signals: %#v", res.Signals)
+	}
+	allowed := map[string]bool{}
+	for _, key := range res.Redaction.AllowedAttributes {
+		allowed[key] = true
+	}
+	for _, signal := range res.Signals {
+		if signal.TraceID == "" || signal.SpanID == "" || signal.CorrelationID == "" {
+			t.Fatalf("signal missing trace identifiers: %#v", signal)
+		}
+		for key := range signal.Attributes {
+			if !allowed[key] {
+				t.Fatalf("signal used non-allowlisted attribute %q in %#v", key, signal)
+			}
+		}
+	}
+}
+
 func hasOperationCount(counters []telemetryOperationCounter, operation, outcome string, count int) bool {
 	for _, counter := range counters {
 		if counter.Operation == operation && counter.Outcome == outcome && counter.Count == count {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSignal(signals []telemetrySignalPreview, name string) bool {
+	for _, signal := range signals {
+		if signal.Name == name {
 			return true
 		}
 	}

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -36,7 +36,7 @@ The daemon exposes loopback HTTP for development/bootstrap and now has explicit 
 ## Cross-cutting response rules
 
 - API version is visible in `status` and `capabilities` responses.
-- Secret values are never returned by status/capabilities/state/source-status endpoints.
+- Secret values are never returned by status/capabilities/state/source-status/telemetry endpoints.
 - Secret-bearing endpoints require local API token authentication for the loopback HTTP transport.
 - Resolve responses may include secret material only for requested refs allowed by policy.
 - Error responses use the typed error envelope below.
@@ -164,6 +164,7 @@ Example response:
     "GET /capabilities",
     "POST /v1/secrets",
     "POST /v1/resolve",
+    "GET /v1/telemetry",
     "GET|POST /v1/recovery/policy",
     "POST /v1/management/lockouts/clear",
     "GET /v1/sources/status"
@@ -182,7 +183,8 @@ Example response:
     "audited-lockout-clear",
     "recovery-policy-metadata",
     "recovery-policy-status",
-    "source-status"
+    "source-status",
+    "metadata-only-telemetry"
   ],
   "futureFeatures": [
     "write-back"
@@ -203,6 +205,18 @@ Example response:
   ]
 }
 ```
+
+### `GET /v1/telemetry`
+
+Read-only metadata telemetry for Service Admin and headless checks. It reports operational counters plus an OpenTelemetry-shaped preview contract:
+
+- `contractVersion`: `service-lasso.secretsbroker.telemetry-preview.v1`
+- `exporter`: configured/disabled status without endpoint or header values
+- `redaction`: allowlisted attributes and omitted field classes
+- `exportPreview`: dry-run/not-sent envelope metadata
+- `signals`: metric previews for operation counts, policy decisions, provider/source states, audit outcomes, and active lockout counts
+
+The endpoint never sends telemetry and never returns raw refs, secret values, provider credentials, tokens, cookies, private keys, recovery material, environment values, raw request/response bodies, OTLP endpoint values, OTLP headers, exported payload bodies, provider response bodies, or raw config values.
 
 ## Recovery policy metadata contract
 

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -129,6 +129,14 @@ Implemented first slice:
 - The first slice intentionally reports duration histograms as an empty array until operation-duration timing is recorded by the broker paths.
 - Telemetry uses `refHash`-only audit reads internally and does not serialize raw refs, secret values, provider credentials, bearer tokens, private keys, cookies, passwords, environment values, or provider response bodies.
 
+Implemented OpenTelemetry preview slice:
+
+- `GET /v1/telemetry` now includes contract `service-lasso.secretsbroker.telemetry-preview.v1`.
+- The response includes a redacted `resource`, allowlisted `redaction` policy, deterministic trace/span/correlation identifiers, and metadata-only metric `signals` for broker operation counts, policy decisions, provider/source states, audit-record outcomes, and active lockout counts.
+- The response includes `exporter` and `exportPreview` status for local OTLP readiness. Export remains disabled by default and reports `dry_run` only when `SECRETSBROKER_OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and `SECRETSBROKER_OTEL_EXPORT_MODE=dry-run` are explicitly configured.
+- `/v1/telemetry` never sends telemetry. Endpoint values, OTLP headers, payload bodies, raw refs, secret values, provider credentials, tokens, cookies, private keys, recovery material, environment values, raw request/response bodies, provider response bodies, and raw config values are omitted.
+- `secretsbroker admin telemetry` returns the same OTel-shaped preview for headless checks without exposing endpoint/header/body values.
+
 ## Events and filtering
 
 Events represent operator-relevant state transitions and decisions. The broker should maintain a bounded recent event store and expose filtered reads.


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Adds `service-lasso.secretsbroker.telemetry-preview.v1` to Secrets Broker `/v1/telemetry` and `secretsbroker admin telemetry`.
- Adds OTel-shaped exporter/resource/redaction/export-preview metadata plus deterministic metric signal previews for broker operation, policy, provider/source, audit, and lockout counters.
- Keeps export disabled by default; dry-run readiness only reports when `SECRETSBROKER_OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and `SECRETSBROKER_OTEL_EXPORT_MODE=dry-run` are configured.

## Scope
- In scope: metadata-only telemetry preview/status contract, docs, tests.
- Out of scope: live OTLP network export, production collector integration, Service Admin rendering changes.

## Spec / contract / fixture impact
- Updated `docs/local-api-bootstrap-contract.md` and `docs/operational-controls-baseline.md` for the new telemetry preview fields and redaction boundary.
- No fixture format changes.

## Safety / redaction impact
- Endpoint values, OTLP headers, payload bodies, raw refs, secret values, provider credentials, tokens, cookies, signing key material, recovery material, environment values, raw request/response bodies, provider response bodies, and raw config values remain omitted.
- Signals use allowlisted low-cardinality attributes only.

## Validation
- PASS `go test ./cmd/secretsbroker -run TestTelemetry -count=1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-secretsbroker-telemetry/test-telemetry-otel-preview.log`
- PASS `go test ./...` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-secretsbroker-telemetry/go-test-all-otel-preview.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-secretsbroker-telemetry/scripts-test-otel-preview.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-secretsbroker-telemetry/diff-check-otel-preview.log`

## Approval trail
- Required: yes if repository branch protections require it.
- Evidence: pending hosted checks/review.

## Cleanup
- Branch: `feature/635-secretsbroker-otel-preview`
- Release-to-demo gate is pending after merge because `@secretsbroker` is demo-consumed. After merge, publish/release Secrets Broker, update the core `@secretsbroker` pin to the exact release tag/commit, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected/catalog/installed/live tag before claiming demo-current.