### PR TITLE
feat: bind launch leases to IPC peer identity

### DIFF
--- a/cmd/secretsbroker/launch_identity_transport_test.go
+++ b/cmd/secretsbroker/launch_identity_transport_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestLaunchIdentityLeaseTransportBinding(t *testing.T) {
+	backend := testBackend(t)
+	backend.now = func() time.Time { return time.Date(2026, 5, 7, 0, 1, 0, 0, time.UTC) }
+	key := "transport-binding-key"
+	peer := transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-1000"}
+
+	lease := testLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-transport-ok")
+	lease.TransportBinding = &launchTransportBinding{Kind: peer.Kind, Subject: peer.Subject}
+	lease = mustSignLaunchIdentityLease(t, lease, key)
+	if err := backend.verifyLaunchIdentityLease(&lease, key, "api-service", "", "resolve", []string{"services/api-service/runtime/API_TOKEN"}, nil, peer); err != nil {
+		t.Fatalf("bound lease should authorize matching transport peer: %v", err)
+	}
+
+	mismatch := testLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-transport-mismatch")
+	mismatch.TransportBinding = &launchTransportBinding{Kind: peer.Kind, Subject: peer.Subject}
+	mismatch = mustSignLaunchIdentityLease(t, mismatch, key)
+	err := backend.verifyLaunchIdentityLease(&mismatch, key, "api-service", "", "resolve", []string{"services/api-service/runtime/API_TOKEN"}, nil, transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-2000"})
+	if !errors.Is(err, errPolicyDenied) {
+		t.Fatalf("mismatched transport peer error = %v, want policy denied", err)
+	}
+
+	missing := testLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-transport-missing")
+	missing.TransportBinding = &launchTransportBinding{Kind: "unix-uid", Subject: "501"}
+	missing = mustSignLaunchIdentityLease(t, missing, key)
+	err = backend.verifyLaunchIdentityLease(&missing, key, "api-service", "", "resolve", []string{"services/api-service/runtime/API_TOKEN"}, nil, transportPeerIdentity{})
+	if !errors.Is(err, errPolicyDenied) {
+		t.Fatalf("missing transport peer error = %v, want policy denied", err)
+	}
+}
+
+func mustSignLaunchIdentityLease(t *testing.T, lease launchIdentityLease, key string) launchIdentityLease {
+	t.Helper()
+	signed, err := signLaunchIdentityLease(lease, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -111,28 +111,35 @@ type writebackIdentity struct {
 }
 
 type launchIdentityLease struct {
-	Issuer            string   `json:"issuer"`
-	ServiceID         string   `json:"serviceId"`
-	WorkspaceID       string   `json:"workspaceId,omitempty"`
-	AllowedRefs       []string `json:"allowedRefs,omitempty"`
-	AllowedNamespaces []string `json:"allowedNamespaces,omitempty"`
-	AllowedOperations []string `json:"allowedOperations,omitempty"`
-	IssuedAt          string   `json:"issuedAt"`
-	ExpiresAt         string   `json:"expiresAt"`
-	JTI               string   `json:"jti"`
-	Signature         string   `json:"signature"`
+	Issuer            string                  `json:"issuer"`
+	ServiceID         string                  `json:"serviceId"`
+	WorkspaceID       string                  `json:"workspaceId,omitempty"`
+	AllowedRefs       []string                `json:"allowedRefs,omitempty"`
+	AllowedNamespaces []string                `json:"allowedNamespaces,omitempty"`
+	AllowedOperations []string                `json:"allowedOperations,omitempty"`
+	IssuedAt          string                  `json:"issuedAt"`
+	ExpiresAt         string                  `json:"expiresAt"`
+	JTI               string                  `json:"jti"`
+	Signature         string                  `json:"signature"`
+	TransportBinding  *launchTransportBinding `json:"transportBinding,omitempty"`
 }
 
 type launchIdentityLeasePayload struct {
-	Issuer            string   `json:"issuer"`
-	ServiceID         string   `json:"serviceId"`
-	WorkspaceID       string   `json:"workspaceId,omitempty"`
-	AllowedRefs       []string `json:"allowedRefs,omitempty"`
-	AllowedNamespaces []string `json:"allowedNamespaces,omitempty"`
-	AllowedOperations []string `json:"allowedOperations,omitempty"`
-	IssuedAt          string   `json:"issuedAt"`
-	ExpiresAt         string   `json:"expiresAt"`
-	JTI               string   `json:"jti"`
+	Issuer            string                  `json:"issuer"`
+	ServiceID         string                  `json:"serviceId"`
+	WorkspaceID       string                  `json:"workspaceId,omitempty"`
+	AllowedRefs       []string                `json:"allowedRefs,omitempty"`
+	AllowedNamespaces []string                `json:"allowedNamespaces,omitempty"`
+	AllowedOperations []string                `json:"allowedOperations,omitempty"`
+	IssuedAt          string                  `json:"issuedAt"`
+	ExpiresAt         string                  `json:"expiresAt"`
+	JTI               string                  `json:"jti"`
+	TransportBinding  *launchTransportBinding `json:"transportBinding,omitempty"`
+}
+
+type launchTransportBinding struct {
+	Kind    string `json:"kind"`
+	Subject string `json:"subject"`
 }
 
 type generatedSecretCaptureRequest struct {
@@ -369,11 +376,12 @@ func launchIdentitySignatureInput(lease launchIdentityLease) ([]byte, error) {
 		IssuedAt:          strings.TrimSpace(lease.IssuedAt),
 		ExpiresAt:         strings.TrimSpace(lease.ExpiresAt),
 		JTI:               strings.TrimSpace(lease.JTI),
+		TransportBinding:  normalizeLaunchTransportBinding(lease.TransportBinding),
 	}
 	return json.Marshal(payload)
 }
 
-func (b *localBackend) authorizeWritebackLaunchLease(req *generatedSecretCaptureRequest, signingKey string) error {
+func (b *localBackend) authorizeWritebackLaunchLease(req *generatedSecretCaptureRequest, signingKey string, peer transportPeerIdentity) error {
 	if req == nil {
 		return errIdentityInvalid
 	}
@@ -381,7 +389,7 @@ func (b *localBackend) authorizeWritebackLaunchLease(req *generatedSecretCapture
 	namespace := strings.Trim(strings.TrimSpace(req.Namespace), "/")
 	ref := strings.Trim(strings.TrimSpace(req.Ref), "/")
 	fullRef := strings.Trim(namespace+"/"+ref, "/")
-	if err := b.verifyLaunchIdentityLease(req.IdentityLease, signingKey, strings.TrimSpace(req.Identity.ServiceID), "", operation, []string{fullRef}, []string{namespace}); err != nil {
+	if err := b.verifyLaunchIdentityLease(req.IdentityLease, signingKey, strings.TrimSpace(req.Identity.ServiceID), "", operation, []string{fullRef}, []string{namespace}, peer); err != nil {
 		_ = b.audit("launch_identity", fullRef, launchIdentityOutcome(err), strings.TrimSpace(req.Identity.ServiceID), req.RequestID)
 		return err
 	}
@@ -397,11 +405,11 @@ func (b *localBackend) authorizeWritebackLaunchLease(req *generatedSecretCapture
 	return nil
 }
 
-func (b *localBackend) authorizeResolveLaunchLease(req *resolveRequest, signingKey string) error {
+func (b *localBackend) authorizeResolveLaunchLease(req *resolveRequest, signingKey string, peer transportPeerIdentity) error {
 	if req == nil {
 		return errIdentityInvalid
 	}
-	if err := b.verifyLaunchIdentityLease(req.IdentityLease, signingKey, strings.TrimSpace(req.ServiceID), strings.TrimSpace(req.WorkspaceID), "resolve", req.Refs, nil); err != nil {
+	if err := b.verifyLaunchIdentityLease(req.IdentityLease, signingKey, strings.TrimSpace(req.ServiceID), strings.TrimSpace(req.WorkspaceID), "resolve", req.Refs, nil, peer); err != nil {
 		_ = b.audit("launch_identity", "", launchIdentityOutcome(err), strings.TrimSpace(req.ServiceID), req.RequestID)
 		return err
 	}
@@ -416,8 +424,12 @@ func (b *localBackend) authorizeResolveLaunchLease(req *resolveRequest, signingK
 	return nil
 }
 
-func (b *localBackend) verifyLaunchIdentityLease(lease *launchIdentityLease, signingKey, expectedServiceID, expectedWorkspaceID, operation string, refs, namespaces []string) error {
+func (b *localBackend) verifyLaunchIdentityLease(lease *launchIdentityLease, signingKey, expectedServiceID, expectedWorkspaceID, operation string, refs, namespaces []string, peer transportPeerIdentity) error {
 	if lease == nil || strings.TrimSpace(signingKey) == "" || strings.TrimSpace(lease.Signature) == "" || strings.TrimSpace(lease.ServiceID) == "" || strings.TrimSpace(lease.Issuer) == "" || strings.TrimSpace(lease.JTI) == "" {
+		return errIdentityInvalid
+	}
+	binding := normalizeLaunchTransportBinding(lease.TransportBinding)
+	if lease.TransportBinding != nil && binding == nil {
 		return errIdentityInvalid
 	}
 	if expectedServiceID != "" && strings.TrimSpace(lease.ServiceID) != expectedServiceID {
@@ -454,10 +466,38 @@ func (b *localBackend) verifyLaunchIdentityLease(lease *launchIdentityLease, sig
 	if !constantTimeTokenEqual(lease.Signature, want) {
 		return errIdentityInvalid
 	}
+	if binding != nil && !launchTransportBindingMatchesPeer(binding, peer) {
+		return errPolicyDenied
+	}
 	if !b.rememberLaunchLeaseJTI(*lease, expiresAt, now) {
 		return errIdentityReplayed
 	}
 	return nil
+}
+
+func normalizeLaunchTransportBinding(binding *launchTransportBinding) *launchTransportBinding {
+	if binding == nil {
+		return nil
+	}
+	normalized := &launchTransportBinding{
+		Kind:    strings.ToLower(strings.TrimSpace(binding.Kind)),
+		Subject: strings.TrimSpace(binding.Subject),
+	}
+	if normalized.Kind == "" || normalized.Subject == "" {
+		return nil
+	}
+	return normalized
+}
+
+func launchTransportBindingMatchesPeer(binding *launchTransportBinding, peer transportPeerIdentity) bool {
+	if binding == nil {
+		return true
+	}
+	peer = normalizeTransportPeerIdentity(peer)
+	if peer.Kind == "" || peer.Subject == "" {
+		return false
+	}
+	return strings.EqualFold(binding.Kind, peer.Kind) && strings.EqualFold(binding.Subject, peer.Subject)
 }
 
 func launchLeaseOperationAllowed(operation string, allowed []string) bool {
@@ -1062,7 +1102,8 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			writeDecodeError(w, err)
 			return
 		}
-		if err := backend.authorizeWritebackLaunchLease(&req, firstNonEmpty(backend.launchIdentitySigningKey, security.token)); err != nil {
+		peer := transportPeerIdentityFromContext(r.Context())
+		if err := backend.authorizeWritebackLaunchLease(&req, firstNonEmpty(backend.launchIdentitySigningKey, security.token), peer); err != nil {
 			writeLaunchIdentityAPIError(w, err)
 			return
 		}
@@ -1100,7 +1141,8 @@ func registerLocalStoreHandlers(mux *http.ServeMux, backend *localBackend, secur
 			writeDecodeError(w, err)
 			return
 		}
-		if err := backend.authorizeResolveLaunchLease(&req, firstNonEmpty(backend.launchIdentitySigningKey, security.token)); err != nil {
+		peer := transportPeerIdentityFromContext(r.Context())
+		if err := backend.authorizeResolveLaunchLease(&req, firstNonEmpty(backend.launchIdentitySigningKey, security.token), peer); err != nil {
 			writeLaunchIdentityAPIError(w, err)
 			return
 		}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -283,6 +283,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"exec-source",
 			"service-json-secret-policy",
 			"signed-launch-identity-leases",
+			"launch-identity-transport-binding",
 			"write-back-policy",
 			"generated-secret-capture",
 			"encrypted-backup-restore",
@@ -384,7 +385,11 @@ func serve(args []string) error {
 	}
 	defer cleanup()
 
-	server := &http.Server{Handler: newHandler(stateView, backend, localAPISecurity{token: *apiToken}), ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{
+		Handler:           newHandler(stateView, backend, localAPISecurity{token: *apiToken}),
+		ReadHeaderTimeout: 5 * time.Second,
+		ConnContext:       transportPeerIdentityConnContext,
+	}
 	go func() {
 		slog.Info("@secretsbroker listening", "transport", binding.Kind, "addr", binding.DisplayAddress, "state", *state)
 		if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -43,6 +43,7 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	assertContains(t, caps.Features, "os-ipc-transport-policy")
 	assertContains(t, caps.Features, "unix-socket-peer-credential-checks")
 	assertContains(t, caps.Features, "windows-named-pipe-identity-checks")
+	assertContains(t, caps.Features, "launch-identity-transport-binding")
 	assertContains(t, caps.Outcomes, "source_auth_required")
 	assertContains(t, caps.Outcomes, "policy_denied")
 }

--- a/cmd/secretsbroker/transport_auth_unix.go
+++ b/cmd/secretsbroker/transport_auth_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 )
 
 type unixPeerCredentialListener struct {
@@ -29,25 +30,26 @@ func (l *unixPeerCredentialListener) Accept() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := authorizeUnixPeerConn(conn, l.allowedUID); err != nil {
+		identity, err := authorizeUnixPeerConn(conn, l.allowedUID)
+		if err != nil {
 			_ = conn.Close()
 			continue
 		}
-		return conn, nil
+		return withTransportPeerIdentityConn(conn, identity), nil
 	}
 }
 
-func authorizeUnixPeerConn(conn net.Conn, allowedUID int) error {
+func authorizeUnixPeerConn(conn net.Conn, allowedUID int) (transportPeerIdentity, error) {
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
-		return fmt.Errorf("unix-socket transport connection is %T, want *net.UnixConn", conn)
+		return transportPeerIdentity{}, fmt.Errorf("unix-socket transport connection is %T, want *net.UnixConn", conn)
 	}
 	uid, _, _, err := unixPeerCredentials(unixConn)
 	if err != nil {
-		return err
+		return transportPeerIdentity{}, err
 	}
 	if !unixPeerUIDAuthorized(uid, allowedUID) {
-		return fmt.Errorf("unix-socket transport rejected local peer uid %d", uid)
+		return transportPeerIdentity{}, fmt.Errorf("unix-socket transport rejected local peer uid %d", uid)
 	}
-	return nil
+	return transportPeerIdentity{Kind: "unix-uid", Subject: strconv.Itoa(uid)}, nil
 }

--- a/cmd/secretsbroker/transport_auth_windows.go
+++ b/cmd/secretsbroker/transport_auth_windows.go
@@ -35,27 +35,28 @@ func (l *windowsNamedPipeListener) Accept() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := authorizeWindowsNamedPipeConn(conn, l.allowedUserSID); err != nil {
+		identity, err := authorizeWindowsNamedPipeConn(conn, l.allowedUserSID)
+		if err != nil {
 			_ = conn.Close()
 			continue
 		}
-		return conn, nil
+		return withTransportPeerIdentityConn(conn, identity), nil
 	}
 }
 
-func authorizeWindowsNamedPipeConn(conn net.Conn, allowedUserSID string) error {
+func authorizeWindowsNamedPipeConn(conn net.Conn, allowedUserSID string) (transportPeerIdentity, error) {
 	fdConn, ok := conn.(windowsPipeConnHandle)
 	if !ok {
-		return fmt.Errorf("windows-named-pipe transport connection is %T, want handle-bearing pipe connection", conn)
+		return transportPeerIdentity{}, fmt.Errorf("windows-named-pipe transport connection is %T, want handle-bearing pipe connection", conn)
 	}
 	identity, err := windowsNamedPipeClientIdentity(windows.Handle(fdConn.Fd()))
 	if err != nil {
-		return err
+		return transportPeerIdentity{}, err
 	}
 	if !windowsNamedPipeClientAuthorized(identity, allowedUserSID) {
-		return fmt.Errorf("windows-named-pipe transport rejected local peer sid")
+		return transportPeerIdentity{}, fmt.Errorf("windows-named-pipe transport rejected local peer sid")
 	}
-	return nil
+	return transportPeerIdentity{Kind: "windows-sid", Subject: identity.UserSID}, nil
 }
 
 func windowsNamedPipeClientAuthorized(identity windowsClientIdentity, allowedUserSID string) bool {

--- a/cmd/secretsbroker/transport_auth_windows_test.go
+++ b/cmd/secretsbroker/transport_auth_windows_test.go
@@ -147,7 +147,7 @@ func TestAuthorizeWindowsNamedPipeConnRejectsNonPipeConn(t *testing.T) {
 	server, client := net.Pipe()
 	defer server.Close()
 	defer client.Close()
-	if err := authorizeWindowsNamedPipeConn(server, "S-1-5-21-1000"); err == nil {
+	if _, err := authorizeWindowsNamedPipeConn(server, "S-1-5-21-1000"); err == nil {
 		t.Fatalf("expected non-pipe connection rejection")
 	}
 }

--- a/cmd/secretsbroker/transport_identity.go
+++ b/cmd/secretsbroker/transport_identity.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+type transportPeerIdentity struct {
+	Kind    string
+	Subject string
+}
+
+type transportPeerIdentityProvider interface {
+	TransportPeerIdentity() transportPeerIdentity
+}
+
+type transportIdentityConn struct {
+	net.Conn
+	identity transportPeerIdentity
+}
+
+type transportPeerIdentityContextKey struct{}
+
+func withTransportPeerIdentityConn(conn net.Conn, identity transportPeerIdentity) net.Conn {
+	identity = normalizeTransportPeerIdentity(identity)
+	if identity.Kind == "" || identity.Subject == "" {
+		return conn
+	}
+	return &transportIdentityConn{Conn: conn, identity: identity}
+}
+
+func (c *transportIdentityConn) TransportPeerIdentity() transportPeerIdentity {
+	return c.identity
+}
+
+func transportPeerIdentityConnContext(ctx context.Context, conn net.Conn) context.Context {
+	provider, ok := conn.(transportPeerIdentityProvider)
+	if !ok {
+		return ctx
+	}
+	return contextWithTransportPeerIdentity(ctx, provider.TransportPeerIdentity())
+}
+
+func contextWithTransportPeerIdentity(ctx context.Context, identity transportPeerIdentity) context.Context {
+	identity = normalizeTransportPeerIdentity(identity)
+	if identity.Kind == "" || identity.Subject == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, transportPeerIdentityContextKey{}, identity)
+}
+
+func transportPeerIdentityFromContext(ctx context.Context) transportPeerIdentity {
+	identity, _ := ctx.Value(transportPeerIdentityContextKey{}).(transportPeerIdentity)
+	return normalizeTransportPeerIdentity(identity)
+}
+
+func normalizeTransportPeerIdentity(identity transportPeerIdentity) transportPeerIdentity {
+	return transportPeerIdentity{
+		Kind:    strings.ToLower(strings.TrimSpace(identity.Kind)),
+		Subject: strings.TrimSpace(identity.Subject),
+	}
+}

--- a/docs/launch-identity-leases.md
+++ b/docs/launch-identity-leases.md
@@ -27,6 +27,10 @@ hmac-sha256:<base64url-no-padding>
   "issuedAt": "2026-06-20T08:00:00Z",
   "expiresAt": "2026-06-20T08:05:00Z",
   "jti": "01J...",
+  "transportBinding": {
+    "kind": "windows-sid",
+    "subject": "S-1-5-21-..."
+  },
   "signature": "hmac-sha256:..."
 }
 ```
@@ -36,6 +40,13 @@ Required claims:
 - `issuer`, `serviceId`, `issuedAt`, `expiresAt`, `jti`, and `signature`
 - at least one of `allowedRefs` or `allowedNamespaces`
 - `allowedOperations`, using `resolve` for resolve requests and write-back operations such as `create`, `update`, `rotate`, or `delete`
+
+Optional transport binding:
+
+- `transportBinding.kind`: `windows-sid` for Windows named-pipe clients or `unix-uid` for Unix socket clients.
+- `transportBinding.subject`: the broker-observed local peer subject, such as a Windows user SID or Unix UID.
+
+When present, `transportBinding` is part of the signed lease payload. The broker requires the request to arrive through an authenticated IPC transport with matching local peer metadata. A transport-bound lease fails closed on loopback HTTP or on a mismatched local peer.
 
 `jti` values are one-time use until their expiry. Replaying a lease returns `identity_replayed`.
 
@@ -47,5 +58,6 @@ The broker rejects the request before reading or writing secret values when:
 - the lease is expired: `identity_expired`
 - the `jti` has already been used: `identity_replayed`
 - the request service, workspace, refs, namespace, or operation exceed the signed scope: `policy_denied`
+- the lease is bound to a local transport identity and the authenticated IPC peer does not match: `policy_denied`
 
 Audit records use metadata only: operation, request id, service id, safe ref/hash where applicable, and typed outcome. Lease signatures, API tokens, and secret values are never written to audit JSONL.

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -40,6 +40,7 @@ Implemented behavior:
 - `auto` chooses the platform IPC transport in production mode: Windows named pipe on Windows, Unix socket elsewhere.
 - Unix-like platforms can serve HTTP over a Unix socket, set the socket path to owner-only mode, and check OS peer credentials before passing a connection to the HTTP server. Linux uses `SO_PEERCRED`; macOS/FreeBSD use `LOCAL_PEERCRED`.
 - Windows can serve HTTP over a named pipe with a restricted security descriptor and a connected-client identity check before passing the connection to the HTTP server.
+- Authenticated IPC listeners attach safe local peer metadata to each accepted request: `windows-sid` for Windows named-pipe peers and `unix-uid` for Unix socket peers. Signed launch identity leases can optionally bind to that transport subject for secret-bearing resolve/write-back requests.
 
 ## Production gate
 
@@ -54,13 +55,13 @@ Current Windows named-pipe support:
 - The listener identifies the connected client process with `GetNamedPipeClientProcessId`, inspects the client process token, and accepts only the same user SID, LocalSystem, or an enabled local Administrators group membership.
 - Connections that cannot be identified or authorized are closed before the HTTP server sees the request.
 - Identity metadata must be safe: no access tokens, environment values, command lines, or raw credentials in responses, logs, or audit events.
-- Secret-bearing endpoints still require the existing local API token/session/launch-identity checks on top of the named-pipe boundary.
+- Secret-bearing endpoints still require the existing local API token/session/launch-identity checks on top of the named-pipe boundary. When a launch identity lease includes `transportBinding`, the request is denied unless the authenticated pipe peer matches that signed binding.
 
 Remaining hardening:
 
 - Define the final Service Lasso launcher policy for administrator and service-account access.
 - Add cross-user denial evidence in an integration environment that can create a second local Windows principal.
-- Bind signed launch identity leases to transport identity where required by a later policy slice.
+- Extend launcher-issued leases to include `transportBinding` by default once the core launcher has a stable broker transport identity policy.
 
 ## Unix socket requirements
 
@@ -80,3 +81,21 @@ secretsbroker serve --listen 127.0.0.1:17890
 ```
 
 Secret-bearing HTTP endpoints still require the local API token and existing launch identity checks. The IPC work changes the process boundary; it does not remove endpoint authentication or policy checks.
+
+## Launch identity transport binding
+
+Launch identity leases support an optional signed `transportBinding` object:
+
+```json
+{
+  "kind": "windows-sid",
+  "subject": "S-1-5-21-..."
+}
+```
+
+Supported binding kinds:
+
+- `windows-sid`: the connected Windows named-pipe client process token user SID.
+- `unix-uid`: the connected Unix socket peer UID.
+
+If a lease omits `transportBinding`, existing token/session and lease scope checks continue unchanged. If a lease includes it, the broker requires an authenticated IPC listener to provide matching peer metadata before `POST /v1/resolve` or `POST /v1/writeback` can proceed. Loopback HTTP does not provide OS peer identity, so transport-bound leases fail closed on loopback.


### PR DESCRIPTION
## Issue
Advances #31

## Summary
- Carry authenticated IPC peer identity from the Unix socket / Windows named-pipe listener into HTTP request context.
- Add optional signed `transportBinding` to launch identity leases so resolve/write-back requests can be bound to a broker-observed local OS subject.
- Document the transport-bound lease behavior and expose it in broker capabilities.

## Scope
- In scope: request-context peer metadata, signed lease binding enforcement, docs/tests.
- Out of scope: changing the core launcher to issue `transportBinding` by default, cross-user Windows integration testing with a second local principal, or changing the existing default launcher service-account policy.

## Spec / contract / fixture impact
- Updated: `docs/os-authenticated-ipc-transport.md`, `docs/launch-identity-leases.md`.
- Contract impact: `identityLease.transportBinding` is optional; existing leases remain compatible. When present, it is part of the signed payload and must match the authenticated IPC peer.

## Security / redaction impact
- Binding subjects are OS identity metadata only (`windows-sid` or `unix-uid`); no tokens, command lines, environment values, or secret payloads are logged or returned.
- Transport-bound leases fail closed on loopback HTTP or mismatched IPC peers.

## Validation
- PASS `go test ./cmd/secretsbroker -count=1` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626-130904\go-test-cmd-secretsbroker.log`
- PASS `go test ./... -count=1` — `...\go-test-all.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `...\scripts-test-ps1.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `...\go-build-commands.log`
- PASS `git diff --check` — `...\git-diff-check.log`
- PASS `GOOS=linux GOARCH=amd64 go test -c ./cmd/secretsbroker` — `...\go-test-compile-linux-amd64.log`
- PASS `GOOS=darwin GOARCH=amd64 go test -c ./cmd/secretsbroker` — `...\go-test-compile-darwin-amd64.log`

## Approval trail
- Required: no explicit human approval expected for this focused implementation slice if hosted checks pass and branch is mergeable.

## Release/demo gate
- Pending. This repo is demo-consumed, so after merge/release the exact new Secrets Broker release must be pinned in `service-lasso/service-lasso`, the canonical demo on port 17883 recycled, and `npm run demo:verify-canonical` passed before claiming demo-current.

## Cleanup
- Branch cleanup after merge/release/pin/demo verification.