### PR TITLE
feat: issue transport-bound launch leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ go run .\cmd\secretsbroker serve --mode production --transport windows-named-pip
 
 The broker process user SID is always included in the named-pipe ACL. Additional SIDs are for a stable Service Lasso launcher or service account. Local Administrators and LocalSystem stay enabled by default for compatibility, and production profiles can turn either off once the launcher identity is fixed.
 
+Launcher-issued transport-bound leases can be produced with the broker helper while core launcher integration is being wired:
+
+```powershell
+$env:SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY = "<launcher-owned-hmac-key>"
+go run .\cmd\secretsbroker admin launch-lease issue `
+  --service-id api-service `
+  --workspace-id workspace-local `
+  --allowed-ref "services/api-service/runtime/*" `
+  --operation resolve `
+  --jti "<one-time-id>" `
+  --transport-binding-kind windows-sid `
+  --transport-binding-subject "S-1-5-21-..."
+```
+
 Check status:
 
 ```powershell

--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type adminCommonOptions struct {
@@ -46,6 +47,13 @@ type adminAuditExportResponse struct {
 	Events      []auditEvent           `json:"events"`
 }
 
+type adminLaunchLeaseIssueResponse struct {
+	ServiceID  string              `json:"serviceId"`
+	APIVersion string              `json:"apiVersion"`
+	Outcome    string              `json:"outcome"`
+	Lease      launchIdentityLease `json:"lease"`
+}
+
 func runAdmin(args []string) error {
 	return executeAdmin(args, os.Stdout)
 }
@@ -75,9 +83,142 @@ func executeAdmin(args []string, out io.Writer) error {
 		return runAdminEvents(args[1:], out)
 	case "mcp":
 		return runAdminMCP(args[1:], out)
+	case "launch-lease":
+		return runAdminLaunchLease(args[1:], out)
 	default:
 		return fmt.Errorf("unknown admin command %q", args[0])
 	}
+}
+
+func runAdminLaunchLease(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("unknown admin launch-lease command %q", "")
+	}
+	sub := args[0]
+	fs := flag.NewFlagSet("admin launch-lease "+sub, flag.ContinueOnError)
+	service := fs.String("service-id", "", "launched service id")
+	workspace := fs.String("workspace-id", "", "workspace id")
+	issuer := fs.String("issuer", "service-lasso-local-launcher", "lease issuer")
+	jti := fs.String("jti", "", "one-time lease id")
+	signingKey := fs.String("signing-key", getenvDefault("SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY", ""), "HMAC signing key; prefer SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY")
+	apiToken := fs.String("api-token", getenvDefault("SECRETSBROKER_API_TOKEN", ""), "bootstrap fallback signing key when launch signing key is unset")
+	issuedAt := fs.String("issued-at", "", "issued-at timestamp, RFC3339; defaults to now")
+	expiresAt := fs.String("expires-at", "", "expires-at timestamp, RFC3339")
+	ttl := fs.Duration("ttl", 5*time.Minute, "lease lifetime when --expires-at is omitted")
+	transportKind := fs.String("transport-binding-kind", "", "optional transport binding kind: windows-sid or unix-uid")
+	transportSubject := fs.String("transport-binding-subject", "", "optional transport binding subject")
+	refs := multiFlag{}
+	namespaces := multiFlag{}
+	operations := multiFlag{}
+	fs.Var(&refs, "allowed-ref", "allowed secret ref or glob; repeatable")
+	fs.Var(&namespaces, "allowed-namespace", "allowed secret namespace; repeatable")
+	fs.Var(&operations, "operation", "allowed operation; repeatable")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if sub != "issue" {
+		return fmt.Errorf("unknown admin launch-lease command %q", sub)
+	}
+	key := firstNonEmpty(*signingKey, *apiToken)
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("launch lease issue requires SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY or --signing-key; bootstrap may use SECRETSBROKER_API_TOKEN or --api-token")
+	}
+	lease, err := buildAdminLaunchLease(adminLaunchLeaseOptions{
+		Issuer:                  *issuer,
+		ServiceID:               *service,
+		WorkspaceID:             *workspace,
+		JTI:                     *jti,
+		AllowedRefs:             []string(refs),
+		AllowedNamespaces:       []string(namespaces),
+		AllowedOperations:       []string(operations),
+		IssuedAt:                *issuedAt,
+		ExpiresAt:               *expiresAt,
+		TTL:                     *ttl,
+		TransportBindingKind:    *transportKind,
+		TransportBindingSubject: *transportSubject,
+	}, time.Now().UTC)
+	if err != nil {
+		return err
+	}
+	signed, err := signLaunchIdentityLease(lease, key)
+	if err != nil {
+		return err
+	}
+	return encodeAdminJSON(out, adminLaunchLeaseIssueResponse{
+		ServiceID:  serviceID,
+		APIVersion: apiVersion,
+		Outcome:    "ready",
+		Lease:      signed,
+	})
+}
+
+type adminLaunchLeaseOptions struct {
+	Issuer                  string
+	ServiceID               string
+	WorkspaceID             string
+	JTI                     string
+	AllowedRefs             []string
+	AllowedNamespaces       []string
+	AllowedOperations       []string
+	IssuedAt                string
+	ExpiresAt               string
+	TTL                     time.Duration
+	TransportBindingKind    string
+	TransportBindingSubject string
+}
+
+func buildAdminLaunchLease(opts adminLaunchLeaseOptions, now func() time.Time) (launchIdentityLease, error) {
+	issued, err := parseOptionalLeaseTime(opts.IssuedAt, now())
+	if err != nil {
+		return launchIdentityLease{}, fmt.Errorf("invalid issued-at: %w", err)
+	}
+	expires, err := parseOptionalLeaseTime(opts.ExpiresAt, issued.Add(opts.TTL))
+	if err != nil {
+		return launchIdentityLease{}, fmt.Errorf("invalid expires-at: %w", err)
+	}
+	lease := launchIdentityLease{
+		Issuer:            strings.TrimSpace(opts.Issuer),
+		ServiceID:         strings.TrimSpace(opts.ServiceID),
+		WorkspaceID:       strings.TrimSpace(opts.WorkspaceID),
+		AllowedRefs:       safeList(opts.AllowedRefs),
+		AllowedNamespaces: safeList(opts.AllowedNamespaces),
+		AllowedOperations: safeList(opts.AllowedOperations),
+		IssuedAt:          issued.Format(time.RFC3339),
+		ExpiresAt:         expires.Format(time.RFC3339),
+		JTI:               strings.TrimSpace(opts.JTI),
+	}
+	if strings.TrimSpace(lease.Issuer) == "" || strings.TrimSpace(lease.ServiceID) == "" || strings.TrimSpace(lease.JTI) == "" {
+		return launchIdentityLease{}, fmt.Errorf("launch lease issue requires issuer, service-id, and jti")
+	}
+	if !expires.After(issued) {
+		return launchIdentityLease{}, fmt.Errorf("launch lease expires-at must be after issued-at")
+	}
+	if len(lease.AllowedRefs) == 0 && len(lease.AllowedNamespaces) == 0 {
+		return launchIdentityLease{}, fmt.Errorf("launch lease issue requires at least one allowed-ref or allowed-namespace")
+	}
+	if len(lease.AllowedOperations) == 0 {
+		return launchIdentityLease{}, fmt.Errorf("launch lease issue requires at least one operation")
+	}
+	binding := normalizeLaunchTransportBinding(&launchTransportBinding{
+		Kind:    opts.TransportBindingKind,
+		Subject: opts.TransportBindingSubject,
+	})
+	if (strings.TrimSpace(opts.TransportBindingKind) != "" || strings.TrimSpace(opts.TransportBindingSubject) != "") && binding == nil {
+		return launchIdentityLease{}, fmt.Errorf("transport binding requires both kind and subject")
+	}
+	lease.TransportBinding = binding
+	return lease, nil
+}
+
+func parseOptionalLeaseTime(value string, fallback time.Time) (time.Time, error) {
+	if strings.TrimSpace(value) == "" {
+		return fallback.UTC().Truncate(time.Second), nil
+	}
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed.UTC(), nil
 }
 
 func runAdminStatus(args []string, out io.Writer) error {

--- a/cmd/secretsbroker/admin_cli_test.go
+++ b/cmd/secretsbroker/admin_cli_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const adminCLISecretValue = "fixture-admin-cli-secret-value"
@@ -145,6 +146,71 @@ func TestAdminCLIProviderValidationMigrationAndAuditAreScrubbed(t *testing.T) {
 	if len(hashOnlyExport.Events) == 0 || hashOnlyExport.Events[0].Ref != "" || hashOnlyExport.Events[0].RefHash == "" {
 		t.Fatalf("hash-only audit export = %#v", hashOnlyExport)
 	}
+}
+
+func TestAdminLaunchLeaseIssuesTransportBoundSignedLease(t *testing.T) {
+	var out bytes.Buffer
+	err := executeAdmin([]string{
+		"launch-lease", "issue",
+		"--service-id", "api-service",
+		"--workspace-id", "workspace-local",
+		"--allowed-ref", "services/api-service/runtime/*",
+		"--allowed-namespace", "services/api-service",
+		"--operation", "resolve",
+		"--operation", "create",
+		"--jti", "jti-admin-launch-lease",
+		"--issued-at", "2026-06-27T03:45:00Z",
+		"--expires-at", "2026-06-27T03:50:00Z",
+		"--transport-binding-kind", "windows-sid",
+		"--transport-binding-subject", "S-1-5-21-1000",
+		"--signing-key", "issuer-secret-key",
+	}, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, out.Bytes(), "issuer-secret-key")
+
+	var issued adminLaunchLeaseIssueResponse
+	if err := json.Unmarshal(out.Bytes(), &issued); err != nil {
+		t.Fatal(err)
+	}
+	if issued.Outcome != "ready" || issued.Lease.Signature == "" {
+		t.Fatalf("launch lease response missing signed ready lease: %#v", issued)
+	}
+	if issued.Lease.TransportBinding == nil || issued.Lease.TransportBinding.Kind != "windows-sid" || issued.Lease.TransportBinding.Subject != "S-1-5-21-1000" {
+		t.Fatalf("transport binding = %#v", issued.Lease.TransportBinding)
+	}
+
+	backend := testBackend(t)
+	backend.now = func() time.Time { return time.Date(2026, 6, 27, 3, 46, 0, 0, time.UTC) }
+	peer := transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-1000"}
+	if err := backend.verifyLaunchIdentityLease(&issued.Lease, "issuer-secret-key", "api-service", "workspace-local", "resolve", []string{"services/api-service/runtime/API_TOKEN"}, nil, peer); err != nil {
+		t.Fatalf("issued transport-bound lease should verify: %v", err)
+	}
+
+	replayBackend := testBackend(t)
+	replayBackend.now = backend.now
+	if err := replayBackend.verifyLaunchIdentityLease(&issued.Lease, "issuer-secret-key", "api-service", "workspace-local", "resolve", []string{"services/api-service/runtime/API_TOKEN"}, nil, transportPeerIdentity{Kind: "windows-sid", Subject: "S-1-5-21-9999"}); !errors.Is(err, errPolicyDenied) {
+		t.Fatalf("mismatched transport-bound lease err=%v, want policy denied", err)
+	}
+}
+
+func TestAdminLaunchLeaseRejectsIncompleteTransportBinding(t *testing.T) {
+	var out bytes.Buffer
+	err := executeAdmin([]string{
+		"launch-lease", "issue",
+		"--service-id", "api-service",
+		"--allowed-ref", "services/api-service/runtime/*",
+		"--operation", "resolve",
+		"--jti", "jti-incomplete-binding",
+		"--issued-at", "2026-06-27T03:45:00Z",
+		"--transport-binding-kind", "windows-sid",
+		"--signing-key", "issuer-secret-key",
+	}, &out)
+	if err == nil || !strings.Contains(err.Error(), "transport binding requires both kind and subject") {
+		t.Fatalf("expected incomplete transport binding rejection, got err=%v body=%s", err, out.String())
+	}
+	assertNoSecretMaterial(t, out.Bytes(), "issuer-secret-key")
 }
 
 func TestAdminCLILockedListFailsClosed(t *testing.T) {

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -252,6 +252,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"CLI secretsbroker backup create|restore",
 			"CLI secretsbroker key initialize|unlock|import|rewrap|wrapper-status|rotate|recovery generate|recovery import",
 			"CLI secretsbroker admin status|secrets|providers|migration|sync|recovery|audit|telemetry|events",
+			"CLI secretsbroker admin launch-lease issue",
 		},
 		Features: []string{
 			"liveness",
@@ -301,6 +302,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"unix-socket-peer-credential-checks",
 			"windows-named-pipe-identity-checks",
 			"windows-named-pipe-service-account-policy",
+			"launcher-issued-transport-bound-leases",
 		},
 		FutureFeatures: []string{
 			"external-backend-write-back",

--- a/docs/launch-identity-leases.md
+++ b/docs/launch-identity-leases.md
@@ -14,6 +14,22 @@ The signature algorithm is HMAC-SHA-256 over the canonical JSON lease payload, e
 hmac-sha256:<base64url-no-padding>
 ```
 
+The broker ships a bounded launcher-compatible issuer helper so the Service Lasso launcher can generate the exact signed payload shape the broker enforces:
+
+```powershell
+$env:SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY = "<launcher-owned-hmac-key>"
+secretsbroker admin launch-lease issue `
+  --service-id api-service `
+  --workspace-id workspace-local `
+  --allowed-ref "services/api-service/runtime/*" `
+  --operation resolve `
+  --jti "<one-time-id>" `
+  --transport-binding-kind windows-sid `
+  --transport-binding-subject "S-1-5-21-..."
+```
+
+For bootstrap compatibility only, the helper can fall back to `SECRETSBROKER_API_TOKEN` when the dedicated launch signing key is not configured. Production launchers should use a distinct signing key and avoid passing secrets as command-line flags.
+
 ## Lease shape
 
 ```json

--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -44,6 +44,7 @@ Implemented behavior:
 - Unix-like platforms can serve HTTP over a Unix socket, set the socket path to owner-only mode, and check OS peer credentials before passing a connection to the HTTP server. Linux uses `SO_PEERCRED`; macOS/FreeBSD use `LOCAL_PEERCRED`.
 - Windows can serve HTTP over a named pipe with a restricted security descriptor and a connected-client identity check before passing the connection to the HTTP server.
 - Authenticated IPC listeners attach safe local peer metadata to each accepted request: `windows-sid` for Windows named-pipe peers and `unix-uid` for Unix socket peers. Signed launch identity leases can optionally bind to that transport subject for secret-bearing resolve/write-back requests.
+- `secretsbroker admin launch-lease issue` can issue a signed lease with an explicit `transportBinding` so launcher integration tests and future core launch flows can produce the same bound payload the broker enforces.
 
 ## Production gate
 
@@ -108,3 +109,18 @@ Supported binding kinds:
 - `unix-uid`: the connected Unix socket peer UID.
 
 If a lease omits `transportBinding`, existing token/session and lease scope checks continue unchanged. If a lease includes it, the broker requires an authenticated IPC listener to provide matching peer metadata before `POST /v1/resolve` or `POST /v1/writeback` can proceed. Loopback HTTP does not provide OS peer identity, so transport-bound leases fail closed on loopback.
+
+The broker-side issuance helper supports the launcher payload shape:
+
+```powershell
+secretsbroker admin launch-lease issue `
+  --service-id api-service `
+  --workspace-id workspace-local `
+  --allowed-ref "services/api-service/runtime/*" `
+  --operation resolve `
+  --jti "<one-time-id>" `
+  --transport-binding-kind windows-sid `
+  --transport-binding-subject "S-1-5-21-..."
+```
+
+The helper signs with `SECRETSBROKER_LAUNCH_IDENTITY_SIGNING_KEY` or, for bootstrap compatibility only, `SECRETSBROKER_API_TOKEN`. It does not discover the current peer itself; the launcher must supply the subject it will run the client under, and the broker still verifies that the actual authenticated IPC peer matches before serving secret-bearing endpoints.


### PR DESCRIPTION
## Issue
Advances #31

## Summary
- Adds `secretsbroker admin launch-lease issue` to mint signed launch identity leases with optional `transportBinding`.
- Validates required lease scope fields, TTL/expiry ordering, and complete binding kind/subject pairs before signing.
- Documents launcher-compatible transport-bound lease issuance in README and IPC/launch-lease docs.

## Scope
- In scope: broker-side CLI helper and validation/tests for launcher-issued transport-bound lease payloads.
- Out of scope: core Service Lasso launcher integration and true cross-user Windows denial evidence; those remain open #31 follow-up work.

## Spec / contract / fixture impact
- Updated: `docs/launch-identity-leases.md`, `docs/os-authenticated-ipc-transport.md`, and README production IPC guidance.
- No fixture change required because this adds a CLI issuance helper over the existing signed lease contract.

## Nash invariant impact
- Invariant: signed launch identity leases remain scoped, redacted, one-time-use, and fail closed when transport-bound peer metadata mismatches.
- Preservation proof: new tests verify the CLI-issued lease signature verifies only for the matching transport peer and rejects an incomplete binding.

## Validation
- PASS `go test ./cmd/secretsbroker -run "TestAdminLaunchLease|TestLaunchIdentityLeaseTransportBinding|TestHTTPResolveHonorsTransportBoundLaunchLease|TestHTTPWritebackHonorsTransportBoundLaunchLease" -count=1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-next-ipc/go-test-focused.log`
- PASS `go test ./...` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-next-ipc/go-test-all.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-next-ipc/go-build-commands.log`
- PASS `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-next-ipc/scripts-test-ps1.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-31-next-ipc/git-diff-check.log`
- PASS canonical demo preflight/recovery before work: `npm run demo:verify-canonical` in core — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/demo-verify-canonical.log`

## Approval trail
- Required: normal repository review/hosted checks before merge.
- Evidence: PR opened by scheduled worker; no merge attempted in this run.

## Cleanup
- Branch: `agent/issue-31-launch-lease-transport-binding`
- Post-merge release-to-demo gate applies because this is a demo-consumed service repo: release `lasso-secretsbroker`, pin exact release in `service-lasso`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify expected/catalog/installed tags match before claiming demo-current.
