### PR TITLE
Add Windows named pipe cross-user verifier

### DIFF
--- a/docs/os-authenticated-ipc-transport.md
+++ b/docs/os-authenticated-ipc-transport.md
@@ -73,6 +73,37 @@ Remaining hardening:
 - Add cross-user denial evidence in an integration environment that can create a second local Windows principal.
 - Extend launcher-issued leases to include `transportBinding` by default once the core launcher has a stable broker transport identity policy.
 
+## Windows cross-user denial verification
+
+The repeatable cross-user proof is `scripts/verify-windows-named-pipe-cross-user.ps1`. It is an integration verifier, not a unit test, because it requires a second local Windows principal and that principal's password.
+
+Required host capability:
+
+- Windows host with Go and PowerShell available.
+- Current broker user can run `secretsbroker`.
+- A separate local user account exists and is not the broker user.
+- The verifier process can call `CreateProcessWithLogonW` through PowerShell `Start-Process -Credential`.
+
+Safe invocation shape:
+
+```powershell
+$env:SECRETSBROKER_CROSS_USER_DENIED_USER = 'MACHINE\other-local-user'
+$env:SECRETSBROKER_CROSS_USER_PASSWORD = '<set in the shell only>'
+pwsh -NoLogo -NoProfile -File .\scripts\verify-windows-named-pipe-cross-user.ps1 `
+  -OutputDir .\.work-agent\logs\windows-named-pipe-cross-user
+```
+
+The verifier starts the broker with a strict Windows named-pipe transport:
+
+- `--mode production`
+- `--transport windows-named-pipe`
+- `--named-pipe-allow-admin=false`
+- `--named-pipe-allow-local-system=false`
+
+It first proves the broker user can reach `/health` over the pipe, then starts the denied user process and expects the pipe connection to fail with access denied before any HTTP request can reach the broker. The summary records safe metadata only: broker user/SID, denied username, pipe path, outcome, and reason. It must not write passwords, tokens, environment dumps, command lines containing secrets, or response bodies with secret material.
+
+If alternate-user credentials are missing, the verifier writes `blocked.json` and exits non-zero. That is environment evidence, not a pass.
+
 ## Unix socket requirements
 
 Current Unix socket support enforces same-UID peer credentials on platforms where Go exposes the required OS APIs:

--- a/scripts/verify-windows-named-pipe-cross-user.ps1
+++ b/scripts/verify-windows-named-pipe-cross-user.ps1
@@ -1,0 +1,176 @@
+param(
+  [string]$DeniedUser = $env:SECRETSBROKER_CROSS_USER_DENIED_USER,
+  [string]$DeniedPasswordEnvVar = 'SECRETSBROKER_CROSS_USER_PASSWORD',
+  [string]$OutputDir = (Join-Path (Split-Path -Parent $PSScriptRoot) '.work-agent\logs\windows-named-pipe-cross-user'),
+  [int]$ConnectTimeoutMs = 2000
+)
+
+$ErrorActionPreference = 'Stop'
+
+$isWindowsHost = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+if (-not $isWindowsHost) {
+  throw 'Windows named-pipe cross-user verification must run on Windows.'
+}
+
+$root = Split-Path -Parent $PSScriptRoot
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$runDir = Join-Path $OutputDir $timestamp
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+function Write-SafeJson {
+  param(
+    [string]$Path,
+    [hashtable]$Value
+  )
+  $Value | ConvertTo-Json -Depth 8 | Set-Content -Encoding utf8 $Path
+}
+
+function Invoke-NamedPipeHttp {
+  param(
+    [string]$PipePath,
+    [string]$RequestPath,
+    [int]$TimeoutMs
+  )
+
+  $pipeName = $PipePath -replace '^\\\\\.\\pipe\\', ''
+  $client = [System.IO.Pipes.NamedPipeClientStream]::new('.', $pipeName, [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::None)
+  try {
+    $client.Connect($TimeoutMs)
+    $client.ReadMode = [System.IO.Pipes.PipeTransmissionMode]::Byte
+    $writer = [System.IO.StreamWriter]::new($client, [System.Text.Encoding]::ASCII, 1024, $true)
+    $writer.NewLine = "`r`n"
+    $writer.Write("GET $RequestPath HTTP/1.1`r`nHost: secretsbroker.local`r`nConnection: close`r`n`r`n")
+    $writer.Flush()
+    $reader = [System.IO.StreamReader]::new($client, [System.Text.Encoding]::ASCII)
+    return $reader.ReadToEnd()
+  }
+  finally {
+    $client.Dispose()
+  }
+}
+
+$passwordValue = if ($DeniedPasswordEnvVar) { [Environment]::GetEnvironmentVariable($DeniedPasswordEnvVar) } else { $null }
+if ([string]::IsNullOrWhiteSpace($DeniedUser) -or [string]::IsNullOrEmpty($passwordValue)) {
+  Write-SafeJson -Path (Join-Path $runDir 'blocked.json') -Value @{
+    status = 'blocked'
+    reason = 'missing_cross_user_credentials'
+    deniedUserProvided = -not [string]::IsNullOrWhiteSpace($DeniedUser)
+    passwordEnvVar = $DeniedPasswordEnvVar
+    nextAction = 'Set SECRETSBROKER_CROSS_USER_DENIED_USER and the password environment variable named by -DeniedPasswordEnvVar, then rerun on an integration Windows host.'
+  }
+  throw 'Missing alternate Windows user credentials for cross-user named-pipe denial verification.'
+}
+
+$securePassword = ConvertTo-SecureString $passwordValue -AsPlainText -Force
+$credential = [pscredential]::new($DeniedUser, $securePassword)
+$current = [Security.Principal.WindowsIdentity]::GetCurrent()
+$currentSID = $current.User.Value
+$pipePath = "\\.\pipe\service-lasso-secretsbroker-cross-user-$([Guid]::NewGuid().ToString('N'))"
+$tmp = Join-Path $root '.tmp\cross-user-named-pipe'
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+$exe = Join-Path $tmp 'secretsbroker.exe'
+
+Push-Location $root
+try {
+  go build -o $exe ./cmd/secretsbroker
+
+  $stdout = Join-Path $runDir 'broker.out.log'
+  $stderr = Join-Path $runDir 'broker.err.log'
+  $proc = Start-Process -FilePath $exe -ArgumentList @(
+    'serve',
+    '--mode', 'production',
+    '--transport', 'windows-named-pipe',
+    '--named-pipe', $pipePath,
+    '--named-pipe-allow-admin=false',
+    '--named-pipe-allow-local-system=false'
+  ) -PassThru -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+
+  try {
+    $ready = $false
+    for ($i = 0; $i -lt 20; $i++) {
+      try {
+        $response = Invoke-NamedPipeHttp -PipePath $pipePath -RequestPath '/health' -TimeoutMs $ConnectTimeoutMs
+        if ($response -match 'HTTP/1\.1 200') {
+          $ready = $true
+          break
+        }
+      }
+      catch {
+        Start-Sleep -Milliseconds 250
+      }
+    }
+    if (-not $ready) {
+      throw 'Broker named-pipe health endpoint did not become reachable for the broker user.'
+    }
+
+    $childScript = Join-Path $runDir 'denied-client.ps1'
+    $childOut = Join-Path $runDir 'denied-client.out.json'
+    $childErr = Join-Path $runDir 'denied-client.err.log'
+    @"
+`$ErrorActionPreference = 'Stop'
+`$pipePath = '$pipePath'
+`$pipeName = `$pipePath -replace '^\\\\\.\\pipe\\', ''
+try {
+  `$client = [System.IO.Pipes.NamedPipeClientStream]::new('.', `$pipeName, [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::None)
+  `$client.Connect($ConnectTimeoutMs)
+  `$client.Dispose()
+  @{ status = 'failed'; reason = 'denied_user_connected'; pipe = `$pipePath } | ConvertTo-Json -Depth 4
+  exit 10
+}
+catch [System.UnauthorizedAccessException] {
+  @{ status = 'passed'; reason = 'connect_unauthorized'; pipe = `$pipePath } | ConvertTo-Json -Depth 4
+  exit 0
+}
+catch {
+  `$message = `$_.Exception.Message
+  if (`$message -match 'Access is denied|Unauthorized') {
+    @{ status = 'passed'; reason = 'connect_access_denied'; pipe = `$pipePath } | ConvertTo-Json -Depth 4
+    exit 0
+  }
+  @{ status = 'blocked'; reason = 'unexpected_connect_error'; error = `$message; pipe = `$pipePath } | ConvertTo-Json -Depth 4
+  exit 20
+}
+"@ | Set-Content -Encoding utf8 $childScript
+
+    $child = Start-Process -FilePath 'powershell.exe' -ArgumentList @(
+      '-NoLogo',
+      '-NoProfile',
+      '-ExecutionPolicy', 'Bypass',
+      '-File', $childScript
+    ) -Credential $credential -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $childOut -RedirectStandardError $childErr
+
+    $childResult = if (Test-Path $childOut) { Get-Content $childOut -Raw | ConvertFrom-Json } else { $null }
+    if ($child.ExitCode -ne 0 -or $null -eq $childResult -or $childResult.status -ne 'passed') {
+      Write-SafeJson -Path (Join-Path $runDir 'summary.json') -Value @{
+        status = 'failed'
+        brokerUser = $current.Name
+        brokerUserSID = $currentSID
+        deniedUser = $DeniedUser
+        childExitCode = $child.ExitCode
+        childResult = $childResult
+        pipe = $pipePath
+      }
+      throw "Denied user process did not produce the expected access-denied result; child exit code $($child.ExitCode)."
+    }
+
+    Write-SafeJson -Path (Join-Path $runDir 'summary.json') -Value @{
+      status = 'passed'
+      brokerUser = $current.Name
+      brokerUserSID = $currentSID
+      deniedUser = $DeniedUser
+      deniedResult = $childResult
+      pipe = $pipePath
+      proof = 'Alternate Windows principal could not connect to a strict broker-owned named pipe.'
+    }
+    Write-Host "Windows named-pipe cross-user denial verification passed. Evidence: $runDir"
+  }
+  finally {
+    if ($proc -and -not $proc.HasExited) {
+      Stop-Process -Id $proc.Id -Force
+      $proc.WaitForExit()
+    }
+  }
+}
+finally {
+  Pop-Location
+}


### PR DESCRIPTION
## Issue
Advances #31

## Summary
- Added `scripts/verify-windows-named-pipe-cross-user.ps1`, a Windows integration verifier for the remaining named-pipe cross-user denial proof.
- Documented required host capabilities, safe invocation, strict broker flags, expected denied-user outcome, and blocked-environment behavior.
- The verifier starts a strict production named-pipe broker, proves same-user `/health`, then launches a separate credentialed Windows user process that must fail to connect before HTTP reaches the broker.

## Scope
- In scope: repeatable Windows cross-user denial verification harness and operator docs.
- Out of scope: claiming the final cross-user evidence has passed on this host; this cron session has no alternate-user password and is not elevated.

## Spec / contract / fixture impact
- Updated: `docs/os-authenticated-ipc-transport.md` with the integration proof procedure.
- Not required: service API/schema behavior did not change.

## Safety / secret handling
- The verifier records safe metadata only: broker user/SID, denied username, pipe path, result, and reason.
- Passwords are read from an environment variable but are not written to logs, summaries, stdout, or issue/PR text.

## Validation
- PASS `go test ./cmd/secretsbroker` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-31-cross-user-denial-20260627-0436\go-test-cmd-secretsbroker.log`
- PASS `go test ./...` — `...\go-test-all.log`
- PASS `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve` — `...\go-build-commands.log`
- PASS `git diff --check` — `...\git-diff-check.log`
- PASS/BLOCKED expected `pwsh -NoLogo -NoProfile -File .\scripts\verify-windows-named-pipe-cross-user.ps1` without alternate credentials writes `blocked.json` and exits non-zero — `...\verifier-missing-credentials-2.log`
- PASS/BLOCKED expected `powershell.exe -NoLogo -NoProfile -File .\scripts\verify-windows-named-pipe-cross-user.ps1` without alternate credentials exits non-zero — `...\verifier-missing-credentials-windows-powershell.log`

## Remaining gate
- To close the remaining #31 gap, rerun the verifier on a Windows integration host with `SECRETSBROKER_CROSS_USER_DENIED_USER` plus `SECRETSBROKER_CROSS_USER_PASSWORD` set for a real second local principal. Expected result: `summary.json` with `status=passed` and denied-user access denied.

## Approval trail
- Required: normal PR review/merge rules.
- Evidence: this PR is intentionally not a completion claim for #31.

## Cleanup
- Branch: `agent/issue-31-windows-cross-user-proof`
- Release-to-demo gate: not applicable until this PR is merged/released; current change is docs/script proof tooling and no demo service pin was changed.