### PR TITLE
Migrate manifests to healthchecks array

### DIFF
--- a/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
+++ b/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
@@ -197,7 +197,7 @@ Current health-model direction:
 - default health model is **process**
 - other health models are allowed when explicitly declared by the service config
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks types observed:
 - `http`
 - `tcp`
 - `file`

--- a/docs/reference/EXAMPLE-service.json
+++ b/docs/reference/EXAMPLE-service.json
@@ -30,9 +30,12 @@
     "env": {
       "ECHO_MESSAGE": "hello from service-template"
     },
-    "depend_on": [],
-    "healthcheck": {
+    "depend_on": []
+  },
+  "healthchecks": [
+    {
+      "id": "process-health",
       "type": "process"
     }
-  }
+  ]
 }

--- a/docs/reference/SERVICE-STRUCTURE-REVIEW.md
+++ b/docs/reference/SERVICE-STRUCTURE-REVIEW.md
@@ -231,7 +231,7 @@ Most services follow this high-level shape:
 - `env`
 - `globalenv`
 - `depend_on`
-- `healthcheck`
+- `healthchecks`
 - `authentication`
 - `outputvarregex`
 - `urls`
@@ -262,7 +262,7 @@ Services explicitly declare dependency order.
 
 This is core and should survive.
 
-### Pattern 4 - `healthcheck`
+### Pattern 4 - `healthchecks`
 Services declare their runtime health expectations.
 
 This is core and should survive, but may need normalization.
@@ -491,7 +491,7 @@ The template repo should likely include:
 
 ### Optional
 - sample config
-- healthcheck probe script
+- healthchecks probe script
 - migration/setup scripts
 - platform-specific packaging helpers
 

--- a/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
+++ b/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
@@ -163,7 +163,7 @@ This determines reserved ports, exposed URLs, and how service endpoints are desc
 
 ### F. Health/readiness
 Fields used include:
-- `healthcheck`
+- `healthchecks`
 
 This determines how the runtime checks whether a service is started/healthy.
 

--- a/docs/service-contract.md
+++ b/docs/service-contract.md
@@ -10,7 +10,7 @@ Key starter files:
 - `scripts/package.*` - reference packaging entrypoints
 - `runtime/` - sample payload/runtime files
 - `config/` - example config inputs
-- `docs/service-json-reference.md` - one-stop reference for `service.json` fields, healthcheck setup, and first-pass contract guidance
+- `docs/service-json-reference.md` - one-stop reference for `service.json` fields, `healthchecks[]` setup, and first-pass contract guidance
 
 This starter is intentionally minimal. It is meant to prove the contract shape, not to be a full production service.
 

--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -13,7 +13,7 @@ It is meant to make the template usable without forcing service authors to recon
 - `actions`
 - `execconfig`
 - env / dependencies / ports
-- healthcheck direction
+- `healthchecks[]` direction
 - examples
 - what is currently canonical vs still illustrative
 
@@ -23,7 +23,7 @@ The current template direction is:
 - **default health model = `process`**
 - other health models are used only when explicitly declared by service config
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks types observed:
 - `http`
 - `tcp`
 - `file`
@@ -99,11 +99,14 @@ The current sample in this repo is:
     "env": {
       "ECHO_MESSAGE": "hello from service-template"
     },
-    "depend_on": [],
-    "healthcheck": {
+    "depend_on": []
+  },
+  "healthchecks": [
+    {
+      "id": "process-health",
       "type": "process"
     }
-  }
+  ]
 }
 ```
 
@@ -258,7 +261,7 @@ Current direction:
 - use this for services that require another service/runtime/provider first
 - keep empty for the minimal sample
 
-## Healthcheck
+## Healthchecks
 
 ### Default rule
 Current rule:
@@ -266,15 +269,18 @@ Current rule:
 
 Example:
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-health",
+    "type": "process"
+  }
+]
 ```
 
 This is the right default for a simple sample service.
 
-### Observed donor healthcheck types
-The donor runtime/code shows these healthcheck types:
+### Observed donor healthchecks types
+The donor runtime/code shows these healthchecks types:
 - `http`
 - `tcp`
 - `file`
@@ -282,66 +288,81 @@ The donor runtime/code shows these healthcheck types:
 
 `process` is the current template default direction, even though the donor code paths most explicitly surfaced in ref material are the four types above.
 
