### PR TITLE
feat: report active lockouts in broker telemetry

### DIFF
--- a/cmd/secretsbroker/lockout.go
+++ b/cmd/secretsbroker/lockout.go
@@ -113,6 +113,27 @@ func (s *lockoutStore) clear(scope string) bool {
 	return existed
 }
 
+func (s *lockoutStore) activeCount() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	count := 0
+	for scope, entry := range s.entries {
+		if entry.ActiveUntil.After(now) {
+			count++
+			continue
+		}
+		if !entry.ActiveUntil.IsZero() {
+			delete(s.entries, scope)
+		}
+	}
+	return count
+}
+
 func (s *lockoutStore) activeLocked(scope string, now time.Time) lockoutDecision {
 	entry, ok := s.entries[scope]
 	if !ok {

--- a/cmd/secretsbroker/telemetry.go
+++ b/cmd/secretsbroker/telemetry.go
@@ -259,7 +259,7 @@ func buildTelemetryResponse(backend *localBackend) (telemetryResponse, error) {
 	res.Counters.Operations = auditOperationCounters(audit.Events)
 	res.Counters.PolicyDecisions = policyDecisionCounters(audit.Events)
 	res.Counters.LocalAPIAuthFailures = localAPIAuthFailureCount(audit.Events)
-	res.Counters.ActiveLockouts = 0
+	res.Counters.ActiveLockouts = backend.lockouts.activeCount()
 	res.Counters.AuditRecords = auditRecordCounters(audit.Events)
 	res.Counters.SourceStates = sourceStateCounters(defaultSourceRegistry(backend).Sources)
 	res.Counters.ProviderStates = providerStateCounters(backend.providerConfigStatusResponse().Providers)

--- a/cmd/secretsbroker/telemetry_test.go
+++ b/cmd/secretsbroker/telemetry_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 const telemetrySecretValue = "fixture-telemetry-secret-value"
@@ -51,6 +53,51 @@ func TestTelemetryCountsOperationalMetadataWithoutSecretMaterial(t *testing.T) {
 	}
 	if len(res.Counters.SourceStates) == 0 || len(res.Counters.ProviderStates) == 0 {
 		t.Fatalf("missing source/provider state counters: %#v", res.Counters)
+	}
+}
+
+func TestTelemetryCountsActiveLockoutsWithoutScopeMaterial(t *testing.T) {
+	backend := testBackend(t)
+	now := time.Date(2026, 6, 26, 13, 40, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: ref, Value: telemetrySecretValue}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 1; i <= localAPILockoutThreshold; i++ {
+		res, err := backend.managedEditApply(managedSecretActionRequest{RequestID: "req-lockout-telemetry", ServiceID: "@serviceadmin", Ref: ref, Value: "replacement-value"})
+		if i < localAPILockoutThreshold && !errors.Is(err, errPolicyDenied) {
+			t.Fatalf("attempt %d err=%v res=%#v", i, err, res)
+		}
+		if i == localAPILockoutThreshold && !errors.Is(err, errLockoutActive) {
+			t.Fatalf("lockout attempt err=%v res=%#v", err, res)
+		}
+	}
+
+	res, err := buildTelemetryResponse(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, encoded, telemetrySecretValue, "replacement-value", ref, "management:edit:@serviceadmin:"+ref)
+	if res.Counters.ActiveLockouts != 1 {
+		t.Fatalf("activeLockouts = %d, want 1", res.Counters.ActiveLockouts)
+	}
+	if !hasLockoutActiveSignal(res.Signals, 1) {
+		t.Fatalf("missing active lockout signal count: %#v", res.Signals)
+	}
+
+	now = now.Add(localAPILockoutCooldown + time.Second)
+	res, err = buildTelemetryResponse(backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Counters.ActiveLockouts != 0 || !hasLockoutActiveSignal(res.Signals, 0) {
+		t.Fatalf("expired lockout should not remain active: counters=%#v signals=%#v", res.Counters, res.Signals)
 	}
 }
 
@@ -380,6 +427,17 @@ func hasSignal(signals []telemetrySignalPreview, name string) bool {
 		if signal.Name == name {
 			return true
 		}
+	}
+	return false
+}
+
+func hasLockoutActiveSignal(signals []telemetrySignalPreview, count int) bool {
+	for _, signal := range signals {
+		if signal.Name != "secretsbroker.lockout.active" {
+			continue
+		}
+		value, ok := signal.Attributes["broker.lockout.active_count"].(int)
+		return ok && value == count
 	}
 	return false
 }

--- a/docs/operational-controls-baseline.md
+++ b/docs/operational-controls-baseline.md
@@ -154,6 +154,12 @@ Implemented API request latency slice:
 - The request telemetry may expose method, route template, route group, status class, outcome, mutating flag, bucket, and count.
 - Raw URL paths, query strings, route parameters, headers, request bodies, response bodies, tokens, refs, provider credentials, environment values, and secret-shaped values are not stored in request telemetry, duration histograms, signals, export previews, or export payloads.
 
+Implemented active-lockout telemetry slice:
+
+- `GET /v1/telemetry` now wires `counters.activeLockouts` and the OTEL-shaped `secretsbroker.lockout.active` signal to the broker lockout store instead of returning a static zero.
+- The lockout metric is aggregate-only. It may expose the active lockout count but not lockout scopes, raw refs, client addresses, presented tokens, expected tokens, reasons, request bodies, or secret values.
+- Expired lockouts are pruned before counting so the telemetry value reflects currently active cooldowns only.
+
 ## Events and filtering
 
 Events represent operator-relevant state transitions and decisions. The broker should maintain a bounded recent event store and expose filtered reads.


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Wire Secrets Broker telemetry `counters.activeLockouts` to the broker lockout store instead of returning a static zero.
- Keep the OTEL-shaped `secretsbroker.lockout.active` signal aggregate-only and low-cardinality.
- Prune expired lockout entries while counting so telemetry reflects current active cooldowns.
- Document the active-lockout telemetry safety boundary.

## Scope
- In scope: aggregate active lockout count for broker management/writeback lockouts and regression coverage for metadata-only output.
- Out of scope: exposing individual lockout scopes, local API client addresses, retry windows, raw refs, request material, or Service Admin UI changes.

## Spec / contract / fixture impact
- Updated: `docs/operational-controls-baseline.md` to record the active-lockout telemetry slice.
- Contract remains metadata-only: aggregate count only; no scope/ref/token/request values.

## Nash invariant impact
- Invariant: telemetry must never expose raw values, tokens, provider credentials, raw refs, request/response bodies, or high-cardinality lockout scopes.
- Preservation proof: the new test asserts active lockout telemetry omits the raw ref, lockout scope, replacement value, and secret value while still reporting count `1`.

## Validation
- PASS `go test ./cmd/secretsbroker -run Telemetry -count=1` — `.work-agent/logs/cron-755b8bea-20260626T232632+1000/issue-635-active-lockout-telemetry/go-test-telemetry.log`
- PASS `go test ./...` — `.work-agent/logs/cron-755b8bea-20260626T232632+1000/issue-635-active-lockout-telemetry/go-test-all.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/cron-755b8bea-20260626T232632+1000/issue-635-active-lockout-telemetry/go-build-commands.log`
- PASS `.\scripts\package.ps1` — `.work-agent/logs/cron-755b8bea-20260626T232632+1000/issue-635-active-lockout-telemetry/package-ps1.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260626T232632+1000/issue-635-active-lockout-telemetry/git-diff-check.log`

## Approval trail
- Required: normal repository PR/check gates.
- Evidence: hosted checks pending at PR creation.

## Cleanup
- Release-to-demo gate is pending because this is a demo-consumed service repo. After merge, publish/release `lasso-secretsbroker`, update the core `@secretsbroker` pin to the exact release tag/commit, merge the core pin PR when allowed, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected vs installed/live tag before claiming demo-current.