### PR TITLE
feat: add named pipe service account policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ go run .\cmd\secretsbroker serve
 
 On Windows, `auto` serves over a named pipe with connected-client identity checks. On Unix-like platforms, `auto` serves over a Unix socket with peer credential checks where supported.
 
+Windows named-pipe production profiles can make launcher/service-account access explicit:
+
+```powershell
+$env:SECRETSBROKER_NAMED_PIPE_ALLOWED_SIDS = "S-1-5-80-..."
+$env:SECRETSBROKER_NAMED_PIPE_ALLOW_ADMIN = "false"
+$env:SECRETSBROKER_NAMED_PIPE_ALLOW_LOCAL_SYSTEM = "true"
+go run .\cmd\secretsbroker serve --mode production --transport windows-named-pipe
+```
+
+The broker process user SID is always included in the named-pipe ACL. Additional SIDs are for a stable Service Lasso launcher or service account. Local Administrators and LocalSystem stay enabled by default for compatibility, and production profiles can turn either off once the launcher identity is fixed.
+
 Check status:
 
 ```powershell

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -298,6 +298,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"os-ipc-transport-policy",
 			"unix-socket-peer-credential-checks",
 			"windows-named-pipe-identity-checks",
+			"windows-named-pipe-service-account-policy",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",
@@ -324,6 +325,9 @@ func serve(args []string) error {
 	transport := fs.String("transport", getenvDefault("SECRETSBROKER_TRANSPORT", "loopback-http"), "serve transport: loopback-http, unix-socket, windows-named-pipe, or auto")
 	unixSocket := fs.String("unix-socket", getenvDefault("SECRETSBROKER_UNIX_SOCKET", ""), "Unix socket path for unix-socket transport")
 	namedPipe := fs.String("named-pipe", getenvDefault("SECRETSBROKER_NAMED_PIPE", ""), "Windows named pipe path for windows-named-pipe transport")
+	namedPipeAllowedSIDs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_NAMED_PIPE_ALLOWED_SIDS", "")))
+	namedPipeAllowAdmin := fs.Bool("named-pipe-allow-admin", envBoolDefault("SECRETSBROKER_NAMED_PIPE_ALLOW_ADMIN", true), "allow enabled local Administrators group members to connect to the Windows named-pipe transport")
+	namedPipeAllowLocalSystem := fs.Bool("named-pipe-allow-local-system", envBoolDefault("SECRETSBROKER_NAMED_PIPE_ALLOW_LOCAL_SYSTEM", true), "allow LocalSystem to connect to the Windows named-pipe transport")
 	state := fs.String("state", getenvDefault("SECRETSBROKER_STATE", "setup_needed"), "state to report")
 	storePath := fs.String("store", getenvDefault("SECRETSBROKER_STORE_PATH", defaultStorePath()), "local encrypted store path")
 	auditPath := fs.String("audit", getenvDefault("SECRETSBROKER_AUDIT_PATH", defaultAuditPath()), "audit JSONL path")
@@ -336,6 +340,7 @@ func serve(args []string) error {
 	sourcesPath := fs.String("sources", getenvDefault("SECRETSBROKER_SOURCES_PATH", ""), "source adapter config path")
 	affectedRefs := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_REFS", "")))
 	affectedServices := multiFlag(splitCSV(getenvDefault("SECRETSBROKER_AFFECTED_SERVICES", "")))
+	fs.Var(&namedPipeAllowedSIDs, "named-pipe-allowed-sid", "additional Windows service-account/user SID allowed to connect to the named-pipe transport; repeatable")
 	fs.Var(&affectedRefs, "affected-ref", "affected secret ref to report for non-ready states; repeatable")
 	fs.Var(&affectedServices, "affected-service", "affected service id to report for non-ready states; repeatable")
 	if err := fs.Parse(args); err != nil {
@@ -370,11 +375,14 @@ func serve(args []string) error {
 	backend.sources = sources
 
 	binding, err := resolveServeTransport(serveTransportOptions{
-		Mode:       *mode,
-		Transport:  *transport,
-		Listen:     *listen,
-		UnixSocket: *unixSocket,
-		NamedPipe:  *namedPipe,
+		Mode:                        *mode,
+		Transport:                   *transport,
+		Listen:                      *listen,
+		UnixSocket:                  *unixSocket,
+		NamedPipe:                   *namedPipe,
+		NamedPipeAllowedSIDs:        []string(namedPipeAllowedSIDs),
+		NamedPipeAllowLocalSystem:   *namedPipeAllowLocalSystem,
+		NamedPipeAllowBuiltinAdmins: *namedPipeAllowAdmin,
 	})
 	if err != nil {
 		return err

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -43,6 +43,7 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	assertContains(t, caps.Features, "os-ipc-transport-policy")
 	assertContains(t, caps.Features, "unix-socket-peer-credential-checks")
 	assertContains(t, caps.Features, "windows-named-pipe-identity-checks")
+	assertContains(t, caps.Features, "windows-named-pipe-service-account-policy")
 	assertContains(t, caps.Features, "launch-identity-transport-binding")
 	assertContains(t, caps.Outcomes, "source_auth_required")
 	assertContains(t, caps.Outcomes, "policy_denied")
@@ -100,6 +101,28 @@ func TestWindowsNamedPipeRequiresPipeNamespace(t *testing.T) {
 	_, err := resolveServeTransport(serveTransportOptions{Transport: "windows-named-pipe", NamedPipe: `C:\tmp\not-a-pipe`})
 	if err == nil {
 		t.Fatalf("expected named pipe namespace rejection")
+	}
+}
+
+func TestWindowsNamedPipeCarriesAccessPolicy(t *testing.T) {
+	binding, err := resolveServeTransport(serveTransportOptions{
+		Transport:                   "windows-named-pipe",
+		NamedPipe:                   `\\.\pipe\service-lasso-secretsbroker-test`,
+		NamedPipeAllowedSIDs:        []string{"S-1-5-80-12345", " "},
+		NamedPipeAllowLocalSystem:   true,
+		NamedPipeAllowBuiltinAdmins: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.WindowsNamedPipeAccessPolicy.AllowBuiltinAdmins {
+		t.Fatalf("builtin admin policy should remain disabled")
+	}
+	if !binding.WindowsNamedPipeAccessPolicy.AllowLocalSystem {
+		t.Fatalf("LocalSystem policy should remain enabled")
+	}
+	if len(binding.WindowsNamedPipeAccessPolicy.AllowedUserSIDs) != 1 || binding.WindowsNamedPipeAccessPolicy.AllowedUserSIDs[0] != "S-1-5-80-12345" {
+		t.Fatalf("allowed SID policy = %#v", binding.WindowsNamedPipeAccessPolicy.AllowedUserSIDs)
 	}
 }
 

--- a/cmd/secretsbroker/transport.go
+++ b/cmd/secretsbroker/transport.go
@@ -11,18 +11,28 @@ import (
 )
 
 type serveTransportOptions struct {
-	Mode       string
-	Transport  string
-	Listen     string
-	UnixSocket string
-	NamedPipe  string
+	Mode                        string
+	Transport                   string
+	Listen                      string
+	UnixSocket                  string
+	NamedPipe                   string
+	NamedPipeAllowedSIDs        []string
+	NamedPipeAllowLocalSystem   bool
+	NamedPipeAllowBuiltinAdmins bool
 }
 
 type serveTransportBinding struct {
-	Kind           string
-	Network        string
-	Address        string
-	DisplayAddress string
+	Kind                         string
+	Network                      string
+	Address                      string
+	DisplayAddress               string
+	WindowsNamedPipeAccessPolicy windowsNamedPipeAccessPolicy
+}
+
+type windowsNamedPipeAccessPolicy struct {
+	AllowedUserSIDs    []string
+	AllowLocalSystem   bool
+	AllowBuiltinAdmins bool
 }
 
 func resolveServeTransport(opts serveTransportOptions) (serveTransportBinding, error) {
@@ -55,7 +65,17 @@ func resolveServeTransport(opts serveTransportOptions) (serveTransportBinding, e
 		if !strings.HasPrefix(strings.ToLower(path), `\\.\pipe\`) {
 			return serveTransportBinding{}, fmt.Errorf("windows named pipe path must start with \\\\.\\pipe\\")
 		}
-		return serveTransportBinding{Kind: kind, Network: "windows-named-pipe", Address: path, DisplayAddress: path}, nil
+		return serveTransportBinding{
+			Kind:           kind,
+			Network:        "windows-named-pipe",
+			Address:        path,
+			DisplayAddress: path,
+			WindowsNamedPipeAccessPolicy: windowsNamedPipeAccessPolicy{
+				AllowedUserSIDs:    safeList(opts.NamedPipeAllowedSIDs),
+				AllowLocalSystem:   opts.NamedPipeAllowLocalSystem,
+				AllowBuiltinAdmins: opts.NamedPipeAllowBuiltinAdmins,
+			},
+		}, nil
 	default:
 		return serveTransportBinding{}, fmt.Errorf("unsupported serve transport %q", opts.Transport)
 	}

--- a/cmd/secretsbroker/transport_auth_windows.go
+++ b/cmd/secretsbroker/transport_auth_windows.go
@@ -12,7 +12,7 @@ import (
 
 type windowsNamedPipeListener struct {
 	net.Listener
-	allowedUserSID string
+	policy windowsNamedPipeAccessPolicy
 }
 
 type windowsPipeConnHandle interface {
@@ -25,8 +25,8 @@ type windowsClientIdentity struct {
 	IsBuiltinAdminMember bool
 }
 
-func authenticatedWindowsNamedPipeListener(ln net.Listener, allowedUserSID string) net.Listener {
-	return &windowsNamedPipeListener{Listener: ln, allowedUserSID: allowedUserSID}
+func authenticatedWindowsNamedPipeListener(ln net.Listener, policy windowsNamedPipeAccessPolicy) net.Listener {
+	return &windowsNamedPipeListener{Listener: ln, policy: normalizeWindowsNamedPipeAccessPolicy(policy)}
 }
 
 func (l *windowsNamedPipeListener) Accept() (net.Conn, error) {
@@ -35,7 +35,7 @@ func (l *windowsNamedPipeListener) Accept() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		identity, err := authorizeWindowsNamedPipeConn(conn, l.allowedUserSID)
+		identity, err := authorizeWindowsNamedPipeConn(conn, l.policy)
 		if err != nil {
 			_ = conn.Close()
 			continue
@@ -44,7 +44,7 @@ func (l *windowsNamedPipeListener) Accept() (net.Conn, error) {
 	}
 }
 
-func authorizeWindowsNamedPipeConn(conn net.Conn, allowedUserSID string) (transportPeerIdentity, error) {
+func authorizeWindowsNamedPipeConn(conn net.Conn, policy windowsNamedPipeAccessPolicy) (transportPeerIdentity, error) {
 	fdConn, ok := conn.(windowsPipeConnHandle)
 	if !ok {
 		return transportPeerIdentity{}, fmt.Errorf("windows-named-pipe transport connection is %T, want handle-bearing pipe connection", conn)
@@ -53,18 +53,23 @@ func authorizeWindowsNamedPipeConn(conn net.Conn, allowedUserSID string) (transp
 	if err != nil {
 		return transportPeerIdentity{}, err
 	}
-	if !windowsNamedPipeClientAuthorized(identity, allowedUserSID) {
+	if !windowsNamedPipeClientAuthorized(identity, policy) {
 		return transportPeerIdentity{}, fmt.Errorf("windows-named-pipe transport rejected local peer sid")
 	}
 	return transportPeerIdentity{Kind: "windows-sid", Subject: identity.UserSID}, nil
 }
 
-func windowsNamedPipeClientAuthorized(identity windowsClientIdentity, allowedUserSID string) bool {
-	allowedUserSID = strings.TrimSpace(allowedUserSID)
-	if allowedUserSID != "" && strings.EqualFold(identity.UserSID, allowedUserSID) {
+func windowsNamedPipeClientAuthorized(identity windowsClientIdentity, policy windowsNamedPipeAccessPolicy) bool {
+	policy = normalizeWindowsNamedPipeAccessPolicy(policy)
+	for _, sid := range policy.AllowedUserSIDs {
+		if strings.EqualFold(identity.UserSID, sid) {
+			return true
+		}
+	}
+	if identity.IsLocalSystem && policy.AllowLocalSystem {
 		return true
 	}
-	return identity.IsLocalSystem || identity.IsBuiltinAdminMember
+	return identity.IsBuiltinAdminMember && policy.AllowBuiltinAdmins
 }
 
 func windowsNamedPipeClientIdentity(pipe windows.Handle) (windowsClientIdentity, error) {
@@ -160,10 +165,45 @@ func windowsSIDIsWellKnown(sidString string, sidType windows.WELL_KNOWN_SID_TYPE
 	return sid.Equals(want), nil
 }
 
-func windowsNamedPipeSecurityDescriptor(userSID string) string {
-	userSID = strings.TrimSpace(userSID)
-	if userSID == "" {
-		return "D:P(A;;GA;;;SY)(A;;GA;;;BA)"
+func windowsNamedPipeAccessPolicyWithServerSID(policy windowsNamedPipeAccessPolicy, serverUserSID string) windowsNamedPipeAccessPolicy {
+	policy = normalizeWindowsNamedPipeAccessPolicy(policy)
+	serverUserSID = strings.TrimSpace(serverUserSID)
+	if serverUserSID != "" {
+		policy.AllowedUserSIDs = append(policy.AllowedUserSIDs, serverUserSID)
 	}
-	return fmt.Sprintf("D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;%s)", userSID)
+	return normalizeWindowsNamedPipeAccessPolicy(policy)
+}
+
+func normalizeWindowsNamedPipeAccessPolicy(policy windowsNamedPipeAccessPolicy) windowsNamedPipeAccessPolicy {
+	seen := map[string]struct{}{}
+	allowed := make([]string, 0, len(policy.AllowedUserSIDs))
+	for _, sid := range policy.AllowedUserSIDs {
+		sid = strings.TrimSpace(sid)
+		if sid == "" {
+			continue
+		}
+		key := strings.ToLower(sid)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		allowed = append(allowed, sid)
+	}
+	policy.AllowedUserSIDs = allowed
+	return policy
+}
+
+func windowsNamedPipeSecurityDescriptor(policy windowsNamedPipeAccessPolicy) string {
+	policy = normalizeWindowsNamedPipeAccessPolicy(policy)
+	aces := []string{}
+	if policy.AllowLocalSystem {
+		aces = append(aces, "(A;;GA;;;SY)")
+	}
+	if policy.AllowBuiltinAdmins {
+		aces = append(aces, "(A;;GA;;;BA)")
+	}
+	for _, sid := range policy.AllowedUserSIDs {
+		aces = append(aces, fmt.Sprintf("(A;;GA;;;%s)", sid))
+	}
+	return "D:P" + strings.Join(aces, "")
 }

--- a/cmd/secretsbroker/transport_auth_windows_test.go
+++ b/cmd/secretsbroker/transport_auth_windows_test.go
@@ -15,17 +15,29 @@ import (
 )
 
 func TestWindowsNamedPipeClientAuthorization(t *testing.T) {
-	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1000"}, "s-1-5-21-1000") {
+	policy := windowsNamedPipeAccessPolicy{
+		AllowedUserSIDs:    []string{"s-1-5-21-1000"},
+		AllowLocalSystem:   true,
+		AllowBuiltinAdmins: true,
+	}
+	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1000"}, policy) {
 		t.Fatalf("same user SID should be authorized")
 	}
-	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-18", IsLocalSystem: true}, "S-1-5-21-1000") {
+	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-18", IsLocalSystem: true}, policy) {
 		t.Fatalf("LocalSystem should be authorized")
 	}
-	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1001", IsBuiltinAdminMember: true}, "S-1-5-21-1000") {
+	if !windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1001", IsBuiltinAdminMember: true}, policy) {
 		t.Fatalf("enabled builtin administrator member should be authorized")
 	}
-	if windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1001"}, "S-1-5-21-1000") {
+	if windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1001"}, policy) {
 		t.Fatalf("untrusted different user SID should be rejected")
+	}
+	strictPolicy := windowsNamedPipeAccessPolicy{AllowedUserSIDs: []string{"S-1-5-21-1000"}}
+	if windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-18", IsLocalSystem: true}, strictPolicy) {
+		t.Fatalf("strict policy should reject LocalSystem when not allowed")
+	}
+	if windowsNamedPipeClientAuthorized(windowsClientIdentity{UserSID: "S-1-5-21-1001", IsBuiltinAdminMember: true}, strictPolicy) {
+		t.Fatalf("strict policy should reject administrators when not allowed")
 	}
 }
 
@@ -34,8 +46,13 @@ func TestWindowsNamedPipeSecurityDescriptorContainsCurrentUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sddl := windowsNamedPipeSecurityDescriptor(sid)
-	for _, want := range []string{"D:P", "SY", "BA", sid} {
+	policy := windowsNamedPipeAccessPolicyWithServerSID(windowsNamedPipeAccessPolicy{
+		AllowedUserSIDs:    []string{"S-1-5-80-12345", sid},
+		AllowLocalSystem:   true,
+		AllowBuiltinAdmins: true,
+	}, sid)
+	sddl := windowsNamedPipeSecurityDescriptor(policy)
+	for _, want := range []string{"D:P", "SY", "BA", sid, "S-1-5-80-12345"} {
 		if !strings.Contains(sddl, want) {
 			t.Fatalf("security descriptor %q missing %q", sddl, want)
 		}
@@ -147,7 +164,7 @@ func TestAuthorizeWindowsNamedPipeConnRejectsNonPipeConn(t *testing.T) {
 	server, client := net.Pipe()
 	defer server.Close()
 	defer client.Close()
-	if _, err := authorizeWindowsNamedPipeConn(server, "S-1-5-21-1000"); err == nil {
+	if _, err := authorizeWindowsNamedPipeConn(server, windowsNamedPipeAccessPolicy{AllowedUserSIDs: []string{"S-1-5-21-1000"}}); err == nil {
 		t.Fatalf("expected non-pipe connection rejection")
 	}
 }

--- a/cmd/secretsbroker/transport_listen_windows.go
+++ b/cmd/secretsbroker/transport_listen_windows.go
@@ -20,15 +20,16 @@ func listenForTransport(binding serveTransportBinding) (net.Listener, func(), er
 		if err != nil {
 			return nil, func() {}, err
 		}
+		policy := windowsNamedPipeAccessPolicyWithServerSID(binding.WindowsNamedPipeAccessPolicy, userSID)
 		ln, err := winio.ListenPipe(binding.Address, &winio.PipeConfig{
-			SecurityDescriptor: windowsNamedPipeSecurityDescriptor(userSID),
+			SecurityDescriptor: windowsNamedPipeSecurityDescriptor(policy),
 			InputBufferSize:    65536,
 			OutputBufferSize:   65536,
 		})
 		if err != nil {
 			return nil, func() {}, err
 		}
-		authenticated := authenticatedWindowsNamedPipeListener(ln, userSID)
+		authenticated := authenticatedWindowsNamedPipeListener(ln, policy)
 		return authenticated, func() { _ = authenticated.Close() }, nil
 	default:
 		return nil, func() {}, errUnsupportedTransport(binding.Kind)

--- a/docs/local-api-bootstrap-contract.md
+++ b/docs/local-api-bootstrap-contract.md
@@ -31,7 +31,7 @@ Development/bootstrap compatibility transport:
 
 - loopback HTTP bound to `127.0.0.1`
 
-The daemon exposes loopback HTTP for development/bootstrap and now has explicit transport selection for production mode. Production mode rejects loopback HTTP and selects the OS IPC transport with `--transport auto`; Unix-like platforms can serve over a Unix socket with same-UID peer credential checks, while Windows can serve over a named pipe with a restricted security descriptor and connected-client token identity checks. Named pipe/Unix socket transports preserve the same request/response schema. See `docs/os-authenticated-ipc-transport.md`.
+The daemon exposes loopback HTTP for development/bootstrap and now has explicit transport selection for production mode. Production mode rejects loopback HTTP and selects the OS IPC transport with `--transport auto`; Unix-like platforms can serve over a Unix socket with same-UID peer credential checks, while Windows can serve over a named pipe with a restricted security descriptor and connected-client token identity checks. Windows named-pipe profiles can add explicit launcher/service-account SIDs and can separately allow or deny Local Administrators and LocalSystem. Named pipe/Unix socket transports preserve the same request/response schema. See `docs/os-authenticated-ipc-transport.md`.
 
 ## Cross-cutting response rules
 

--- a/docs/local-api-security.md
+++ b/docs/local-api-security.md
@@ -229,7 +229,7 @@ Preferred transports:
 - Unix socket with filesystem permissions and peer credential checks where available
 - loopback HTTP only for development/bootstrap compatibility
 
-The #31 IPC foundation is implemented as an explicit transport policy. `secretsbroker serve` accepts `--mode`, `--transport`, `--unix-socket`, and `--named-pipe`; production mode rejects loopback HTTP rather than falling back silently. Unix sockets enforce same-UID peer credentials where supported, and Windows named pipes use a restricted security descriptor plus connected-client token checks before HTTP handling. See `docs/os-authenticated-ipc-transport.md` for the current supported behavior and remaining launcher-policy hardening.
+The #31 IPC foundation is implemented as an explicit transport policy. `secretsbroker serve` accepts `--mode`, `--transport`, `--unix-socket`, and `--named-pipe`; production mode rejects loopback HTTP rather than falling back silently. Unix sockets enforce same-UID peer credentials where supported, and Windows named pipes use a restricted security descriptor plus connected-client token checks before HTTP handling. Windows named-pipe access can now include explicit launcher/service-account SIDs with `--named-pipe-allowed-sid` or `SECRETSBROKER_NAMED_PIPE_ALLOWED_SIDS`, and production profiles can separately disable Local Administrators or LocalSystem access once the launcher identity is stable. See `docs/os-authenticated-ipc-transport.md` for the current supported behavior and remaining launcher-policy hardening.
 
 Planned session model:
 

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -30,6 +30,9 @@ SECRETSBROKER_TRANSPORT=auto|loopback-http|unix-socket|windows-named-pipe
 SECRETSBROKER_LISTEN=127.0.0.1:17890
 SECRETSBROKER_UNIX_SOCKET=/tmp/service-lasso-secretsbroker.sock
 SECRETSBROKER_NAMED_PIPE=\\.\pipe\service-lasso-secretsbroker
+SECRETSBROKER_NAMED_PIPE_ALLOWED_SIDS=S-1-5-80-...
+SECRETSBROKER_NAMED_PIPE_ALLOW_ADMIN=true|false
+SECRETSBROKER_NAMED_PIPE_ALLOW_LOCAL_SYSTEM=true|false
 ```
 
 Implemented behavior:
