### PR TITLE
test: cover transport-bound launch lease endpoints

### DIFF
--- a/cmd/secretsbroker/launch_identity_transport_test.go
+++ b/cmd/secretsbroker/launch_identity_transport_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -34,6 +38,90 @@ func TestLaunchIdentityLeaseTransportBinding(t *testing.T) {
 	if !errors.Is(err, errPolicyDenied) {
 		t.Fatalf("missing transport peer error = %v, want policy denied", err)
 	}
+}
+
+func TestHTTPResolveHonorsTransportBoundLaunchLease(t *testing.T) {
+	backend := testBackend(t)
+	backend.now = func() time.Time { return time.Date(2026, 5, 7, 0, 1, 0, 0, time.UTC) }
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: "services/api-service/runtime/API_TOKEN", Value: "transport-bound-secret"}); err != nil {
+		t.Fatal(err)
+	}
+	state := "ready"
+	handler := newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"})
+	peer := transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-1000"}
+
+	matchingLease := boundTestLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-http-transport-ok", peer)
+	matchingBody := []byte(`{"requestId":"req-transport-ok","serviceId":"api-service","identityLease":` + mustLeaseJSON(t, matchingLease) + `,"refs":["services/api-service/runtime/API_TOKEN"]}`)
+	res := serveTransportBoundRequest(t, handler, http.MethodPost, "/v1/resolve", "test-token", matchingBody, peer)
+	if res.Code != http.StatusOK {
+		t.Fatalf("matching transport-bound resolve status=%d body=%s", res.Code, res.Body.String())
+	}
+	var resolved resolveResponse
+	if err := json.NewDecoder(res.Body).Decode(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != "transport-bound-secret" {
+		t.Fatalf("matching transport-bound resolve = %#v", resolved)
+	}
+
+	mismatchedLease := boundTestLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-http-transport-mismatch", peer)
+	mismatchedBody := []byte(`{"requestId":"req-transport-mismatch","serviceId":"api-service","identityLease":` + mustLeaseJSON(t, mismatchedLease) + `,"refs":["services/api-service/runtime/API_TOKEN"]}`)
+	res = serveTransportBoundRequest(t, handler, http.MethodPost, "/v1/resolve", "test-token", mismatchedBody, transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-2000"})
+	if res.Code != http.StatusForbidden || !bytes.Contains(res.Body.Bytes(), []byte(`"code":"policy_denied"`)) {
+		t.Fatalf("mismatched transport-bound resolve status=%d body=%s", res.Code, res.Body.String())
+	}
+	assertNoSecretMaterial(t, res.Body.Bytes(), "transport-bound-secret", "test-token")
+
+	missingPeerLease := boundTestLaunchIdentityLease(t, backend, "api-service", []string{"services/api-service/*"}, nil, []string{"resolve"}, "jti-http-transport-missing-peer", peer)
+	missingPeerBody := []byte(`{"requestId":"req-transport-missing-peer","serviceId":"api-service","identityLease":` + mustLeaseJSON(t, missingPeerLease) + `,"refs":["services/api-service/runtime/API_TOKEN"]}`)
+	res = serveTransportBoundRequest(t, handler, http.MethodPost, "/v1/resolve", "test-token", missingPeerBody, transportPeerIdentity{})
+	if res.Code != http.StatusForbidden || !bytes.Contains(res.Body.Bytes(), []byte(`"code":"policy_denied"`)) {
+		t.Fatalf("missing-peer transport-bound resolve status=%d body=%s", res.Code, res.Body.String())
+	}
+	assertNoSecretMaterial(t, res.Body.Bytes(), "transport-bound-secret", "test-token")
+}
+
+func TestHTTPWritebackHonorsTransportBoundLaunchLease(t *testing.T) {
+	backend := testBackend(t)
+	backend.now = func() time.Time { return time.Date(2026, 5, 7, 0, 1, 0, 0, time.UTC) }
+	state := "ready"
+	handler := newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"})
+	peer := transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-1000"}
+
+	matchingLease := boundTestLaunchIdentityLease(t, backend, "api-service", nil, []string{"services/api-service"}, []string{"create"}, "jti-writeback-transport-ok", peer)
+	matchingBody := []byte(`{"requestId":"req-writeback-transport-ok","identity":{"serviceId":"api-service","expiresAt":"2026-05-07T00:05:00Z"},"identityLease":` + mustLeaseJSON(t, matchingLease) + `,"policy":{"allowedNamespaces":["services/api-service"],"allowedOperations":["create"]},"operation":"create","namespace":"services/api-service","ref":"runtime/API_TOKEN","value":"transport-writeback-secret"}`)
+	res := serveTransportBoundRequest(t, handler, http.MethodPost, "/v1/writeback", "test-token", matchingBody, peer)
+	if res.Code != http.StatusOK || !bytes.Contains(res.Body.Bytes(), []byte(`"outcome":"ready"`)) {
+		t.Fatalf("matching transport-bound writeback status=%d body=%s", res.Code, res.Body.String())
+	}
+
+	missingPeerLease := boundTestLaunchIdentityLease(t, backend, "api-service", nil, []string{"services/api-service"}, []string{"create"}, "jti-writeback-transport-missing-peer", peer)
+	missingPeerBody := []byte(`{"requestId":"req-writeback-transport-missing-peer","identity":{"serviceId":"api-service","expiresAt":"2026-05-07T00:05:00Z"},"identityLease":` + mustLeaseJSON(t, missingPeerLease) + `,"policy":{"allowedNamespaces":["services/api-service"],"allowedOperations":["create"]},"operation":"create","namespace":"services/api-service","ref":"runtime/MISSING_PEER","value":"blocked-writeback-secret"}`)
+	res = serveTransportBoundRequest(t, handler, http.MethodPost, "/v1/writeback", "test-token", missingPeerBody, transportPeerIdentity{})
+	if res.Code != http.StatusForbidden || !bytes.Contains(res.Body.Bytes(), []byte(`"code":"policy_denied"`)) {
+		t.Fatalf("missing-peer transport-bound writeback status=%d body=%s", res.Code, res.Body.String())
+	}
+	assertNoSecretMaterial(t, res.Body.Bytes(), "blocked-writeback-secret", "test-token")
+}
+
+func boundTestLaunchIdentityLease(t *testing.T, backend *localBackend, serviceID string, refs, namespaces, operations []string, jti string, peer transportPeerIdentity) launchIdentityLease {
+	t.Helper()
+	lease := testLaunchIdentityLease(t, backend, serviceID, refs, namespaces, operations, jti)
+	lease.TransportBinding = &launchTransportBinding{Kind: peer.Kind, Subject: peer.Subject}
+	return mustSignLaunchIdentityLease(t, lease, "test-token")
+}
+
+func serveTransportBoundRequest(t *testing.T, handler http.Handler, method, path, token string, body []byte, peer transportPeerIdentity) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req = req.WithContext(contextWithTransportPeerIdentity(req.Context(), peer))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
 }
 
 func mustSignLaunchIdentityLease(t *testing.T, lease launchIdentityLease, key string) launchIdentityLease {


### PR DESCRIPTION
## Issue
Advances #31

## Summary
- Adds handler-level tests proving transport-bound launch identity leases are honored by `/v1/resolve` and `/v1/writeback`.
- Covers matching peer success and mismatched/missing peer fail-closed paths.
- Asserts denied responses do not leak secret values or local API tokens.

## Scope
- In scope: endpoint-level regression coverage for existing transport-bound lease enforcement.
- Out of scope: new IPC transport behavior, cross-user Windows integration proof, release/demo pin completion.

## Spec / contract / fixture impact
- Not required because this PR only adds tests for behavior already documented in `docs/launch-identity-leases.md` and already implemented in request-context lease verification.

## Service Lasso invariant impact
- Preserves local-first `@secretsbroker` behavior and keeps secret-bearing endpoints protected by local API token plus scoped signed launch leases.
- No secret values, API tokens, or transport credentials are added to logs or fixtures.

## Validation
- PASS `go test ./cmd/secretsbroker` — `.work-agent/logs/cron-755b8bea-20260627-013110/go-test-cmd-secretsbroker.log`
- PASS `go test ./...` — `.work-agent/logs/cron-755b8bea-20260627-013110/go-test-all.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/cron-755b8bea-20260627-013110/go-build-commands.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260627-013110/git-diff-check.log`
- PASS canonical preflight health before work: Service Admin HTTP 200; runtime health HTTP 200/status `ok`.

## Approval trail
- Required: normal repository PR/check rules.
- Evidence: hosted checks will gate this PR after opening.

## Cleanup
- Branch cleanup after merge if repo rules allow.
- Release-to-demo gate applies if this demo-consumed repo is merged/released; this PR is an advanced test slice, not full #31 completion.