### PR TITLE
fix: align IPC transport capabilities

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -219,7 +219,7 @@ func defaultCapabilities() CapabilitiesResponse {
 		ServiceID:  serviceID,
 		APIVersion: apiVersion,
 		Version:    version,
-		Transports: []string{"loopback-http"},
+		Transports: []string{"loopback-http", "unix-socket", "windows-named-pipe"},
 		Endpoints: []string{
 			"GET /health",
 			"GET /ready",

--- a/cmd/secretsbroker/main_test.go
+++ b/cmd/secretsbroker/main_test.go
@@ -38,6 +38,9 @@ func TestCapabilitiesExposeBootstrapContract(t *testing.T) {
 	}
 	assertContains(t, caps.Endpoints, "GET /capabilities")
 	assertContains(t, caps.Endpoints, "GET /ready")
+	assertContains(t, caps.Transports, "loopback-http")
+	assertContains(t, caps.Transports, "unix-socket")
+	assertContains(t, caps.Transports, "windows-named-pipe")
 	assertContains(t, caps.Features, "readiness")
 	assertContains(t, caps.Features, "batched-resolve")
 	assertContains(t, caps.Features, "os-ipc-transport-policy")


### PR DESCRIPTION
## Issue
Advances #31

## Summary
- Advertise the implemented IPC transport surface in `/capabilities`.
- Extend the bootstrap capabilities contract test to assert `loopback-http`, `unix-socket`, and `windows-named-pipe`.

## Scope
- In scope: capability metadata alignment for already-implemented #31 IPC transports.
- Out of scope: true cross-user Windows denial integration evidence and final end-to-end signed lease/request enforcement beyond the existing unit coverage.

## Spec / contract / fixture impact
- Updated: API capability response contract via `defaultCapabilities()` and its test.
- Docs not changed because `docs/os-authenticated-ipc-transport.md` and README already describe these implemented transports.

## Nash invariant impact
- Invariant: production transport must not silently fall back to loopback HTTP.
- Preservation proof: this PR only changes advertised capabilities; existing production transport selection/fail-closed behavior is unchanged and covered by existing tests.

## Validation
- PASS `go test ./cmd/secretsbroker` — `.work-agent/logs/cron-755b8bea-20260627-004328/go-test-cmd-secretsbroker.log`
- PASS `go test ./...` — `.work-agent/logs/cron-755b8bea-20260627-004328/go-test-all.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/cron-755b8bea-20260627-004328/go-build-commands.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260627-004328/git-diff-check.log`
- PASS canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: normal repository PR review/merge rules.
- Evidence: opened as a focused PR for hosted checks and review.

## Cleanup
- Branch cleanup after merge.
- Release-to-demo gate is pending after merge/release because this repo is demo-consumed: publish/release `lasso-secretsbroker`, update the core `@secretsbroker` pin to the exact release/commit, recycle canonical demo on port `17883`, and run `npm run demo:verify-canonical` before any done claim.