### PR TITLE
feat: add broker request latency telemetry

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -49,6 +49,7 @@ type localBackend struct {
 	now                      func() time.Time
 	lockouts                 *lockoutStore
 	campaigns                map[string]bulkCampaignResponse
+	telemetry                *telemetryRequestRecorder
 	launchIdentitySigningKey string
 	launchLeaseMu            sync.Mutex
 	seenLaunchLeaseJTI       map[string]time.Time
@@ -227,7 +228,7 @@ type auditEvent struct {
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
-	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, seenLaunchLeaseJTI: map[string]time.Time{}}
+	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, telemetry: newTelemetryRequestRecorder(50), seenLaunchLeaseJTI: map[string]time.Time{}}
 	backend.lockouts = newLockoutStore(func() time.Time {
 		if backend.now == nil {
 			return time.Now().UTC()

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -458,8 +458,13 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerLockoutManagementHandlers(mux, backend, security)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
 		applyTelemetryResponseHeaders(w, r)
-		mux.ServeHTTP(w, r)
+		recorder := &telemetryStatusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		mux.ServeHTTP(recorder, r)
+		if backend != nil {
+			recordTelemetryHTTPRequest(backend.telemetry, r, recorder.statusCode, time.Since(started))
+		}
 	})
 }
 

--- a/cmd/secretsbroker/telemetry.go
+++ b/cmd/secretsbroker/telemetry.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -167,6 +168,23 @@ type telemetryDurationHistogram struct {
 	Buckets   map[string]int `json:"buckets"`
 }
 
+type telemetryRequestSummary struct {
+	RouteTemplate string `json:"routeTemplate"`
+	RouteGroup    string `json:"routeGroup"`
+	Method        string `json:"method"`
+	StatusClass   string `json:"statusClass"`
+	Outcome       string `json:"outcome"`
+	DurationMs    int    `json:"durationMs"`
+	Mutating      bool   `json:"mutating"`
+}
+
+type telemetryRequestRecorder struct {
+	mu           sync.Mutex
+	capacity     int
+	requests     []telemetryRequestSummary
+	droppedCount int
+}
+
 type telemetrySignalPreview struct {
 	Kind          string         `json:"kind"`
 	Name          string         `json:"name"`
@@ -180,6 +198,37 @@ type telemetrySignalPreview struct {
 type telemetrySafety struct {
 	LowCardinalityLabels  bool `json:"lowCardinalityLabels"`
 	ValueMaterialIncluded bool `json:"valueMaterialIncluded"`
+}
+
+func newTelemetryRequestRecorder(capacity int) *telemetryRequestRecorder {
+	if capacity < 1 {
+		capacity = 50
+	}
+	return &telemetryRequestRecorder{capacity: capacity}
+}
+
+func (r *telemetryRequestRecorder) record(request telemetryRequestSummary) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.requests) >= r.capacity {
+		copy(r.requests, r.requests[1:])
+		r.requests[len(r.requests)-1] = request
+		r.droppedCount++
+		return
+	}
+	r.requests = append(r.requests, request)
+}
+
+func (r *telemetryRequestRecorder) snapshot() ([]telemetryRequestSummary, int) {
+	if r == nil {
+		return nil, 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]telemetryRequestSummary(nil), r.requests...), r.droppedCount
 }
 
 func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
@@ -214,7 +263,13 @@ func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
 	res.Counters.AuditRecords = auditRecordCounters(audit.Events)
 	res.Counters.SourceStates = sourceStateCounters(defaultSourceRegistry(backend).Sources)
 	res.Counters.ProviderStates = providerStateCounters(backend.providerConfigStatusResponse().Providers)
+	var requests []telemetryRequestSummary
+	if backend.telemetry != nil {
+		requests, _ = backend.telemetry.snapshot()
+	}
+	res.DurationHistograms = requestDurationHistograms(requests)
 	res.Signals = buildTelemetrySignals(res.Counters)
+	res.Signals = append(res.Signals, buildRequestDurationSignals(requests)...)
 	res.ExportPreview = telemetryExportPreviewFromEnv(res.Exporter, len(res.Signals), res.Redaction)
 	return res, nil
 }
