### PR TITLE
ISS-111: expose provisioning status metadata

### DIFF
--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -47,6 +47,10 @@ var typedOutcomes = []string{
 	"cleared",
 	"not_found",
 	"disabled",
+	"stale",
+	"unsupported",
+	"audit_unavailable",
+	"failed",
 }
 
 type Status struct {
@@ -186,7 +190,7 @@ func defaultStatus(state string) Status {
 		Ready:       isReadyState(state),
 		LocalFirst:  true,
 		Backend:     "local",
-		Description: "Lean local-first Vault-like broker bootstrap skeleton. Secrets storage/resolution is intentionally not implemented yet.",
+		Description: "Local-first secrets broker with encrypted local storage, metadata-safe management, resolve, write-back, and provisioning status surfaces.",
 		CheckedAt:   time.Now().UTC(),
 	}
 }
@@ -229,6 +233,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/secrets",
 			"POST /v1/writeback",
 			"POST /v1/resolve",
+			"GET /v1/provisioning/status",
 			"GET /v1/sources/status",
 			"GET /v1/providers/capabilities",
 			"GET /v1/providers/config/status",
@@ -289,6 +294,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"launch-identity-transport-binding",
 			"write-back-policy",
 			"generated-secret-capture",
+			"generated-secret-provisioning-status",
 			"encrypted-backup-restore",
 			"master-key-initialize-unlock-import-rewrap",
 			"os-wrapper-status",

--- a/cmd/secretsbroker/secrets_management.go
+++ b/cmd/secretsbroker/secrets_management.go
@@ -36,6 +36,40 @@ type managedSecretsResponse struct {
 	Results     []managedSecretRecord `json:"results"`
 }
 