-### `process` healthcheck
+### `process` healthchecks item
 Use when:
 - service health is adequately represented by the process being up/running
 - you do not need a deeper readiness endpoint yet
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-health",
+    "type": "process"
+  }
+]
 ```
 
-### `http` healthcheck
+### `http` healthchecks item
 Use when:
 - the service exposes an HTTP readiness or health endpoint
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "http",
-  "url": "http://localhost:${SERVICE_PORT}/health",
-  "expected_status": 200
-}
+"healthchecks": [
+  {
+    "id": "http-health",
+    "type": "http",
+    "url": "http://localhost:${SERVICE_PORT}/health",
+    "expected_status": 200
+  }
+]
 ```
 
-### `tcp` healthcheck
+### `tcp` healthchecks item
 Use when:
 - readiness is best represented by a socket accepting connections
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "tcp"
-}
+"healthchecks": [
+  {
+    "id": "tcp-ready",
+    "type": "tcp"
+  }
+]
 ```
 
 Current donor behavior suggests this relies on the configured service host/port.
 
-### `file` healthcheck
+### `file` healthchecks item
 Use when:
 - the service creates a file that represents successful readiness/setup
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "file",
-  "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
-}
+"healthchecks": [
+  {
+    "id": "ready-file",
+    "type": "file",
+    "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
+  }
+]
 ```
 
-### `variable` healthcheck
+### `variable` healthchecks item
 Use when:
 - a specific resolved/exported variable is the readiness signal
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "variable",
-  "variable": "${SERVICE_URL}"
-}
+"healthchecks": [
+  {
+    "id": "service-url-ready",
+    "type": "variable",
+    "variable": "${SERVICE_URL}"
+  }
+]
 ```
 
 ## Other important manifest aspects

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -11,7 +11,7 @@ Current first-pass direction:
 - local and CI usage should share the same harness contract path
 - default health model is `process`; other health models should come from explicit service config
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks types observed:
 - `http`
 - `tcp`
 - `file`

--- a/service.json
+++ b/service.json
@@ -140,11 +140,14 @@
       "SECRETSBROKER_STATE": "setup_needed",
       "SECRETSBROKER_LISTEN": "127.0.0.1:17890"
     },
-    "depend_on": [],
-    "healthcheck": {
+    "depend_on": []
+  },
+  "healthchecks": [
+    {
+      "id": "secretsbroker-http-health",
       "type": "http",
       "url": "http://127.0.0.1:17890/health",
       "timeoutSeconds": 5
     }
-  }
+  ]
 }

--- a/services/@nginx/service.json
+++ b/services/@nginx/service.json
@@ -91,11 +91,14 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${HTTP_PORT}/health",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "nginx-http-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${HTTP_PORT}/health",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -43,7 +43,10 @@
       }
     }
   },
-  "healthcheck": {
-    "type": "process"
-  }
+  "healthchecks": [
+    {
+      "id": "serviceadmin-process-health",
+      "type": "process"
+    }
+  ]
 }

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -151,11 +151,14 @@
       }
     ]
   },
-  "healthcheck": {
-    "type": "http",
-    "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
-    "expected_status": 200,
-    "retries": 80,
-    "interval": 250
-  }
+  "healthchecks": [
+    {
+      "id": "traefik-ping-health",
+      "type": "http",
+      "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
+      "expected_status": 200,
+      "retries": 80,
+      "interval": 250
+    }
+  ]
 }

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -69,7 +69,10 @@
       "kind": "local"
     }
   ],
-  "healthcheck": {
-    "type": "process"
-  }
+  "healthchecks": [
+    {
+      "id": "echo-process-health",
+      "type": "process"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Migrates checked-in service manifests from singular `healthcheck` to canonical `healthchecks[]`.
- Adds stable per-check IDs while preserving existing process/http readiness behavior.
- Updates Secrets Broker service manifest examples and reference docs to teach `healthchecks[]`.

## Verification
- JSON parse validation for all touched manifests/examples
- Contract check: each touched manifest/example has `healthchecks[]`, unique IDs, and no legacy `healthcheck`
- `scripts/verify.ps1` with repo-local `.harness/bin/service-lasso-harness.exe`
- `go test ./...` (initial Windows named-pipe test timed out once, targeted rerun passed, full rerun passed)

Closes #126.