@@ -277,7 +332,11 @@ func auditOperationCounters(events []auditEvent) []telemetryOperationCounter {
 		event = normalizeAuditEvent(event)
 		counts[event.Operation+"\x00"+event.Outcome]++
 	}
-	keys := sortedKeys(counts)
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 	out := make([]telemetryOperationCounter, 0, len(keys))
 	for _, key := range keys {
 		operation, outcome := splitCounterKey(key)
@@ -294,7 +353,11 @@ func policyDecisionCounters(events []auditEvent) []telemetryOutcomeCounter {
 			counts[event.Outcome]++
 		}
 	}
-	keys := sortedKeys(counts)
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 	out := make([]telemetryOutcomeCounter, 0, len(keys))
 	for _, key := range keys {
 		out = append(out, telemetryOutcomeCounter{Outcome: key, Count: counts[key]})
@@ -380,9 +443,16 @@ func secretsBrokerTelemetryAttributePolicy() telemetryAttributePolicy {
 		RedactedValue: "[REDACTED]",
 		AllowedAttributes: []string{
 			"broker.audit.status",
+			"broker.api.duration_bucket",
+			"broker.api.method",
+			"broker.api.mutating",
+			"broker.api.route",
+			"broker.api.route_group",
+			"broker.api.status_class",
 			"broker.lockout.active_count",
 			"broker.operation",
 			"broker.operation.count",
+			"broker.operation.duration_ms",
 			"broker.operation.outcome",
 			"broker.policy.outcome",
 			"broker.provider.id",
@@ -402,6 +472,7 @@ func secretsBrokerTelemetryAttributePolicy() telemetryAttributePolicy {
 			"cookies and authorization headers",
 			"signing key material and recovery material",
 			"raw request or response bodies",
+			"raw URL paths and query strings",
 			"environment values",
 			"provider response bodies",
 			"raw refs and raw config values",
@@ -652,6 +723,59 @@ func buildTelemetrySignals(counters telemetryCounters) []telemetrySignalPreview 
 	return signals
 }
 
+func requestDurationHistograms(requests []telemetryRequestSummary) []telemetryDurationHistogram {
+	counts := map[string]map[string]int{}
+	for _, request := range requests {
+		key := request.RouteTemplate + "\x00" + request.Outcome
+		if counts[key] == nil {
+			counts[key] = map[string]int{}
+		}
+		counts[key][telemetryDurationBucket(request.DurationMs)]++
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]telemetryDurationHistogram, 0, len(keys))
+	for _, key := range keys {
+		operation, outcome := splitCounterKey(key)
+		out = append(out, telemetryDurationHistogram{Operation: operation, Outcome: outcome, Buckets: counts[key]})
+	}
+	return out
+}
+
+func buildRequestDurationSignals(requests []telemetryRequestSummary) []telemetrySignalPreview {
+	counts := map[string]int{}
+	exemplars := map[string]telemetryRequestSummary{}
+	for _, request := range requests {
+		bucket := telemetryDurationBucket(request.DurationMs)
+		key := request.RouteTemplate + "\x00" + request.RouteGroup + "\x00" + request.Method + "\x00" + request.StatusClass + "\x00" + request.Outcome + "\x00" + bucket + "\x00" + fmt.Sprint(request.Mutating)
+		counts[key]++
+		exemplars[key] = request
+	}
+	keys := sortedKeys(counts)
+	out := make([]telemetrySignalPreview, 0, len(keys))
+	for _, key := range keys {
+		parts := strings.Split(key, "\x00")
+		if len(parts) != 7 {
+			continue
+		}
+		request := exemplars[key]
+		out = append(out, telemetrySignal("metric", "secretsbroker.api.request.duration_bucket", map[string]any{
+			"broker.api.route":           parts[0],
+			"broker.api.route_group":     parts[1],
+			"broker.api.method":          parts[2],
+			"broker.api.status_class":    parts[3],
+			"broker.operation.outcome":   parts[4],
+			"broker.api.duration_bucket": parts[5],
+			"broker.api.mutating":        request.Mutating,
+			"broker.operation.count":     counts[key],
+		}))
+	}
+	return out
+}
+
 func telemetrySignal(kind string, name string, attrs map[string]any) telemetrySignalPreview {
 	traceID := telemetryHash("trace:"+name, 32)
 	spanID := telemetryHash("span:"+name, 16)
@@ -714,6 +838,169 @@ func applyTelemetryResponseHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(telemetryCorrelationIDHeader, identity.CorrelationID)
 	w.Header().Set(telemetryTraceIDHeader, identity.TraceID)
 	w.Header().Set(telemetryTraceparentHeader, identity.Traceparent)
+}
+
+type telemetryStatusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *telemetryStatusRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}
+
+func recordTelemetryHTTPRequest(recorder *telemetryRequestRecorder, r *http.Request, statusCode int, duration time.Duration) {
+	if recorder == nil || r == nil {
+		return
+	}
+	method := strings.ToUpper(strings.TrimSpace(r.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	routeTemplate := telemetryRouteTemplate(r.URL.Path)
+	recorder.record(telemetryRequestSummary{
+		RouteTemplate: routeTemplate,
+		RouteGroup:    telemetryRouteGroup(routeTemplate),
+		Method:        method,
+		StatusClass:   telemetryStatusClass(statusCode),
+		Outcome:       telemetryRequestOutcome(statusCode),
+		DurationMs:    max(0, int(duration.Milliseconds())),
+		Mutating:      telemetryMutatingMethod(method),
+	})
+}
+
+func telemetryRouteTemplate(path string) string {
+	switch strings.TrimSpace(path) {
+	case "/health":
+		return "/health"
+	case "/ready":
+		return "/ready"
+	case "/status":
+		return "/status"
+	case "/state":
+		return "/state"
+	case "/capabilities":
+		return "/capabilities"
+	case "/v1/secrets":
+		return "/v1/secrets"
+	case "/v1/writeback":
+		return "/v1/writeback"
+	case "/v1/resolve":
+		return "/v1/resolve"
+	case "/v1/sources/status":
+		return "/v1/sources/status"
+	case "/v1/providers/capabilities":
+		return "/v1/providers/capabilities"
+	case "/v1/providers/config/status":
+		return "/v1/providers/config/status"
+	case "/v1/providers/config/validate":
+		return "/v1/providers/config/validate"
+	case "/v1/providers/config/apply":
+		return "/v1/providers/config/apply"
+	case "/v1/providers/migration/dry-run":
+		return "/v1/providers/migration/dry-run"
+	case "/v1/providers/migration/apply":
+		return "/v1/providers/migration/apply"
+	case "/v1/telemetry":
+		return "/v1/telemetry"
+	case "/v1/telemetry/export":
+		return "/v1/telemetry/export"
+	case "/v1/events":
+		return "/v1/events"
+	case "/v1/recovery/policy":
+		return "/v1/recovery/policy"
+	case "/v1/management/lockouts/clear":
+		return "/v1/management/lockouts/clear"
+	case "/v1/management/secrets":
+		return "/v1/management/secrets"
+	case "/v1/management/secrets/value-search":
+		return "/v1/management/secrets/value-search"
+	case "/v1/management/secrets/reveal":
+		return "/v1/management/secrets/reveal"
+	case "/v1/management/secrets/edit/dry-run":
+		return "/v1/management/secrets/edit/dry-run"
+	case "/v1/management/secrets/edit/apply":
+		return "/v1/management/secrets/edit/apply"
+	case "/v1/management/secrets/reset/dry-run":
+		return "/v1/management/secrets/reset/dry-run"
+	case "/v1/management/secrets/reset/apply":
+		return "/v1/management/secrets/reset/apply"
+	case "/v1/management/secrets/rotation/dry-run":
+		return "/v1/management/secrets/rotation/dry-run"
+	case "/v1/management/secrets/campaigns/create":
+		return "/v1/management/secrets/campaigns/create"
+	case "/v1/management/secrets/campaigns/revalidate":
+		return "/v1/management/secrets/campaigns/revalidate"
+	case "/v1/management/secrets/campaigns/apply":
+		return "/v1/management/secrets/campaigns/apply"
+	case "/v1/management/secrets/campaigns/status":
+		return "/v1/management/secrets/campaigns/status"
+	case "/v1/management/secrets/sync/dry-run":
+		return "/v1/management/secrets/sync/dry-run"
+	case "/v1/management/secrets/policy/preview":
+		return "/v1/management/secrets/policy/preview"
+	case "/v1/management/secrets/policy/apply":
+		return "/v1/management/secrets/policy/apply"
+	default:
+		return "/unmatched"
+	}
+}
+
+func telemetryRouteGroup(routeTemplate string) string {
+	trimmed := strings.Trim(routeTemplate, "/")
+	if trimmed == "" {
+		return "root"
+	}
+	parts := strings.Split(trimmed, "/")
+	if parts[0] == "v1" && len(parts) > 1 {
+		return parts[1]
+	}
+	return parts[0]
+}
+
+func telemetryStatusClass(statusCode int) string {
+	if statusCode < 100 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%dxx", statusCode/100)
+}
+
+func telemetryRequestOutcome(statusCode int) string {
+	switch {
+	case statusCode >= 200 && statusCode < 300:
+		return "ready"
+	case statusCode >= 300 && statusCode < 400:
+		return "redirect"
+	case statusCode >= 400 && statusCode < 500:
+		return "client_error"
+	case statusCode >= 500:
+		return "server_error"
+	default:
+		return "unknown"
+	}
+}
+
+func telemetryMutatingMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func telemetryDurationBucket(durationMs int) string {
+	switch {
+	case durationMs < 50:
+		return "lt_50ms"
+	case durationMs < 250:
+		return "50_249ms"
+	case durationMs < 1000:
+		return "250_999ms"
+	default:
+		return "1s_plus"
+	}
 }
 
 func telemetryHash(value string, length int) string {

--- a/cmd/secretsbroker/telemetry_test.go
+++ b/cmd/secretsbroker/telemetry_test.go
@@ -113,6 +113,71 @@ func TestTelemetryEndpointAndAdminCLIAreMetadataOnly(t *testing.T) {
 	}
 }
 
+func TestTelemetryRecordsHTTPRequestLatencyBucketsWithoutRawRouteMaterial(t *testing.T) {
+	backend := testBackend(t)
+	server := httptest.NewServer(newHandler(runtimeState{}, backend, localAPISecurity{token: "local-token"}))
+	defer server.Close()
+
+	sentinelPath := "SERVICE_LASSO_FAKE_OTEL_PATH_SECRET_DO_NOT_USE"
+	healthResp, err := http.Get(server.URL + "/health?token=" + sentinelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	healthResp.Body.Close()
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("health status = %d", healthResp.StatusCode)
+	}
+	missingResp, err := http.Get(server.URL + "/v1/unknown/" + sentinelPath + "?credential=" + sentinelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingResp.Body.Close()
+	if missingResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing route status = %d", missingResp.StatusCode)
+	}
+
+	resp, err := http.Get(server.URL + "/v1/telemetry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("telemetry status = %d", resp.StatusCode)
+	}
+	var body telemetryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, sentinelPath)
+	if len(body.DurationHistograms) == 0 {
+		t.Fatalf("missing duration histograms: %#v", body)
+	}
+	if !hasDurationHistogram(body.DurationHistograms, "/health", "ready") {
+		t.Fatalf("missing health duration histogram: %#v", body.DurationHistograms)
+	}
+	if !hasDurationHistogram(body.DurationHistograms, "/unmatched", "client_error") {
+		t.Fatalf("missing sanitized unmatched duration histogram: %#v", body.DurationHistograms)
+	}
+	if !hasSignal(body.Signals, "secretsbroker.api.request.duration_bucket") {
+		t.Fatalf("missing API request duration signal: %#v", body.Signals)
+	}
+	allowed := map[string]bool{}
+	for _, key := range body.Redaction.AllowedAttributes {
+		allowed[key] = true
+	}
+	for _, signal := range body.Signals {
+		for key := range signal.Attributes {
+			if !allowed[key] {
+				t.Fatalf("signal used non-allowlisted attribute %q in %#v", key, signal)
+			}
+		}
+	}
+}
+
 func TestTelemetryOTelPreviewIsDryRunAndRedacted(t *testing.T) {
 	t.Setenv("SECRETSBROKER_OTEL_ENABLED", "1")
 	t.Setenv("SECRETSBROKER_OTEL_EXPORT_MODE", "dry-run")
@@ -313,6 +378,15 @@ func hasOperationCount(counters []telemetryOperationCounter, operation, outcome 
 func hasSignal(signals []telemetrySignalPreview, name string) bool {
 	for _, signal := range signals {
 		if signal.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDurationHistogram(histograms []telemetryDurationHistogram, operation, outcome string) bool {
+	for _, histogram := range histograms {
+		if histogram.Operation == operation && histogram.Outcome == outcome && len(histogram.Buckets) > 0 {
 			return true
 		}
 	}

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -146,6 +146,14 @@ Implemented OTLP export-action slice:
 - Responses report safe proof only: mode, status, protocol, content type, signal count, exporter status code, configured booleans, and non-return booleans for endpoint/header/body values.
 - Endpoint values, OTLP header values, exported payload bodies, raw refs, secret values, provider credentials, tokens, cookies, private keys, recovery material, environment values, raw URL paths/query strings, raw request/response bodies, provider response bodies, and raw config values remain omitted from responses and the export payload.
 
+Implemented API request latency slice:
+
+- The HTTP server records a bounded in-memory view of recent broker API requests and folds it into `GET /v1/telemetry` as `durationHistograms` plus OTEL-shaped `secretsbroker.api.request.duration_bucket` metric signals.
+- Route labels are template-only and low-cardinality. Known routes such as `/health`, `/v1/resolve`, and `/v1/management/secrets/reveal` may appear; unmatched routes are collapsed to `/unmatched`.
+- Latency uses fixed bucket labels: `lt_50ms`, `50_249ms`, `250_999ms`, and `1s_plus`.
+- The request telemetry may expose method, route template, route group, status class, outcome, mutating flag, bucket, and count.
+- Raw URL paths, query strings, route parameters, headers, request bodies, response bodies, tokens, refs, provider credentials, environment values, and secret-shaped values are not stored in request telemetry, duration histograms, signals, export previews, or export payloads.
+
 ## Events and filtering
 
 Events represent operator-relevant state transitions and decisions. The broker should maintain a bounded recent event store and expose filtered reads.


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Add bounded in-memory broker HTTP request latency telemetry.
- Emit template-only `durationHistograms` and OTEL-shaped `secretsbroker.api.request.duration_bucket` metric signals from `GET /v1/telemetry`.
- Document the request-latency telemetry safety contract.

## Scope
- In scope: safe route templates, route groups, methods, status classes, outcomes, mutating flags, latency buckets, and counts.
- Out of scope: raw paths/query strings/headers/bodies, exact timing streams, persistent telemetry storage, and service manifest pinning before merge/release.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md`.
- Tests updated for the telemetry contract and redaction behavior.

## Service Lasso invariant impact
- Invariant: telemetry remains metadata-only and low-cardinality.
- Preservation proof: unmatched routes collapse to `/unmatched`, known labels are route templates only, and regression tests assert fake secret path/query material is absent from telemetry output.

## Validation
- PASS `go test ./cmd/secretsbroker -run Telemetry -count=1` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-broker-request-latency/go-test-telemetry.log`
- PASS `go test ./...` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-broker-request-latency/go-test-all.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-broker-request-latency/git-diff-check.log`
- PASS `.\scripts\package.ps1` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-broker-request-latency/package-ps1.log`
- BLOCKED `.\scripts\verify.ps1` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-broker-request-latency/verify-ps1.log`; local `service-lasso-harness` binary is not installed/on PATH.

## Release / demo gate
- Pending. `lasso-secretsbroker` is demo-consumed, so after this PR merges and releases, core must pin the exact new release, merge the core pin PR, recycle the canonical demo on port `17883`, and run `npm run demo:verify-canonical` before #635 can claim this slice demo-current.

## Approval trail
- Required: repo rules / hosted checks.
- Evidence: pending GitHub checks on this PR.

## Cleanup
- Branch cleanup after merge/release/pin/demo verification.