@@ -51,15 +54,21 @@ The broker must not silently fall back to loopback HTTP in production mode. If t
 Current Windows named-pipe support:
 
 - The pipe path must be under `\\.\pipe\`.
-- The pipe security descriptor limits access to the broker user SID, local administrators, and LocalSystem.
-- The listener identifies the connected client process with `GetNamedPipeClientProcessId`, inspects the client process token, and accepts only the same user SID, LocalSystem, or an enabled local Administrators group membership.
+- The pipe security descriptor limits access to the broker user SID, explicitly configured service-account SIDs, and optionally local administrators and LocalSystem.
+- The listener identifies the connected client process with `GetNamedPipeClientProcessId`, inspects the client process token, and accepts only the broker user SID, configured service-account SIDs, LocalSystem when allowed, or an enabled local Administrators group membership when allowed.
 - Connections that cannot be identified or authorized are closed before the HTTP server sees the request.
 - Identity metadata must be safe: no access tokens, environment values, command lines, or raw credentials in responses, logs, or audit events.
 - Secret-bearing endpoints still require the existing local API token/session/launch-identity checks on top of the named-pipe boundary. When a launch identity lease includes `transportBinding`, the request is denied unless the authenticated pipe peer matches that signed binding.
 
+Windows service-account policy:
+
+- `--named-pipe-allowed-sid` is repeatable and adds explicit service-account or launcher user SIDs to the named-pipe ACL and runtime authorization allowlist. `SECRETSBROKER_NAMED_PIPE_ALLOWED_SIDS` accepts a comma-separated list for service managers that prefer environment configuration.
+- `--named-pipe-allow-admin` / `SECRETSBROKER_NAMED_PIPE_ALLOW_ADMIN` controls whether enabled local Administrators group members can connect. The default is `true` for compatibility with existing local administrator launch flows; production profiles can set it to `false` once the launcher runs under a stable service account.
+- `--named-pipe-allow-local-system` / `SECRETSBROKER_NAMED_PIPE_ALLOW_LOCAL_SYSTEM` controls whether LocalSystem can connect. The default is `true` for service-manager compatibility; production profiles can set it to `false` when LocalSystem is not the launcher identity.
+- The Service Lasso core launcher should eventually issue transport-bound launch identity leases only after the selected launcher account SID is known and present in this policy. Until then, leases without `transportBinding` remain compatible and are still scoped by token/session/lease policy.
+
 Remaining hardening:
 
-- Define the final Service Lasso launcher policy for administrator and service-account access.
 - Add cross-user denial evidence in an integration environment that can create a second local Windows principal.
 - Extend launcher-issued leases to include `transportBinding` by default once the core launcher has a stable broker transport identity policy.
 


### PR DESCRIPTION
## Issue

Advances #31

## Summary

- Adds explicit Windows named-pipe access policy configuration for launcher/service-account SIDs.
- Adds compatibility-preserving admin and LocalSystem allow toggles for production profiles.
- Carries the access policy into the named-pipe ACL and runtime peer authorization path.
- Updates IPC/local API docs and capabilities to describe the service-account policy slice.

## Scope

- In scope: Windows named-pipe ACL/authorization policy shape and docs for stable launcher/service-account access.
- Out of scope: cross-user denial integration evidence, core launcher default `transportBinding` issuance, and release/demo pinning after merge.

## Spec / contract / fixture impact

- Updated: `docs/os-authenticated-ipc-transport.md`, `docs/local-api-security.md`, `docs/local-api-bootstrap-contract.md`, `README.md`.
- Contract stays backward compatible: broker process SID is still allowed; local Administrators and LocalSystem remain enabled by default unless production profile toggles disable them.

## Validation

- PASS `go test ./cmd/secretsbroker -count=1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/go-test-cmd-secretsbroker.log`
- PASS `go test ./... -count=1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/go-test-all.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/scripts-test-ps1.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/go-build-commands.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/git-diff-check.log`
- PASS `GOOS=linux GOARCH=amd64 go test -c ./cmd/secretsbroker` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/go-test-compile-linux-amd64.log`
- PASS `GOOS=darwin GOARCH=amd64 go test -c ./cmd/secretsbroker` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/20260626-140051/issue-31-named-pipe-access-policy/go-test-compile-darwin-amd64.log`
- PASS canonical preflight health: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail

- Required: normal repository PR checks/review gates.
- Evidence: pending hosted checks on this PR.

## Cleanup

- Branch: `agent/issue-31-named-pipe-access-policy`
- Commit: `cd5f89c`
- Release/demo gate is not complete yet. If/when merged, publish/release `lasso-secretsbroker`, pin the exact release in `service-lasso/service-lasso`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and prove expected vs installed/live tag match before claiming done.