+type generatedValuePolicyMetadata struct {
+	Kind           string `json:"kind"`
+	LengthClass    string `json:"lengthClass"`
+	EntropyClass   string `json:"entropyClass"`
+	RotationPolicy string `json:"rotationPolicy"`
+}
+
+type provisioningStatusRecord struct {
+	Ref                  string                       `json:"ref"`
+	Namespace            string                       `json:"namespace"`
+	OwnerServiceID       string                       `json:"ownerServiceId"`
+	SourceID             string                       `json:"sourceId"`
+	ProviderID           string                       `json:"providerId"`
+	ProviderKind         string                       `json:"providerKind"`
+	DesiredOperation     string                       `json:"desiredOperation"`
+	ProvisionedState     string                       `json:"provisionedState"`
+	LastOperationID      string                       `json:"lastOperationId,omitempty"`
+	LastOutcome          string                       `json:"lastOutcome"`
+	NextAction           string                       `json:"nextAction,omitempty"`
+	AuditStatus          string                       `json:"auditStatus"`
+	PolicyResult         string                       `json:"policyResult"`
+	GeneratedValuePolicy generatedValuePolicyMetadata `json:"generatedValuePolicy"`
+	UpdatedAt            *time.Time                   `json:"updatedAt,omitempty"`
+}
+
+type provisioningStatusResponse struct {
+	ServiceID  string                     `json:"serviceId"`
+	APIVersion string                     `json:"apiVersion"`
+	Query      string                     `json:"query,omitempty"`
+	Ref        string                     `json:"ref,omitempty"`
+	Outcome    string                     `json:"outcome"`
+	Results    []provisioningStatusRecord `json:"results"`
+}
+
 type managedSecretActionRequest struct {
 	RequestID string `json:"requestId"`
 	ServiceID string `json:"serviceId"`
@@ -106,6 +140,50 @@ func (b *localBackend) listManagedSecrets(query string, valueSearch bool) (manag
 	return managedSecretsResponse{ServiceID: serviceID, APIVersion: apiVersion, Query: query, ValueSearch: valueSearch, Outcome: "ready", Results: records}, nil
 }
 
+func (b *localBackend) listProvisioningStatus(query, refFilter string) (provisioningStatusResponse, error) {
+	query = strings.TrimSpace(query)
+	refFilter = strings.TrimSpace(refFilter)
+	res := provisioningStatusResponse{ServiceID: serviceID, APIVersion: apiVersion, Query: query, Ref: refFilter, Outcome: "ready", Results: []provisioningStatusRecord{}}
+	if refFilter != "" && !validSecretRef(refFilter) {
+		res.Outcome = "invalid_ref"
+		return res, errInvalidRef
+	}
+	if b.locked() {
+		res.Outcome = "locked"
+		return res, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		res.Outcome = "degraded"
+		return res, errBackendDegraded
+	}
+	seen := map[string]bool{}
+	for ref, entry := range store.Secrets {
+		record := provisioningRecordFromLocalEntry(ref, entry)
+		seen[ref] = true
+		if provisioningRecordMatches(record, query, refFilter) {
+			res.Results = append(res.Results, record)
+		}
+	}
+	for _, source := range b.sources.enabledSources() {
+		for ref := range source.Refs {
+			if seen[ref] {
+				continue
+			}
+			record := provisioningRecordFromSource(ref, source)
+			seen[ref] = true
+			if provisioningRecordMatches(record, query, refFilter) {
+				res.Results = append(res.Results, record)
+			}
+		}
+	}
+	if refFilter != "" && !seen[refFilter] {
+		res.Results = append(res.Results, missingProvisioningRecord(refFilter))
+	}
+	sort.Slice(res.Results, func(i, j int) bool { return res.Results[i].Ref < res.Results[j].Ref })
+	return res, nil
+}
+
 func managedRecordFromLocalEntry(ref string, entry secretEntry) managedSecretRecord {
 	updated := entry.Metadata.UpdatedAt
 	return managedSecretRecord{
@@ -123,6 +201,64 @@ func managedRecordFromLocalEntry(ref string, entry secretEntry) managedSecretRec
 		ValueSearch:    "supported",
 		UpdatedAt:      &updated,
 		Metadata:       entry.Metadata,
+	}
+}
+
+func provisioningRecordFromLocalEntry(ref string, entry secretEntry) provisioningStatusRecord {
+	updated := entry.Metadata.UpdatedAt
+	sourceID := firstNonEmpty(entry.Metadata.SourceID, localStoreSource)
+	return provisioningStatusRecord{
+		Ref:                  ref,
+		Namespace:            namespaceFromRef(ref),
+		OwnerServiceID:       ownerFromRef(ref),
+		SourceID:             sourceID,
+		ProviderID:           sourceID,
+		ProviderKind:         "local-encrypted-store",
+		DesiredOperation:     "none",
+		ProvisionedState:     "ready",
+		LastOperationID:      entry.Metadata.Version,
+		LastOutcome:          "ready",
+		AuditStatus:          "audit_available",
+		PolicyResult:         "allowed",
+		GeneratedValuePolicy: defaultGeneratedValuePolicy(ref),
+		UpdatedAt:            &updated,
+	}
+}
+
+func provisioningRecordFromSource(ref string, source sourceConfig) provisioningStatusRecord {
+	lifecycle := sourceRegistryLifecycle(source)
+	return provisioningStatusRecord{
+		Ref:                  ref,
+		Namespace:            namespaceFromRef(ref),
+		OwnerServiceID:       ownerFromRef(ref),
+		SourceID:             source.SourceID,
+		ProviderID:           source.SourceID,
+		ProviderKind:         source.Kind,
+		DesiredOperation:     "create",
+		ProvisionedState:     provisioningStateForOutcome(lifecycle.Outcome),
+		LastOutcome:          lifecycle.Outcome,
+		NextAction:           firstNonEmpty(lifecycle.NextAction, nextActionForProvisioningOutcome(lifecycle.Outcome)),
+		AuditStatus:          "audit_available",
+		PolicyResult:         policyResultForProvisioningOutcome(lifecycle.Outcome),
+		GeneratedValuePolicy: defaultGeneratedValuePolicy(ref),
+	}
+}
+
+func missingProvisioningRecord(ref string) provisioningStatusRecord {
+	return provisioningStatusRecord{
+		Ref:                  ref,
+		Namespace:            namespaceFromRef(ref),
+		OwnerServiceID:       ownerFromRef(ref),
+		SourceID:             localStoreSource,
+		ProviderID:           localStoreSource,
+		ProviderKind:         "local-encrypted-store",
+		DesiredOperation:     "create",
+		ProvisionedState:     "not_planned",
+		LastOutcome:          "missing_ref",
+		NextAction:           "declare_writeback_or_configure_source_ref",
+		AuditStatus:          "audit_available",
+		PolicyResult:         "unknown",
+		GeneratedValuePolicy: defaultGeneratedValuePolicy(ref),
 	}
 }
 
@@ -201,6 +337,85 @@ func managedRecordMatches(record managedSecretRecord, query string) bool {
 	}
 	haystack := strings.ToLower(strings.Join([]string{record.Ref, record.Name, record.SourceID, record.ProviderKind, record.OwnerServiceID, record.WorkspaceID, record.State, record.Outcome, record.Policy}, " "))
 	return strings.Contains(haystack, query)
+}
+
+func provisioningRecordMatches(record provisioningStatusRecord, query, refFilter string) bool {
+	if refFilter != "" && record.Ref != refFilter {
+		return false
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{record.Ref, record.Namespace, record.OwnerServiceID, record.SourceID, record.ProviderID, record.ProviderKind, record.DesiredOperation, record.ProvisionedState, record.LastOutcome, record.PolicyResult}, " "))
+	return strings.Contains(haystack, query)
+}
+
+func namespaceFromRef(ref string) string {
+	ref = strings.Trim(ref, "/")
+	parts := strings.Split(ref, "/")
+	if len(parts) <= 1 {
+		return ref
+	}
+	return strings.Join(parts[:len(parts)-1], "/")
+}
+
+func defaultGeneratedValuePolicy(ref string) generatedValuePolicyMetadata {
+	return generatedValuePolicyMetadata{
+		Kind:           "opaque",
+		LengthClass:    "policy_default",
+		EntropyClass:   "policy_default",
+		RotationPolicy: "service_policy",
+	}
+}
+
+func provisioningStateForOutcome(outcome string) string {
+	switch outcome {
+	case "ready":
+		return "pending"
+	case "missing_ref", "disabled":
+		return "not_planned"
+	case "policy_denied", "source_auth_required", "locked", "invalid_ref":
+		return "blocked"
+	case "source_unavailable", "degraded":
+		return "failed"
+	case "stale":
+		return "stale"
+	default:
+		return "blocked"
+	}
+}
+
+func policyResultForProvisioningOutcome(outcome string) string {
+	switch outcome {
+	case "ready", "missing_ref", "source_auth_required", "locked", "source_unavailable", "degraded", "disabled":
+		return "unknown"
+	case "policy_denied":
+		return "denied"
+	default:
+		return "unknown"
+	}
+}
+
+func nextActionForProvisioningOutcome(outcome string) string {
+	switch outcome {
+	case "ready":
+		return "writeback_generated_value_or_mark_ready"
+	case "missing_ref":
+		return "check_ref"
+	case "policy_denied":
+		return "review_policy"
+	case "source_auth_required":
+		return "reconnect_source"
+	case "locked":
+		return "unlock_broker"
+	case "disabled":
+		return "enable_source"
+	case "source_unavailable", "degraded":
+		return "retry_or_inspect_source"
+	default:
+		return "inspect_status"
+	}
 }
 
 func configuredSourceRefCount(cfg sourceConfigFile) int {
@@ -547,6 +762,21 @@ func nextActionForManagedOutcome(outcome string) string {
 }
 
 func registerSecretsManagementHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/provisioning/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/provisioning/status.", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		res, err := backend.listProvisioningStatus(r.URL.Query().Get("search"), r.URL.Query().Get("ref"))
+		if err != nil {
+			writeManagementError(w, err, res.Outcome, "Provisioning status failed closed.")
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
 	mux.HandleFunc("/v1/management/secrets", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use GET /v1/management/secrets.", "invalid_ref", "")

--- a/cmd/secretsbroker/secrets_management_test.go
+++ b/cmd/secretsbroker/secrets_management_test.go
@@ -66,6 +66,79 @@ func TestManagedValueSearchReturnsRefsOnlyAndOmitsUnsupportedSources(t *testing.
 	assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "unmatched-fixture-value")
 }
 
+func TestProvisioningStatusIsMetadataOnlyAndDistinguishesOutcomes(t *testing.T) {
+	backend := managedTestBackend(t)
+	readyRef := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, readyRef, managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "vault-dev", Kind: "vault", DisplayName: "Vault dev", Enabled: true, Address: "https://vault.invalid", Token: "provider-token-fixture", Refs: map[string]sourceRefConfig{
+			"services/search/runtime/EXTERNAL_ONLY_REF": {Path: "secret/data/search", Field: "value"},
+		},
+	}, {
+		SourceID: "vault-auth-required", Kind: "vault", DisplayName: "Vault auth required", Enabled: true, Address: "https://vault.invalid", Refs: map[string]sourceRefConfig{
+			"services/payments/runtime/AUTH_REQUIRED_REF": {Path: "secret/data/payments", Field: "value"},
+		},
+	}}}
+
+	res, err := backend.listProvisioningStatus("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != "ready" || len(res.Results) != 3 {
+		t.Fatalf("provisioning response = %#v", res)
+	}
+	byRef := map[string]provisioningStatusRecord{}
+	for _, result := range res.Results {
+		byRef[result.Ref] = result
+	}
+	if got := byRef[readyRef]; got.ProvisionedState != "ready" || got.LastOutcome != "ready" || got.DesiredOperation != "none" || got.GeneratedValuePolicy.Kind != "opaque" {
+		t.Fatalf("ready provisioning record = %#v", got)
+	}
+	if got := byRef["services/search/runtime/EXTERNAL_ONLY_REF"]; got.ProvisionedState != "pending" || got.LastOutcome != "ready" || got.NextAction != "writeback_generated_value_or_mark_ready" {
+		t.Fatalf("source ready provisioning record = %#v", got)
+	}
+	if got := byRef["services/payments/runtime/AUTH_REQUIRED_REF"]; got.ProvisionedState != "blocked" || got.LastOutcome != "source_auth_required" || got.NextAction != "reconnect_source" {
+		t.Fatalf("auth-required provisioning record = %#v", got)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), managedSecretValue, "provider-token-fixture")
+
+	missing, err := backend.listProvisioningStatus("", "services/missing/runtime/NEW_SECRET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing.Results) != 1 || missing.Results[0].ProvisionedState != "not_planned" || missing.Results[0].LastOutcome != "missing_ref" {
+		t.Fatalf("missing provisioning record = %#v", missing)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, missing), managedSecretValue, "provider-token-fixture")
+}
+
+func TestProvisioningStatusHTTPContractIsMetadataOnly(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/v1/provisioning/status?ref="+ref, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readClose(t, res.Body)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("provisioning status=%d body=%s", res.StatusCode, got)
+	}
+	if !bytes.Contains(got, []byte(`"provisionedState":"ready"`)) || !bytes.Contains(got, []byte(`"generatedValuePolicy"`)) {
+		t.Fatalf("provisioning body=%s", got)
+	}
+	assertNoSecretMaterial(t, got, managedSecretValue, "test-token")
+}
+
 func TestManagedRevealIsOnlyRawValueSuccessPath(t *testing.T) {
 	backend := managedTestBackend(t)
 	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -13,10 +13,56 @@ The contract is metadata-first. List/search/value-search responses return safe r
 - Edit/reset/policy operations expose dry-run/preview before apply.
 - Apply requests are secret-bearing where relevant and use the same local API auth and body-size guardrails as existing write/resolve endpoints.
 - Audit entries record operation/ref/outcome/request identity only; they do not include raw values.
+- Provisioning status is metadata-only. It reports generated value policy classes and per-ref status, never generated values, master keys, provider credentials, tokens, private keys, cookies, passwords, environment values, or recovery material.
 
 ## Endpoints
 
 All endpoints require the local API token when configured, via `Authorization: Bearer <token>` or `X-SecretsBroker-Token`.
+
+### `GET /v1/provisioning/status?ref=<secret-ref>&search=<metadata-query>`
+
+Returns metadata-only first-run generated/provisioned secret status for Service Lasso and Service Admin.
+
+The endpoint reports local encrypted-store refs, configured source refs, and an explicit `missing_ref` record when a valid `ref` query does not exist in either place. It is intended for first-run and operator dashboards that need to explain whether a generated/service secret is ready, pending, blocked, failed, stale, or not planned without reading secret values.
+
+Response:
+
+```json
+{
+  "serviceId": "@secretsbroker",
+  "apiVersion": "secretsbroker.local/v1",
+  "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+  "outcome": "ready",
+  "results": [
+    {
+      "ref": "services/@serviceadmin/runtime/SESSION_SIGNING_KEY",
+      "namespace": "services/@serviceadmin/runtime",
+      "ownerServiceId": "@serviceadmin",
+      "sourceId": "local",
+      "providerId": "local",
+      "providerKind": "local-encrypted-store",
+      "desiredOperation": "none",
+      "provisionedState": "ready",
+      "lastOperationId": "2026-05-07T00:00:00Z",
+      "lastOutcome": "ready",
+      "auditStatus": "audit_available",
+      "policyResult": "allowed",
+      "generatedValuePolicy": {
+        "kind": "opaque",
+        "lengthClass": "policy_default",
+        "entropyClass": "policy_default",
+        "rotationPolicy": "service_policy"
+      }
+    }
+  ]
+}
+```
+
+Per-ref `provisionedState` values: `not_planned`, `pending`, `ready`, `blocked`, `failed`, and `stale`.
+
+Per-ref `lastOutcome` values include `ready`, `missing_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `degraded`, `disabled`, and `stale`.
+
+The endpoint is read-only. A `pending` record does not generate, write, rotate, or migrate a value; callers must use the existing signed write-back path or a future explicit generation operation to change broker state.
 
 ### `GET /v1/management/secrets?search=<metadata-query>`
 
@@ -275,4 +321,4 @@ Preview/apply policy changes. This first contract records the requested policy h
 
 ## Typed outcomes
 
-Common outcomes: `ready`, `dry_run_ready`, `applied`, `migrated`, `partial_failure`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`, `stale_plan`, `skipped`, `failed`.
+Common outcomes: `ready`, `dry_run_ready`, `applied`, `migrated`, `partial_failure`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`, `stale`, `stale_plan`, `skipped`, `failed`.


### PR DESCRIPTION
## Issue
Refs #111

## Summary
- Adds GET /v1/provisioning/status as a metadata-only generated/provisioned secret status surface.
- Reports local ready refs, configured source refs, source auth/blocked states, and explicit missing-ref status without returning secret values.
- Updates /status, /capabilities, and docs/secrets-management-api.md to reflect the implemented local store, resolve, write-back, and provisioning status surfaces.

## Scope
- In scope: broker metadata API shape, source/local status derivation, docs, focused tests.
- Out of scope: mutating broker-generated secret operation; pending records direct callers to existing signed write-back or future explicit generation flows.

## Spec / contract / fixture impact
- Updated: docs/secrets-management-api.md.
- Updated: /capabilities endpoint list and features.

## Validation
- PASS go test ./cmd/secretsbroker -run "Test(ProvisioningStatus|Managed|RotationDryRun)" -count=1 — evidence in .work-agent/logs for run $(Split-Path C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260702T102919Z -Leaf).
- PASS go test ./... -count=1 — evidence in .work-agent/logs for run $(Split-Path C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260702T102919Z -Leaf).
- PASS GitHub Actions alidate-template on linux, macOS, and Windows for commit 9decee5306b9fdf25da7cc3a3050a3901236fce.

## Approval trail
- Required: no special approval identified for this bounded metadata-only API slice.

## Cleanup
- Branch remains active for PR review/merge. #111 should remain open after this slice because broker-owned generation/apply semantics are still future work.