### PR TITLE
#132 define management operation lifecycle contract

### DIFF
--- a/cmd/secretsbroker/backup_restore.go
+++ b/cmd/secretsbroker/backup_restore.go
@@ -242,6 +242,15 @@ func (b *localBackend) rotateMasterKey(newMasterKey string) (keyRotateResponse, 
 		}
 		plaintext[ref] = value
 	}
+	tombstonePlaintext := make(map[string]string, len(store.Tombstones))
+	for ref, tombstone := range store.Tombstones {
+		value, err := b.decrypt(tombstone.Entry.Payload)
+		if err != nil {
+			_ = b.audit("key_rotate", ref, "degraded", "", "")
+			return keyRotateResponse{}, errInvalidBackupKey
+		}
+		tombstonePlaintext[ref] = value
+	}
 	oldKeyID := masterKeyID(b.masterKey)
 	b.masterKey = newMasterKey
 	for ref, value := range plaintext {
@@ -254,6 +263,17 @@ func (b *localBackend) rotateMasterKey(newMasterKey string) (keyRotateResponse, 
 		entry.Payload = payload
 		entry.Metadata.UpdatedAt = b.now()
 		store.Secrets[ref] = entry
+	}
+	for ref, value := range tombstonePlaintext {
+		tombstone := store.Tombstones[ref]
+		payload, err := b.encrypt(value)
+		if err != nil {
+			_ = b.audit("key_rotate", ref, "degraded", "", "")
+			return keyRotateResponse{}, err
+		}
+		tombstone.Entry.Payload = payload
+		tombstone.Entry.Metadata.UpdatedAt = b.now()
+		store.Tombstones[ref] = tombstone
 	}
 	store.KeyID = masterKeyID(newMasterKey)
 	store.KeyVersion = masterKeyVersion
@@ -269,6 +289,11 @@ func (b *localBackend) rotateMasterKey(newMasterKey string) (keyRotateResponse, 
 func (b *localBackend) verifyStoreDecryptable(store localStoreFile) error {
 	for _, entry := range store.Secrets {
 		if _, err := b.decrypt(entry.Payload); err != nil {
+			return err
+		}
+	}
+	for _, tombstone := range store.Tombstones {
+		if _, err := b.decrypt(tombstone.Entry.Payload); err != nil {
 			return err
 		}
 	}

--- a/cmd/secretsbroker/contract_artifacts_test.go
+++ b/cmd/secretsbroker/contract_artifacts_test.go
@@ -46,6 +46,9 @@ func contractRoutes() []contractRoute {
 	migrationAction := func(path, summary string) contractRoute {
 		return contractRoute{Method: http.MethodPost, Path: path, Summary: summary, Auth: true, Request: migrationPlanRequest{}, Response: migrationPlanResponse{}}
 	}
+	decommissionAction := func(path, summary string) contractRoute {
+		return contractRoute{Method: http.MethodPost, Path: path, Summary: summary, Auth: true, Request: decommissionRequest{}, Response: decommissionResponse{}}
+	}
 
 	return []contractRoute{
 		{Method: http.MethodGet, Path: "/health", Summary: "Broker liveness", Response: HealthResponse{}},
@@ -79,6 +82,9 @@ func contractRoutes() []contractRoute {
 		managedAction("/v1/management/secrets/edit/apply", "Apply a managed secret edit"),
 		managedAction("/v1/management/secrets/reset/dry-run", "Preview a managed secret reset"),
 		managedAction("/v1/management/secrets/reset/apply", "Apply a managed secret reset"),
+		decommissionAction("/v1/management/secrets/decommission/dry-run", "Plan a local secret decommission"),
+		decommissionAction("/v1/management/secrets/decommission/apply", "Decommission a local secret into an encrypted tombstone"),
+		decommissionAction("/v1/management/secrets/decommission/restore", "Restore a local secret from an encrypted tombstone"),
 		{Method: http.MethodPost, Path: "/v1/management/secrets/rotation/dry-run", Summary: "Preview credential rotation", Auth: true, Request: rotationDryRunRequest{}, Response: rotationDryRunResponse{}},
 		bulkAction("/v1/management/secrets/campaigns/create", "Create a bulk secret campaign"),
 		bulkAction("/v1/management/secrets/campaigns/revalidate", "Revalidate a bulk secret campaign"),

--- a/cmd/secretsbroker/contract_artifacts_test.go
+++ b/cmd/secretsbroker/contract_artifacts_test.go
@@ -368,6 +368,8 @@ func (b *contractSchemaBuilder) schemaFor(typ reflect.Type) map[string]any {
 			schema["enum"] = []string{"read", "mutation"}
 		case "OperationScope":
 			schema["enum"] = []string{"broker-local", "provider-remote", "source-boundary", "mixed"}
+		case "OperationCompletionMode":
+			schema["enum"] = []string{"synchronous", "asynchronous"}
 		}
 		return schema
 	case reflect.Bool:

--- a/cmd/secretsbroker/decommission.go
+++ b/cmd/secretsbroker/decommission.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const decommissionPlanTTL = 5 * time.Minute
+
+var (
+	errDecommissionAuditUnavailable = errors.New("decommission audit unavailable")
+	errDecommissionDependency       = errors.New("decommission dependency check blocked")
+	errDecommissionStalePlan        = errors.New("decommission plan is stale")
+)
+
+type localSecretTombstone struct {
+	Ref                string      `json:"ref"`
+	State              string      `json:"state"`
+	Version            string      `json:"version"`
+	DecommissionID     string      `json:"decommissionOperationId"`
+	RestoreOperationID string      `json:"restoreOperationId,omitempty"`
+	DecommissionedAt   time.Time   `json:"decommissionedAt"`
+	RestoredAt         time.Time   `json:"restoredAt,omitempty"`
+	Entry              secretEntry `json:"entry"`
+}
+
+type decommissionPlan struct {
+	Ref                string    `json:"ref"`
+	OperationID        string    `json:"operationId"`
+	ExpectedVersion    string    `json:"expectedVersion"`
+	DependencyStatus   string    `json:"dependencyStatus"`
+	DependencySnapshot string    `json:"dependencySnapshot"`
+	ExpiresAt          time.Time `json:"expiresAt"`
+	Signature          string    `json:"signature"`
+}
+
+type decommissionRequest struct {
+	RequestID          string            `json:"requestId"`
+	ServiceID          string            `json:"serviceId"`
+	Ref                string            `json:"ref"`
+	OperationID        string            `json:"operationId"`
+	Reason             string            `json:"reason"`
+	Confirm            bool              `json:"confirm"`
+	DependencyStatus   string            `json:"dependencyStatus"`
+	DependencySnapshot string            `json:"dependencySnapshot"`
+	Dependencies       []string          `json:"dependencies"`
+	ExpectedVersion    string            `json:"expectedVersion"`
+	Plan               *decommissionPlan `json:"plan,omitempty"`
+}
+
+type decommissionTombstoneMetadata struct {
+	State              string    `json:"state"`
+	Version            string    `json:"version"`
+	DecommissionID     string    `json:"decommissionOperationId"`
+	RestoreOperationID string    `json:"restoreOperationId,omitempty"`
+	DecommissionedAt   time.Time `json:"decommissionedAt"`
+	RestoredAt         time.Time `json:"restoredAt,omitempty"`
+}
+
+type decommissionResponse struct {
+	ServiceID            string                         `json:"serviceId"`
+	APIVersion           string                         `json:"apiVersion"`
+	RequestID            string                         `json:"requestId,omitempty"`
+	OperationID          string                         `json:"operationId,omitempty"`
+	Ref                  string                         `json:"ref"`
+	Operation            string                         `json:"operation"`
+	Mode                 string                         `json:"mode"`
+	Outcome              string                         `json:"outcome"`
+	Applied              bool                           `json:"applied"`
+	RequiresConfirmation bool                           `json:"requiresConfirmation"`
+	AuditStatus          string                         `json:"auditStatus"`
+	PolicyResult         string                         `json:"policyResult"`
+	NextAction           string                         `json:"nextAction,omitempty"`
+	ExpectedVersion      string                         `json:"expectedVersion,omitempty"`
+	DependencyStatus     string                         `json:"dependencyStatus"`
+	DependencySnapshot   string                         `json:"dependencySnapshot,omitempty"`
+	Dependencies         []string                       `json:"dependencies"`
+	Recoverable          bool                           `json:"recoverable"`
+	Plan                 *decommissionPlan              `json:"plan,omitempty"`
+	Tombstone            *decommissionTombstoneMetadata `json:"tombstone,omitempty"`
+	AffectedRefs         []string                       `json:"affectedRefs"`
+	AffectedServices     []string                       `json:"affectedServices"`
+}
+
+func (b *localBackend) decommissionDryRun(req decommissionRequest) (decommissionResponse, error) {
+	res := baseDecommissionResponse(req, "decommission", "dry-run")
+	res.RequiresConfirmation = true
+	fail := func(outcome, nextAction string, operationErr error) (decommissionResponse, error) {
+		return b.decommissionFailureWithAudit("management_decommission_dry_run", req, res, outcome, nextAction, operationErr)
+	}
+	if !validSecretRef(req.Ref) || safeOperationToken(req.OperationID) == "" {
+		return fail("invalid_ref", "provide_valid_ref_and_operation_id", errInvalidRef)
+	}
+	if b.locked() {
+		return fail("locked", "unlock_broker", errLocked)
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return fail("degraded", "inspect_local_store", errBackendDegraded)
+	}
+	entry, ok := store.Secrets[strings.TrimSpace(req.Ref)]
+	if !ok {
+		if b.configuredSourceHasRef(req.Ref) {
+			res.PolicyResult = "unsupported"
+			return fail("unsupported", "use_provider_specific_decommission", errUnsupportedProvider)
+		}
+		return fail("missing_ref", "check_ref", errMissingRef)
+	}
+	res.ExpectedVersion = entry.Metadata.Version
+	res.DependencyStatus = strings.ToLower(strings.TrimSpace(req.DependencyStatus))
+	dependencySnapshot := strings.TrimSpace(req.DependencySnapshot)
+	res.Dependencies = safeDecommissionDependencies(req.Dependencies)
+	if res.DependencyStatus != "clear" || !validDependencySnapshot(dependencySnapshot) || len(res.Dependencies) != 0 || len(res.Dependencies) != len(safeList(req.Dependencies)) {
+		res.PolicyResult = "denied"
+		return fail("dependency_blocked", "clear_dependencies_and_refresh_snapshot", errDecommissionDependency)
+	}
+	res.DependencySnapshot = dependencySnapshot
+	plan := decommissionPlan{
+		Ref:                strings.TrimSpace(req.Ref),
+		OperationID:        safeOperationToken(req.OperationID),
+		ExpectedVersion:    entry.Metadata.Version,
+		DependencyStatus:   "clear",
+		DependencySnapshot: res.DependencySnapshot,
+		ExpiresAt:          b.now().Add(decommissionPlanTTL),
+	}
+	signed, err := signDecommissionPlan(plan, b.masterKey)
+	if err != nil {
+		return fail("locked", "unlock_broker", errLocked)
+	}
+	if err := b.audit("management_decommission_dry_run", req.Ref, "dry_run_ready", req.ServiceID, req.RequestID); err != nil {
+		return decommissionAuditUnavailable(res), errDecommissionAuditUnavailable
+	}
+	res.Outcome = "dry_run_ready"
+	res.AuditStatus = "audit_recorded"
+	res.PolicyResult = "allowed"
+	res.NextAction = "confirm_signed_plan_before_expiry"
+	res.Plan = &signed
+	res.Recoverable = true
+	return res, nil
+}
+
+func validDependencySnapshot(value string) bool {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil
+}
+
+func safeDecommissionDependencies(values []string) []string {
+	clean := make([]string, 0, len(values))
+	for _, value := range safeList(values) {
+		if len(value) > 128 || (!strings.HasPrefix(value, "@") && !strings.HasPrefix(value, "service:")) || !validSecretRef(value) {
+			continue
+		}
+		clean = append(clean, value)
+	}
+	return clean
+}
+
+func (b *localBackend) decommissionApply(req decommissionRequest) (decommissionResponse, error) {
+	b.decommissionMu.Lock()
+	defer b.decommissionMu.Unlock()
+
+	res := baseDecommissionResponse(req, "decommission", "apply")
+	fail := func(outcome, nextAction string, operationErr error) (decommissionResponse, error) {
+		return b.decommissionFailureWithAudit("management_decommission_apply", req, res, outcome, nextAction, operationErr)
+	}
+	if !validSecretRef(req.Ref) || !req.Confirm || strings.TrimSpace(req.Reason) == "" || req.Plan == nil {
+		res.PolicyResult = "denied"
+		return fail("policy_denied", "confirm_with_audit_reason_and_fresh_plan", errPolicyDenied)
+	}
+	plan := *req.Plan
+	if err := verifyDecommissionPlan(plan, b.masterKey, b.now()); err != nil || strings.TrimSpace(req.Ref) != plan.Ref || safeOperationToken(req.OperationID) != plan.OperationID {
+		return fail("stale_plan", "run_fresh_decommission_dry_run", errDecommissionStalePlan)
+	}
+	res.OperationID = plan.OperationID
+	res.ExpectedVersion = plan.ExpectedVersion
+	res.DependencyStatus = plan.DependencyStatus
+	res.DependencySnapshot = plan.DependencySnapshot
+	if b.locked() {
+		return fail("locked", "unlock_broker", errLocked)
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return fail("degraded", "inspect_local_store", errBackendDegraded)
+	}
+	if tombstone, ok := store.Tombstones[plan.Ref]; ok && tombstone.State == "decommissioned" {
+		if tombstone.DecommissionID != plan.OperationID || tombstone.Version != plan.ExpectedVersion {
+			return fail("stale_plan", "inspect_tombstone_and_run_fresh_plan", errDecommissionStalePlan)
+		}
+		if err := b.audit("management_decommission_apply", plan.Ref, "applied", req.ServiceID, req.RequestID); err != nil {
+			return decommissionAuditUnavailable(res), errDecommissionAuditUnavailable
+		}
+		return decommissionAppliedResponse(res, tombstone, "already_decommissioned"), nil
+	}
+	entry, ok := store.Secrets[plan.Ref]
+	if !ok {
+		return fail("missing_ref", "check_ref_or_tombstone", errMissingRef)
+	}
+	if entry.Metadata.Version != plan.ExpectedVersion {
+		return fail("stale_plan", "run_fresh_decommission_dry_run", errDecommissionStalePlan)
+	}
+	if err := b.requireDecommissionAudit("management_decommission_apply", req); err != nil {
+		return decommissionAuditUnavailable(res), err
+	}
+	now := b.now()
+	tombstone := localSecretTombstone{Ref: plan.Ref, State: "decommissioned", Version: entry.Metadata.Version, DecommissionID: plan.OperationID, DecommissionedAt: now, Entry: entry}
+	store.Tombstones[plan.Ref] = tombstone
+	delete(store.Secrets, plan.Ref)
+	store.UpdatedAt = now
+	if err := b.saveStore(store); err != nil {
+		return fail("degraded", "retry_or_restore_store", errBackendDegraded)
+	}
+	_ = b.audit("management_decommission_apply", plan.Ref, "applied", req.ServiceID, req.RequestID)
+	return decommissionAppliedResponse(res, tombstone, "retain_tombstone_until_recovery_window_expires"), nil
+}
+
+func (b *localBackend) decommissionRestore(req decommissionRequest) (decommissionResponse, error) {
+	b.decommissionMu.Lock()
+	defer b.decommissionMu.Unlock()
+
+	res := baseDecommissionResponse(req, "decommission_restore", "apply")
+	fail := func(outcome, nextAction string, operationErr error) (decommissionResponse, error) {
+		return b.decommissionFailureWithAudit("management_decommission_restore", req, res, outcome, nextAction, operationErr)
+	}
+	expectedVersion := strings.TrimSpace(req.ExpectedVersion)
+	if !validSecretRef(req.Ref) || safeOperationToken(req.OperationID) == "" || !req.Confirm || strings.TrimSpace(req.Reason) == "" || expectedVersion == "" {
+		res.PolicyResult = "denied"
+		return fail("policy_denied", "confirm_restore_with_operation_id_expected_version_and_audit_reason", errPolicyDenied)
+	}
+	if b.locked() {
+		return fail("locked", "unlock_broker", errLocked)
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return fail("degraded", "inspect_local_store", errBackendDegraded)
+	}
+	tombstone, ok := store.Tombstones[strings.TrimSpace(req.Ref)]
+	if !ok || tombstone.Version != expectedVersion {
+		return fail("stale_plan", "inspect_current_tombstone", errDecommissionStalePlan)
+	}
+	res.ExpectedVersion = expectedVersion
+	operationID := safeOperationToken(req.OperationID)
+	if active, exists := store.Secrets[tombstone.Ref]; exists {
+		if tombstone.State == "restored" && tombstone.RestoreOperationID == operationID && active.Metadata.Version == tombstone.Version {
+			if err := b.audit("management_decommission_restore", tombstone.Ref, "applied", req.ServiceID, req.RequestID); err != nil {
+				return decommissionAuditUnavailable(res), errDecommissionAuditUnavailable
+			}
+			return decommissionRestoredResponse(res, tombstone, "already_restored"), nil
+		}
+		return fail("stale_plan", "inspect_active_secret_before_restore", errDecommissionStalePlan)
+	}
+	if tombstone.State != "decommissioned" {
+		return fail("stale_plan", "inspect_current_tombstone", errDecommissionStalePlan)
+	}
+	if err := b.requireDecommissionAudit("management_decommission_restore", req); err != nil {
+		return decommissionAuditUnavailable(res), err
+	}
+	now := b.now()
+	store.Secrets[tombstone.Ref] = tombstone.Entry
+	tombstone.State = "restored"
+	tombstone.RestoreOperationID = operationID
+	tombstone.RestoredAt = now
+	store.Tombstones[tombstone.Ref] = tombstone
+	store.UpdatedAt = now
+	if err := b.saveStore(store); err != nil {
+		return fail("degraded", "retry_or_restore_store", errBackendDegraded)
+	}
+	_ = b.audit("management_decommission_restore", tombstone.Ref, "applied", req.ServiceID, req.RequestID)
+	return decommissionRestoredResponse(res, tombstone, "secret_restored_from_encrypted_tombstone"), nil
+}
+
+func (b *localBackend) configuredSourceHasRef(ref string) bool {
+	for _, source := range b.sources.enabledSources() {
+		if _, ok := source.Refs[strings.TrimSpace(ref)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func signDecommissionPlan(plan decommissionPlan, key string) (decommissionPlan, error) {
+	if strings.TrimSpace(key) == "" {
+		return plan, errLocked
+	}
+	plan.Signature = ""
+	payload, err := json.Marshal(plan)
+	if err != nil {
+		return plan, err
+	}
+	mac := hmac.New(sha256.New, []byte("service-lasso:decommission-plan:v1:"+key))
+	_, _ = mac.Write(payload)
+	plan.Signature = "hmac-sha256:" + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return plan, nil
+}
+
+func verifyDecommissionPlan(plan decommissionPlan, key string, now time.Time) error {
+	if strings.TrimSpace(plan.Signature) == "" || strings.TrimSpace(plan.Ref) == "" || strings.TrimSpace(plan.OperationID) == "" || strings.TrimSpace(plan.ExpectedVersion) == "" || plan.DependencyStatus != "clear" || strings.TrimSpace(plan.DependencySnapshot) == "" || !plan.ExpiresAt.After(now) {
+		return errDecommissionStalePlan
+	}
+	signature := plan.Signature
+	signed, err := signDecommissionPlan(plan, key)
+	if err != nil || !constantTimeTokenEqual(signature, signed.Signature) {
+		return errDecommissionStalePlan
+	}
+	return nil
+}
+
+func (b *localBackend) requireDecommissionAudit(operation string, req decommissionRequest) error {
+	if b == nil || strings.TrimSpace(b.auditPath) == "" {
+		return errDecommissionAuditUnavailable
+	}
+	if err := b.audit(operation, req.Ref, "ready", req.ServiceID, req.RequestID); err != nil {
+		return errDecommissionAuditUnavailable
+	}
+	return nil
+}
+
+func baseDecommissionResponse(req decommissionRequest, operation, mode string) decommissionResponse {
+	return decommissionResponse{
+		ServiceID:            serviceID,
+		APIVersion:           apiVersion,
+		RequestID:            strings.TrimSpace(req.RequestID),
+		OperationID:          safeOperationToken(req.OperationID),
+		Ref:                  strings.TrimSpace(req.Ref),
+		Operation:            operation,
+		Mode:                 mode,
+		Outcome:              "pending",
+		RequiresConfirmation: mode != "dry-run",
+		AuditStatus:          "audit_pending",
+		PolicyResult:         "unknown",
+		DependencyStatus:     "unknown",
+		Dependencies:         []string{},
+		AffectedRefs:         safeList([]string{req.Ref}),
+		AffectedServices:     safeList([]string{firstNonEmpty(req.ServiceID, ownerFromRef(req.Ref))}),
+	}
+}
+
+func decommissionFailure(res decommissionResponse, outcome, nextAction string, _ error) decommissionResponse {
+	res.Outcome = outcome
+	res.Applied = false
+	res.NextAction = nextAction
+	if res.PolicyResult == "unknown" {
+		res.PolicyResult = "denied"
+	}
+	return res
+}
+
+func (b *localBackend) decommissionFailureWithAudit(operation string, req decommissionRequest, res decommissionResponse, outcome, nextAction string, operationErr error) (decommissionResponse, error) {
+	res = decommissionFailure(res, outcome, nextAction, operationErr)
+	if b == nil || strings.TrimSpace(b.auditPath) == "" {
+		return res, operationErr
+	}
+	if err := b.audit(operation, req.Ref, outcome, req.ServiceID, req.RequestID); err == nil {
+		res.AuditStatus = "audit_recorded"
+	} else {
+		res.AuditStatus = "audit_unavailable"
+	}
+	return res, operationErr
+}
+
+func decommissionAuditUnavailable(res decommissionResponse) decommissionResponse {
+	res = decommissionFailure(res, "audit_unavailable", "restore_audit_and_retry", errDecommissionAuditUnavailable)
+	res.AuditStatus = "audit_unavailable"
+	return res
+}
+
+func decommissionAppliedResponse(res decommissionResponse, tombstone localSecretTombstone, nextAction string) decommissionResponse {
+	res.Outcome = "applied"
+	res.Applied = true
+	res.RequiresConfirmation = false
+	res.AuditStatus = "audit_recorded"
+	res.PolicyResult = "allowed"
+	res.NextAction = nextAction
+	res.Recoverable = true
+	metadata := tombstoneMetadata(tombstone)
+	res.Tombstone = &metadata
+	return res
+}
+
+func decommissionRestoredResponse(res decommissionResponse, tombstone localSecretTombstone, nextAction string) decommissionResponse {
+	res = decommissionAppliedResponse(res, tombstone, nextAction)
+	res.Recoverable = false
+	return res
+}
+
+func tombstoneMetadata(tombstone localSecretTombstone) decommissionTombstoneMetadata {
+	return decommissionTombstoneMetadata{State: tombstone.State, Version: tombstone.Version, DecommissionID: tombstone.DecommissionID, RestoreOperationID: tombstone.RestoreOperationID, DecommissionedAt: tombstone.DecommissionedAt, RestoredAt: tombstone.RestoredAt}
+}
+
+func registerDecommissionHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	registerDecommissionAction(mux, security, "/v1/management/secrets/decommission/dry-run", backend.decommissionDryRun)
+	registerDecommissionAction(mux, security, "/v1/management/secrets/decommission/apply", backend.decommissionApply)
+	registerDecommissionAction(mux, security, "/v1/management/secrets/decommission/restore", backend.decommissionRestore)
+}
+
+func registerDecommissionAction(mux *http.ServeMux, security localAPISecurity, path string, handler func(decommissionRequest) (decommissionResponse, error)) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Use POST "+path+".", "invalid_ref", "")
+			return
+		}
+		if !security.require(w, r) {
+			return
+		}
+		var req decommissionRequest
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		res, err := handler(req)
+		if err != nil {
+			writeDecommissionError(w, err, res)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	})
+}
+
+func writeDecommissionError(w http.ResponseWriter, err error, res decommissionResponse) {
+	status := http.StatusServiceUnavailable
+	switch {
+	case errors.Is(err, errInvalidRef):
+		status = http.StatusBadRequest
+	case errors.Is(err, errMissingRef):
+		status = http.StatusNotFound
+	case errors.Is(err, errPolicyDenied), errors.Is(err, errUnsupportedProvider):
+		status = http.StatusForbidden
+	case errors.Is(err, errDecommissionDependency), errors.Is(err, errDecommissionStalePlan):
+		status = http.StatusConflict
+	}
+	writeJSON(w, status, res)
+}

--- a/cmd/secretsbroker/decommission_test.go
+++ b/cmd/secretsbroker/decommission_test.go
@@ -1,0 +1,441 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const decommissionSecretValue = "fixture-decommission-secret-value"
+
+func TestLocalDecommissionSignedPlanApplyRetryRestartAndRestore(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, decommissionSecretValue)
+	version := currentDecommissionVersion(t, backend, ref)
+
+	plan, err := backend.decommissionDryRun(decommissionRequest{
+		RequestID:          "req-decommission-plan",
+		ServiceID:          "@serviceadmin",
+		Ref:                ref,
+		OperationID:        "decommission-serviceadmin-session",
+		DependencyStatus:   "clear",
+		DependencySnapshot: "sha256:" + strings.Repeat("a", 64),
+	})
+	if err != nil || plan.Outcome != "dry_run_ready" || plan.Plan == nil || plan.Plan.Signature == "" || plan.ExpectedVersion != version || !plan.Recoverable {
+		t.Fatalf("plan = %#v err=%v", plan, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, plan), decommissionSecretValue, backend.masterKey)
+
+	request := decommissionRequest{
+		RequestID:   "req-decommission-apply",
+		ServiceID:   "@serviceadmin",
+		Ref:         ref,
+		OperationID: plan.OperationID,
+		Reason:      "service dependency review approved",
+		Confirm:     true,
+		Plan:        plan.Plan,
+	}
+	applied, err := backend.decommissionApply(request)
+	if err != nil || !applied.Applied || applied.Outcome != "applied" || applied.Tombstone == nil || applied.Tombstone.State != "decommissioned" || !applied.Recoverable {
+		t.Fatalf("applied = %#v err=%v", applied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), decommissionSecretValue, backend.masterKey)
+	assertDecommissioned(t, backend, ref, version)
+
+	storeBeforeRetry := readDecommissionStore(t, backend)
+	retried, err := backend.decommissionApply(request)
+	if err != nil || !retried.Applied || retried.NextAction != "already_decommissioned" {
+		t.Fatalf("retry = %#v err=%v", retried, err)
+	}
+	if !bytes.Equal(storeBeforeRetry, readDecommissionStore(t, backend)) {
+		t.Fatal("idempotent decommission retry changed the store")
+	}
+
+	restarted := newLocalBackend(backend.storePath, backend.auditPath, backend.masterKey)
+	restarted.eventPath = backend.eventPath
+	assertDecommissioned(t, restarted, ref, version)
+	restoreRequest := decommissionRequest{RequestID: "req-decommission-restore", ServiceID: "@serviceadmin", Ref: ref, OperationID: "restore-serviceadmin-session", ExpectedVersion: version, Reason: "rollback after consumer validation failure", Confirm: true}
+	restored, err := restarted.decommissionRestore(restoreRequest)
+	if err != nil || !restored.Applied || restored.Tombstone == nil || restored.Tombstone.State != "restored" || restored.Recoverable {
+		t.Fatalf("restored = %#v err=%v", restored, err)
+	}
+	resolved := restarted.resolve(resolveRequest{RequestID: "req-after-restore", ServiceID: "@serviceadmin", Purpose: "decommission-restore-test", Refs: []string{ref}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != decommissionSecretValue {
+		t.Fatalf("restored resolution = %#v", resolved)
+	}
+
+	storeBeforeRestoreRetry := readDecommissionStore(t, restarted)
+	restoredAgain, err := restarted.decommissionRestore(restoreRequest)
+	if err != nil || !restoredAgain.Applied || restoredAgain.NextAction != "already_restored" {
+		t.Fatalf("restore retry = %#v err=%v", restoredAgain, err)
+	}
+	if !bytes.Equal(storeBeforeRestoreRetry, readDecommissionStore(t, restarted)) {
+		t.Fatal("idempotent restore retry changed the store")
+	}
+
+	audit, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []string{"management_decommission_dry_run", "management_decommission_apply", "management_decommission_restore"} {
+		if !bytes.Contains(audit, []byte(operation)) {
+			t.Fatalf("audit missing %s: %s", operation, audit)
+		}
+	}
+	assertNoSecretMaterial(t, audit, decommissionSecretValue, backend.masterKey)
+}
+
+func TestLocalDecommissionFailsClosedForDependenciesStalePlansAndUnsupportedSources(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/API_KEY"
+	writeManagedTestSecret(t, backend, ref, decommissionSecretValue)
+
+	blocked, err := backend.decommissionDryRun(decommissionRequest{RequestID: "req-dependency-blocked", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-blocked", DependencyStatus: "blocked", DependencySnapshot: "sha256:" + strings.Repeat("b", 64), Dependencies: []string{"@api"}})
+	if !errors.Is(err, errDecommissionDependency) || blocked.Outcome != "dependency_blocked" || blocked.Plan != nil || len(blocked.Dependencies) != 1 {
+		t.Fatalf("dependency response = %#v err=%v", blocked, err)
+	}
+	unsafeMetadata, err := backend.decommissionDryRun(decommissionRequest{RequestID: "req-unsafe-dependency", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-unsafe", DependencyStatus: "clear", DependencySnapshot: decommissionSecretValue, Dependencies: []string{decommissionSecretValue}})
+	if !errors.Is(err, errDecommissionDependency) || unsafeMetadata.Outcome != "dependency_blocked" {
+		t.Fatalf("unsafe dependency response = %#v err=%v", unsafeMetadata, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsafeMetadata), decommissionSecretValue)
+
+	plan, err := backend.decommissionDryRun(decommissionRequest{RequestID: "req-stale-plan", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-stale", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("c", 64)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tamperedPlan := *plan.Plan
+	tamperedPlan.ExpectedVersion = decommissionSecretValue
+	tampered, err := backend.decommissionApply(decommissionRequest{RequestID: "req-tampered-apply", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Reason: "approved", Confirm: true, Plan: &tamperedPlan})
+	if !errors.Is(err, errDecommissionStalePlan) || tampered.Outcome != "stale_plan" {
+		t.Fatalf("tampered response = %#v err=%v", tampered, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, tampered), decommissionSecretValue)
+	previousNow := backend.now
+	backend.now = func() time.Time { return previousNow().Add(time.Minute) }
+	writeManagedTestSecret(t, backend, ref, "replacement-after-plan")
+	stale, err := backend.decommissionApply(decommissionRequest{RequestID: "req-stale-apply", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Reason: "approved", Confirm: true, Plan: plan.Plan})
+	if !errors.Is(err, errDecommissionStalePlan) || stale.Outcome != "stale_plan" || stale.Applied {
+		t.Fatalf("stale response = %#v err=%v", stale, err)
+	}
+	resolved := backend.resolve(resolveRequest{RequestID: "req-stale-resolve", ServiceID: "@serviceadmin", Purpose: "stale-plan-test", Refs: []string{ref}})
+	if resolved.Results[0].Value != "replacement-after-plan" {
+		t.Fatalf("stale plan mutated current value: %#v", resolved.Results[0])
+	}
+
+	denied, err := backend.decommissionApply(decommissionRequest{RequestID: "req-denied", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Plan: plan.Plan})
+	if !errors.Is(err, errPolicyDenied) || denied.Outcome != "policy_denied" || denied.Applied {
+		t.Fatalf("denied response = %#v err=%v", denied, err)
+	}
+
+	locked := newLocalBackend(filepath.Join(t.TempDir(), "store.json"), filepath.Join(t.TempDir(), "audit.jsonl"), "")
+	lockedPlan, err := locked.decommissionDryRun(decommissionRequest{RequestID: "req-locked", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-locked", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("d", 64)})
+	if !errors.Is(err, errLocked) || lockedPlan.Outcome != "locked" {
+		t.Fatalf("locked response = %#v err=%v", lockedPlan, err)
+	}
+
+	remote := managedTestBackend(t)
+	remote.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "vault-ready", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: "provider-token-fixture", Refs: map[string]sourceRefConfig{ref: {Path: "secret/data/serviceadmin", Field: "api_key"}}}}}
+	unsupported, err := remote.decommissionDryRun(decommissionRequest{RequestID: "req-remote", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-remote", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("e", 64)})
+	if !errors.Is(err, errUnsupportedProvider) || unsupported.Outcome != "unsupported" || unsupported.Plan != nil {
+		t.Fatalf("unsupported response = %#v err=%v", unsupported, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), "provider-token-fixture")
+}
+
+func TestLocalDecommissionAuditUnavailablePreservesActiveStoreAndHTTPIsSafe(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, decommissionSecretValue)
+	plan, err := backend.decommissionDryRun(decommissionRequest{RequestID: "req-audit-plan", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-audit-down", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("f", 64)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := readDecommissionStore(t, backend)
+	blockedAudit := filepath.Join(t.TempDir(), "audit-is-directory")
+	if err := os.Mkdir(blockedAudit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend.auditPath = blockedAudit
+
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+	body, err := json.Marshal(decommissionRequest{RequestID: "req-audit-apply", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Reason: "approved", Confirm: true, Plan: plan.Plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/management/secrets/decommission/apply", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer test-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusServiceUnavailable || !bytes.Contains(payload, []byte(`"outcome":"audit_unavailable"`)) {
+		t.Fatalf("status=%d body=%s", response.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, decommissionSecretValue, "test-token", backend.masterKey)
+	if !bytes.Equal(before, readDecommissionStore(t, backend)) {
+		t.Fatal("store changed when audit was unavailable")
+	}
+}
+
+func TestLocalDecommissionTombstoneSurvivesBrokerProcessRestart(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "store.json")
+	auditPath := filepath.Join(dir, "audit.jsonl")
+	eventsPath := filepath.Join(dir, "events.jsonl")
+	address := freeDecommissionAddress(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+
+	process := startDecommissionBrokerProcess(t, address, storePath, auditPath, eventsPath)
+	writePayload := postDecommissionProcessJSON(t, address, "/v1/secrets", writeSecretRequest{Ref: ref, Value: decommissionSecretValue})
+	var written writeSecretResponse
+	if err := json.Unmarshal(writePayload, &written); err != nil {
+		t.Fatal(err)
+	}
+	planPayload := postDecommissionProcessJSON(t, address, "/v1/management/secrets/decommission/dry-run", decommissionRequest{RequestID: "req-process-plan", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-process", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("1", 64)})
+	var plan decommissionResponse
+	if err := json.Unmarshal(planPayload, &plan); err != nil || plan.Plan == nil {
+		t.Fatalf("decode plan: %v body=%s", err, planPayload)
+	}
+	applyPayload := postDecommissionProcessJSON(t, address, "/v1/management/secrets/decommission/apply", decommissionRequest{RequestID: "req-process-apply", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Reason: "approved process test", Confirm: true, Plan: plan.Plan})
+	var applied decommissionResponse
+	if err := json.Unmarshal(applyPayload, &applied); err != nil || !applied.Applied {
+		t.Fatalf("decode apply: %v body=%s", err, applyPayload)
+	}
+	stopDecommissionBrokerProcess(t, process)
+
+	process = startDecommissionBrokerProcess(t, address, storePath, auditPath, eventsPath)
+	defer stopDecommissionBrokerProcess(t, process)
+	restorePayload := postDecommissionProcessJSON(t, address, "/v1/management/secrets/decommission/restore", decommissionRequest{RequestID: "req-process-restore", ServiceID: "@serviceadmin", Ref: ref, OperationID: "restore-process", ExpectedVersion: written.Metadata.Version, Reason: "consumer rollback", Confirm: true})
+	var restored decommissionResponse
+	if err := json.Unmarshal(restorePayload, &restored); err != nil || !restored.Applied || restored.Tombstone == nil || restored.Tombstone.State != "restored" {
+		t.Fatalf("decode restore: %v body=%s", err, restorePayload)
+	}
+	revealPayload := postDecommissionProcessJSON(t, address, "/v1/management/secrets/reveal", managedSecretActionRequest{RequestID: "req-process-reveal", ServiceID: "@serviceadmin", Ref: ref, Reason: "process restart proof", Confirm: true})
+	var revealed managedSecretActionResponse
+	if err := json.Unmarshal(revealPayload, &revealed); err != nil || revealed.Value != decommissionSecretValue {
+		t.Fatalf("decode reveal: %v outcome=%s", err, revealed.Outcome)
+	}
+}
+
+func TestLocalDecommissionTombstoneSurvivesBackupRestoreAndMasterKeyRotation(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/API_KEY"
+	writeManagedTestSecret(t, backend, ref, decommissionSecretValue)
+	version := currentDecommissionVersion(t, backend, ref)
+	plan, err := backend.decommissionDryRun(decommissionRequest{RequestID: "req-portable-plan", ServiceID: "@serviceadmin", Ref: ref, OperationID: "decommission-portable", DependencyStatus: "clear", DependencySnapshot: "sha256:" + strings.Repeat("2", 64)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.decommissionApply(decommissionRequest{RequestID: "req-portable-apply", ServiceID: "@serviceadmin", Ref: ref, OperationID: plan.OperationID, Reason: "approved", Confirm: true, Plan: plan.Plan}); err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath := filepath.Join(t.TempDir(), "decommission-backup.json")
+	if _, err := backend.createBackup(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	backupBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, backupBytes, decommissionSecretValue, backend.masterKey)
+
+	restored := newLocalBackend(filepath.Join(t.TempDir(), "restored-store.json"), filepath.Join(t.TempDir(), "restored-audit.jsonl"), backend.masterKey)
+	if _, err := restored.restoreBackup(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	assertDecommissioned(t, restored, ref, version)
+
+	if _, err := restored.rotateMasterKey("next-master-key"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := restored.decommissionRestore(decommissionRequest{RequestID: "req-portable-restore", ServiceID: "@serviceadmin", Ref: ref, OperationID: "restore-portable", ExpectedVersion: version, Reason: "recovery proof", Confirm: true}); err != nil {
+		t.Fatal(err)
+	}
+	resolved := restored.resolve(resolveRequest{RequestID: "req-portable-resolve", ServiceID: "@serviceadmin", Purpose: "backup-key-rotation-test", Refs: []string{ref}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != decommissionSecretValue {
+		t.Fatalf("restored after key rotation = %#v", resolved)
+	}
+	storeBytes := readDecommissionStore(t, restored)
+	assertNoSecretMaterial(t, storeBytes, decommissionSecretValue, "test-master-key")
+}
+
+func TestDecommissionBrokerProcessHelper(t *testing.T) {
+	if os.Getenv("SECRETSBROKER_DECOMMISSION_PROCESS_HELPER") != "1" {
+		return
+	}
+	separator := -1
+	for index, arg := range os.Args {
+		if arg == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+1 >= len(os.Args) {
+		fmt.Fprintln(os.Stderr, "missing broker helper arguments")
+		os.Exit(2)
+	}
+	if err := run(os.Args[separator+1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func currentDecommissionVersion(t *testing.T, backend *localBackend, ref string) string {
+	t.Helper()
+	store, err := backend.loadStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := store.Secrets[ref]
+	if !ok {
+		t.Fatalf("missing secret %s", ref)
+	}
+	return entry.Metadata.Version
+}
+
+func assertDecommissioned(t *testing.T, backend *localBackend, ref, version string) {
+	t.Helper()
+	store, err := backend.loadStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Secrets[ref]; ok {
+		t.Fatalf("active secret %s still exists", ref)
+	}
+	tombstone, ok := store.Tombstones[ref]
+	if !ok || tombstone.State != "decommissioned" || tombstone.Version != version {
+		t.Fatalf("tombstone = %#v", tombstone)
+	}
+	payload := readDecommissionStore(t, backend)
+	if strings.Contains(string(payload), decommissionSecretValue) {
+		t.Fatal("store tombstone exposed plaintext")
+	}
+}
+
+func readDecommissionStore(t *testing.T, backend *localBackend) []byte {
+	t.Helper()
+	payload, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func freeDecommissionAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return address
+}
+
+func startDecommissionBrokerProcess(t *testing.T, address, storePath, auditPath, eventsPath string) *exec.Cmd {
+	t.Helper()
+	logFile, err := os.Create(filepath.Join(t.TempDir(), "broker.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestDecommissionBrokerProcessHelper$", "--", "serve", "--listen", address, "--mode", "development", "--transport", "loopback-http", "--state", "ready", "--store", storePath, "--audit", auditPath, "--events", eventsPath, "--master-key", "test-master-key", "--api-token", "test-token")
+	command.Env = append(os.Environ(), "SECRETSBROKER_DECOMMISSION_PROCESS_HELPER=1")
+	command.Stdout = logFile
+	command.Stderr = logFile
+	if err := command.Start(); err != nil {
+		logFile.Close()
+		t.Fatal(err)
+	}
+	_ = logFile.Close()
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	})
+	client := &http.Client{Timeout: 250 * time.Millisecond, Transport: &http.Transport{DisableKeepAlives: true}}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		response, requestErr := client.Get("http://" + address + "/health")
+		if requestErr == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return command
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("broker process did not become ready at %s", address)
+	return nil
+}
+
+func stopDecommissionBrokerProcess(t *testing.T, command *exec.Cmd) {
+	t.Helper()
+	if command == nil || command.ProcessState != nil {
+		return
+	}
+	if err := command.Process.Kill(); err != nil {
+		t.Fatalf("stop broker process: %v", err)
+	}
+	if _, err := command.Process.Wait(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("wait broker process: %v", err)
+		}
+	}
+}
+
+func postDecommissionProcessJSON(t *testing.T, address, path string, body any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, "http://"+address+path, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer test-token")
+	request.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{DisableKeepAlives: true}}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	responsePayload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s status=%d body=%s", path, response.StatusCode, responsePayload)
+	}
+	return responsePayload
+}

--- a/cmd/secretsbroker/key_lifecycle.go
+++ b/cmd/secretsbroker/key_lifecycle.go
@@ -250,7 +250,7 @@ func (b *localBackend) initializeStoreWithSource(masterKey, keySourceType string
 	now := b.now()
 	vaultID := vaultIDFor(keyID, b.storePath)
 	rootIdentity := rootIdentityFor(vaultID, keyID, keySourceType, now)
-	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, VaultID: vaultID, KeyID: keyID, KeyVersion: masterKeyVersion, RootIdentity: &rootIdentity, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}}
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, VaultID: vaultID, KeyID: keyID, KeyVersion: masterKeyVersion, RootIdentity: &rootIdentity, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}, Tombstones: map[string]localSecretTombstone{}}
 	if err := b.saveStore(store); err != nil {
 		_ = b.audit("key_initialize", "", "degraded", "", "")
 		return keyLifecycleResponse{}, errBackendDegraded

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -53,19 +53,21 @@ type localBackend struct {
 	launchIdentitySigningKey string
 	launchLeaseMu            sync.Mutex
 	seenLaunchLeaseJTI       map[string]time.Time
+	decommissionMu           sync.Mutex
 }
 
 type localStoreFile struct {
-	Version      int                        `json:"version"`
-	ServiceID    string                     `json:"serviceId"`
-	VaultID      string                     `json:"vaultId,omitempty"`
-	KeyID        string                     `json:"keyId,omitempty"`
-	KeyVersion   string                     `json:"keyVersion,omitempty"`
-	RootIdentity *vaultRootIdentityMetadata `json:"rootIdentity,omitempty"`
-	CreatedAt    time.Time                  `json:"createdAt"`
-	UpdatedAt    time.Time                  `json:"updatedAt"`
-	Secrets      map[string]secretEntry     `json:"secrets"`
-	Recovery     *recoveryPolicyMetadata    `json:"recoveryPolicy,omitempty"`
+	Version      int                             `json:"version"`
+	ServiceID    string                          `json:"serviceId"`
+	VaultID      string                          `json:"vaultId,omitempty"`
+	KeyID        string                          `json:"keyId,omitempty"`
+	KeyVersion   string                          `json:"keyVersion,omitempty"`
+	RootIdentity *vaultRootIdentityMetadata      `json:"rootIdentity,omitempty"`
+	CreatedAt    time.Time                       `json:"createdAt"`
+	UpdatedAt    time.Time                       `json:"updatedAt"`
+	Secrets      map[string]secretEntry          `json:"secrets"`
+	Tombstones   map[string]localSecretTombstone `json:"tombstones,omitempty"`
+	Recovery     *recoveryPolicyMetadata         `json:"recoveryPolicy,omitempty"`
 }
 
 type secretEntry struct {
@@ -869,7 +871,7 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 
 func (b *localBackend) loadStore() (localStoreFile, error) {
 	now := b.now()
-	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}}
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}, Tombstones: map[string]localSecretTombstone{}}
 	bytes, err := os.ReadFile(b.storePath)
 	if errors.Is(err, os.ErrNotExist) {
 		return store, nil
@@ -885,6 +887,9 @@ func (b *localBackend) loadStore() (localStoreFile, error) {
 	}
 	if store.Secrets == nil {
 		store.Secrets = map[string]secretEntry{}
+	}
+	if store.Tombstones == nil {
+		store.Tombstones = map[string]localSecretTombstone{}
 	}
 	return store, nil
 }

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -51,6 +51,8 @@ var typedOutcomes = []string{
 	"stale",
 	"unsupported",
 	"audit_unavailable",
+	"dependency_blocked",
+	"stale_plan",
 	"failed",
 }
 
@@ -257,6 +259,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/management/secrets/reveal",
 			"POST /v1/management/secrets/edit/dry-run|apply",
 			"POST /v1/management/secrets/reset/dry-run|apply",
+			"POST /v1/management/secrets/decommission/dry-run|apply|restore",
 			"POST /v1/management/secrets/rotation/dry-run",
 			"POST /v1/management/secrets/campaigns/create|revalidate|apply|status",
 			"POST /v1/management/secrets/sync/dry-run",
@@ -293,6 +296,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"secrets-management-value-search-metadata-only",
 			"secrets-management-controlled-reveal",
 			"secrets-management-dry-run-apply",
+			"local-secret-decommission-tombstone-restore",
 			"credential-rotation-dry-run",
 			"bulk-secret-operation-campaigns",
 			"metadata-only-secrets-sync-dry-run",
@@ -468,6 +472,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 		registerLocalStoreHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
+		registerDecommissionHandlers(mux, backend, security)
 		registerRotationHandlers(mux, backend, security)
 		registerBulkCampaignHandlers(mux, backend, security)
 		registerSyncDryRunHandlers(mux, backend, security)

--- a/cmd/secretsbroker/operation_manifest.go
+++ b/cmd/secretsbroker/operation_manifest.go
@@ -34,6 +34,13 @@ const (
 	OperationScopeMixed          OperationScope = "mixed"
 )
 
+type OperationCompletionMode string
+
+const (
+	OperationCompletionSynchronous  OperationCompletionMode = "synchronous"
+	OperationCompletionAsynchronous OperationCompletionMode = "asynchronous"
+)
+
 // OperationCapability is the canonical machine-readable release statement for
 // one Broker HTTP operation. Codes are intentionally safe for logs and UI.
 type OperationCapability struct {
@@ -47,6 +54,8 @@ type OperationCapability struct {
 	AuditRequired          bool                    `json:"auditRequired"`
 	Scope                  OperationScope          `json:"scope"`
 	ProviderKinds          []string                `json:"providerKinds"`
+	CompletionMode         OperationCompletionMode `json:"completionMode"`
+	StatusPath             string                  `json:"statusPath,omitempty"`
 	LimitationCode         string                  `json:"limitationCode"`
 	ReasonCode             string                  `json:"reasonCode"`
 	NextAction             string                  `json:"nextAction"`
@@ -84,6 +93,7 @@ func manifestOperation(method, path string, maturity OperationMaturity, classifi
 		AuditRequired:          auditRequired,
 		Scope:                  scope,
 		ProviderKinds:          append([]string{}, providerKinds...),
+		CompletionMode:         OperationCompletionSynchronous,
 		LimitationCode:         limitationCode,
 		ReasonCode:             reasonCode,
 		NextAction:             nextAction,

--- a/cmd/secretsbroker/operation_manifest.go
+++ b/cmd/secretsbroker/operation_manifest.go
@@ -154,6 +154,9 @@ func defaultOperationManifest() []OperationCapability {
 		manifestOperation(http.MethodPost, "/v1/management/secrets/edit/apply", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "local_store_only"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/reset/dry-run", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "no_secret_mutation"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/reset/apply", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "local_store_only"),
+		manifestOperation(http.MethodPost, "/v1/management/secrets/decommission/dry-run", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "signed_expected_version_dependency_plan"),
+		manifestOperation(http.MethodPost, "/v1/management/secrets/decommission/apply", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "encrypted_recoverable_tombstone"),
+		manifestOperation(http.MethodPost, "/v1/management/secrets/decommission/restore", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "encrypted_tombstone_restore"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/rotation/dry-run", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, localAndAWS, "no_rotation_apply_route"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/campaigns/create", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "plan_state_only"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/campaigns/revalidate", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "plan_state_only"),
@@ -195,6 +198,9 @@ func providerOperationCapabilities(kind string, lifecycle SourceLifecycle, audit
 		{http.MethodPost, "/v1/management/secrets/edit/apply"},
 		{http.MethodPost, "/v1/management/secrets/reset/dry-run"},
 		{http.MethodPost, "/v1/management/secrets/reset/apply"},
+		{http.MethodPost, "/v1/management/secrets/decommission/dry-run"},
+		{http.MethodPost, "/v1/management/secrets/decommission/apply"},
+		{http.MethodPost, "/v1/management/secrets/decommission/restore"},
 		{http.MethodPost, "/v1/management/secrets/rotation/dry-run"},
 		{http.MethodPost, "/v1/providers/migration/dry-run"},
 		{http.MethodPost, "/v1/providers/migration/apply"},
@@ -254,11 +260,11 @@ func providerOperationMaturity(kind, path string) OperationMaturity {
 		if local || has(AdapterCapabilityValueSearch) {
 			return OperationMaturityValidated
 		}
-	case "/v1/secrets", "/v1/writeback", "/v1/provisioning/operations/apply", "/v1/management/secrets/edit/apply", "/v1/management/secrets/reset/apply":
+	case "/v1/secrets", "/v1/writeback", "/v1/provisioning/operations/apply", "/v1/management/secrets/edit/apply", "/v1/management/secrets/reset/apply", "/v1/management/secrets/decommission/apply", "/v1/management/secrets/decommission/restore":
 		if local {
 			return OperationMaturityValidated
 		}
-	case "/v1/management/secrets/edit/dry-run":
+	case "/v1/management/secrets/edit/dry-run", "/v1/management/secrets/decommission/dry-run":
 		if local || has(AdapterCapabilityWrite) {
 			return OperationMaturityDryRun
 		}

--- a/cmd/secretsbroker/operation_manifest_test.go
+++ b/cmd/secretsbroker/operation_manifest_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,10 @@ func TestOperationManifestRecordsAreCompleteAndRegistered(t *testing.T) {
 		OperationScopeSourceBoundary: true,
 		OperationScopeMixed:          true,
 	}
+	validCompletionMode := map[OperationCompletionMode]bool{
+		OperationCompletionSynchronous:  true,
+		OperationCompletionAsynchronous: true,
+	}
 
 	backend := managedTestBackend(t)
 	state := "ready"
@@ -43,8 +48,14 @@ func TestOperationManifestRecordsAreCompleteAndRegistered(t *testing.T) {
 			t.Fatalf("duplicate operation route %q", key)
 		}
 		seenRoutes[key] = true
-		if !validMaturity[operation.Maturity] || !validClassification[operation.Classification] || !validScope[operation.Scope] {
+		if !validMaturity[operation.Maturity] || !validClassification[operation.Classification] || !validScope[operation.Scope] || !validCompletionMode[operation.CompletionMode] {
 			t.Fatalf("invalid operation classification for %s: %#v", key, operation)
+		}
+		if operation.CompletionMode == OperationCompletionSynchronous && operation.StatusPath != "" {
+			t.Fatalf("synchronous operation must not advertise polling status path for %s: %#v", key, operation)
+		}
+		if operation.CompletionMode == OperationCompletionAsynchronous && operation.StatusPath == "" {
+			t.Fatalf("asynchronous operation must advertise a status path for %s: %#v", key, operation)
 		}
 		if operation.LimitationCode == "" || operation.ReasonCode == "" || operation.NextAction == "" || operation.ProviderKinds == nil {
 			t.Fatalf("operation safe decision fields are incomplete for %s: %#v", key, operation)
@@ -58,6 +69,27 @@ func TestOperationManifestRecordsAreCompleteAndRegistered(t *testing.T) {
 		handler.ServeHTTP(response, request)
 		if response.Code == 404 {
 			t.Errorf("manifest route is not registered: %s", key)
+		}
+	}
+}
+
+func TestManagementOperationsAdvertiseSynchronousNoPollingContract(t *testing.T) {
+	for _, endpoint := range defaultCapabilities().Endpoints {
+		if endpoint == "GET /v1/management/secret-operations/{operationId}" ||
+			endpoint == "GET /v1/management/secrets/operations/{operationId}" {
+			t.Fatalf("capabilities advertise unsupported management operation polling endpoint: %s", endpoint)
+		}
+	}
+
+	for _, operation := range defaultOperationManifest() {
+		if !strings.HasPrefix(operation.Path, "/v1/management/secrets/") {
+			continue
+		}
+		if operation.CompletionMode != OperationCompletionSynchronous {
+			t.Fatalf("management operation should complete synchronously until async status is implemented: %#v", operation)
+		}
+		if operation.StatusPath != "" {
+			t.Fatalf("management operation must not point Admin at a missing status endpoint: %#v", operation)
 		}
 	}
 }

--- a/conformance/fixtures/contract-states.json
+++ b/conformance/fixtures/contract-states.json
@@ -74,6 +74,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "liveness_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -89,6 +90,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "readiness_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -104,6 +106,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -119,6 +122,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -134,6 +138,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "release_metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -151,6 +156,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "local_store_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -168,6 +174,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "local_store_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -193,6 +200,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "runtime_controls_revalidated",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -218,6 +226,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -235,6 +244,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_secret_mutation",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -252,6 +262,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "broker_generated_local_values_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -277,6 +288,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -302,6 +314,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "provider_family_upper_bound",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -327,6 +340,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -342,6 +356,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "redacted_metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -357,6 +372,7 @@
             "auditRequired": false,
             "scope": "provider-remote",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "configured_exporter_only",
             "reasonCode": "implemented_executable",
             "nextAction": "satisfy_runtime_preconditions"
@@ -372,6 +388,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -389,6 +406,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "recovery_metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -406,6 +424,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only_no_share_material",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -421,6 +440,7 @@
             "auditRequired": true,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "scoped_lockout_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -446,6 +466,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "configuration_validation_only",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -471,6 +492,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "configuration_not_persisted",
             "reasonCode": "planning_only_not_executable",
             "nextAction": "do_not_enable_apply"
@@ -496,6 +518,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "local_target_only",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -521,6 +544,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "migration_items_not_copied",
             "reasonCode": "planning_only_not_executable",
             "nextAction": "do_not_enable_apply"
@@ -546,6 +570,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -564,6 +589,7 @@
               "local-encrypted-store",
               "aws-secrets-manager"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "values_never_returned",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -589,6 +615,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "single_ref_ttl_bounded",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -614,6 +641,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_secret_mutation",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -631,6 +659,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "local_store_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -656,6 +685,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_secret_mutation",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -673,6 +703,7 @@
             "providerKinds": [
               "local-encrypted-store"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "local_store_only",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
@@ -691,6 +722,7 @@
               "local-encrypted-store",
               "aws-secrets-manager"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_rotation_apply_route",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -716,6 +748,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "plan_state_only",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -741,6 +774,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "plan_state_only",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -766,6 +800,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "provider_mutations_not_executed",
             "reasonCode": "planning_only_not_executable",
             "nextAction": "do_not_enable_apply"
@@ -781,6 +816,7 @@
             "auditRequired": false,
             "scope": "broker-local",
             "providerKinds": [],
+            "completionMode": "synchronous",
             "limitationCode": "in_memory_campaign_metadata_only",
             "reasonCode": "implemented_read_only",
             "nextAction": "read_when_authorized"
@@ -806,6 +842,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_sync_apply_route",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -831,6 +868,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "no_policy_mutation",
             "reasonCode": "implemented_dry_run",
             "nextAction": "review_plan_before_apply"
@@ -856,6 +894,7 @@
               "bitwarden-bws",
               "onepassword-cli"
             ],
+            "completionMode": "synchronous",
             "limitationCode": "policy_binding_not_persisted",
             "reasonCode": "planning_only_not_executable",
             "nextAction": "do_not_enable_apply"
@@ -1112,6 +1151,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1129,6 +1169,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1146,6 +1187,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1163,6 +1205,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1180,6 +1223,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1197,6 +1241,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1214,6 +1259,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1231,6 +1277,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1248,6 +1295,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1265,6 +1313,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "runtime_auth_policy_audit_revalidated",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1282,6 +1331,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1299,6 +1349,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1316,6 +1367,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "migration_items_not_copied",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1333,6 +1385,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1350,6 +1403,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "planning_only_no_provider_mutation",
                 "reasonCode": "source_operation_available",
                 "nextAction": "invoke_with_required_controls"
@@ -1367,6 +1421,7 @@
                 "providerKinds": [
                   "local-encrypted-store"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_binding_not_persisted",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1449,6 +1504,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1466,6 +1522,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1483,6 +1540,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1500,6 +1558,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1517,6 +1576,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1534,6 +1594,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1551,6 +1612,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1568,6 +1630,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1585,6 +1648,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1602,6 +1666,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1619,6 +1684,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1636,6 +1702,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1653,6 +1720,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "migration_items_not_copied",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1670,6 +1738,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1687,6 +1756,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1704,6 +1774,7 @@
                 "providerKinds": [
                   "openbao"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_binding_not_persisted",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -1789,6 +1860,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1806,6 +1878,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1823,6 +1896,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1840,6 +1914,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1857,6 +1932,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1874,6 +1950,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1891,6 +1968,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1908,6 +1986,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1925,6 +2004,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1942,6 +2022,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -1959,6 +2040,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1976,6 +2058,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -1993,6 +2076,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "migration_items_not_copied",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2010,6 +2094,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -2027,6 +2112,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "source_auth_required",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "reconnect_source"
@@ -2044,6 +2130,7 @@
                 "providerKinds": [
                   "aws-secrets-manager"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_binding_not_persisted",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2128,6 +2215,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2145,6 +2233,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2162,6 +2251,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2179,6 +2269,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2196,6 +2287,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2213,6 +2305,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2230,6 +2323,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2247,6 +2341,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2264,6 +2359,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2281,6 +2377,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2298,6 +2395,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2315,6 +2413,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2332,6 +2431,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "migration_items_not_copied",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2349,6 +2449,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2366,6 +2467,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_denied",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "review_policy"
@@ -2383,6 +2485,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_binding_not_persisted",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2467,6 +2570,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2484,6 +2588,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2501,6 +2606,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2518,6 +2624,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2535,6 +2642,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2552,6 +2660,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2569,6 +2678,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2586,6 +2696,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2603,6 +2714,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2620,6 +2732,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_operation_not_implemented",
                 "reasonCode": "operation_not_implemented",
                 "nextAction": "do_not_enable_operation"
@@ -2637,6 +2750,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "provider_apply_path_not_implemented",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2654,6 +2768,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2671,6 +2786,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "migration_items_not_copied",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2688,6 +2804,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2705,6 +2822,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "audit_unavailable",
                 "reasonCode": "source_operation_blocked",
                 "nextAction": "restore_audit"
@@ -2722,6 +2840,7 @@
                 "providerKinds": [
                   "vault"
                 ],
+                "completionMode": "synchronous",
                 "limitationCode": "policy_binding_not_persisted",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
@@ -2824,6 +2943,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2841,6 +2961,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2858,6 +2979,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2875,6 +2997,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2892,6 +3015,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2909,6 +3033,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2926,6 +3051,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2943,6 +3069,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2960,6 +3087,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2977,6 +3105,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -2994,6 +3123,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -3011,6 +3141,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -3028,6 +3159,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -3045,6 +3177,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -3062,6 +3195,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"
@@ -3079,6 +3213,7 @@
               "providerKinds": [
                 "future-provider"
               ],
+              "completionMode": "synchronous",
               "limitationCode": "provider_operation_not_implemented",
               "reasonCode": "operation_not_implemented",
               "nextAction": "do_not_enable_operation"

--- a/conformance/fixtures/contract-states.json
+++ b/conformance/fixtures/contract-states.json
@@ -52,6 +52,7 @@
           "POST /v1/management/secrets/reveal",
           "POST /v1/management/secrets/edit/dry-run|apply",
           "POST /v1/management/secrets/reset/dry-run|apply",
+          "POST /v1/management/secrets/decommission/dry-run|apply|restore",
           "POST /v1/management/secrets/rotation/dry-run",
           "POST /v1/management/secrets/campaigns/create|revalidate|apply|status",
           "POST /v1/management/secrets/sync/dry-run",
@@ -709,6 +710,60 @@
             "nextAction": "invoke_with_required_controls"
           },
           {
+            "operationId": "postv1_management_secrets_decommission_dry_run",
+            "method": "POST",
+            "path": "/v1/management/secrets/decommission/dry-run",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "broker-local",
+            "providerKinds": [
+              "local-encrypted-store"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "signed_expected_version_dependency_plan",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "postv1_management_secrets_decommission_apply",
+            "method": "POST",
+            "path": "/v1/management/secrets/decommission/apply",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "broker-local",
+            "providerKinds": [
+              "local-encrypted-store"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "encrypted_recoverable_tombstone",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "postv1_management_secrets_decommission_restore",
+            "method": "POST",
+            "path": "/v1/management/secrets/decommission/restore",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "broker-local",
+            "providerKinds": [
+              "local-encrypted-store"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "encrypted_tombstone_restore",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
             "operationId": "postv1_management_secrets_rotation_dry_run",
             "method": "POST",
             "path": "/v1/management/secrets/rotation/dry-run",
@@ -925,6 +980,7 @@
           "secrets-management-value-search-metadata-only",
           "secrets-management-controlled-reveal",
           "secrets-management-dry-run-apply",
+          "local-secret-decommission-tombstone-restore",
           "credential-rotation-dry-run",
           "bulk-secret-operation-campaigns",
           "metadata-only-secrets-sync-dry-run",
@@ -977,6 +1033,8 @@
           "stale",
           "unsupported",
           "audit_unavailable",
+          "dependency_blocked",
+          "stale_plan",
           "failed"
         ]
       },
@@ -1304,6 +1362,60 @@
                 "operationId": "postv1_management_secrets_reset_apply",
                 "method": "POST",
                 "path": "/v1/management/secrets/reset/apply",
+                "maturity": "validated",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_dry_run",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/dry-run",
+                "maturity": "dry-run",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "planning_only_no_provider_mutation",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_apply",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/apply",
+                "maturity": "validated",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_restore",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/restore",
                 "maturity": "validated",
                 "classification": "mutation",
                 "authenticationRequired": true,
@@ -1657,6 +1769,60 @@
                 "operationId": "postv1_management_secrets_reset_apply",
                 "method": "POST",
                 "path": "/v1/management/secrets/reset/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_dry_run",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/dry-run",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_apply",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_restore",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/restore",
                 "maturity": "unavailable",
                 "classification": "mutation",
                 "authenticationRequired": true,
@@ -2028,6 +2194,60 @@
                 "nextAction": "do_not_enable_operation"
               },
               {
+                "operationId": "postv1_management_secrets_decommission_dry_run",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/dry-run",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_apply",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_restore",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/restore",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
                 "operationId": "postv1_management_secrets_rotation_dry_run",
                 "method": "POST",
                 "path": "/v1/management/secrets/rotation/dry-run",
@@ -2383,6 +2603,60 @@
                 "nextAction": "do_not_enable_operation"
               },
               {
+                "operationId": "postv1_management_secrets_decommission_dry_run",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/dry-run",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_apply",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_restore",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/restore",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
                 "operationId": "postv1_management_secrets_rotation_dry_run",
                 "method": "POST",
                 "path": "/v1/management/secrets/rotation/dry-run",
@@ -2723,6 +2997,60 @@
                 "operationId": "postv1_management_secrets_reset_apply",
                 "method": "POST",
                 "path": "/v1/management/secrets/reset/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_dry_run",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/dry-run",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_apply",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/apply",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_management_secrets_decommission_restore",
+                "method": "POST",
+                "path": "/v1/management/secrets/decommission/restore",
                 "maturity": "unavailable",
                 "classification": "mutation",
                 "authenticationRequired": true,
@@ -3096,6 +3424,60 @@
               "operationId": "postv1_management_secrets_reset_apply",
               "method": "POST",
               "path": "/v1/management/secrets/reset/apply",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_management_secrets_decommission_dry_run",
+              "method": "POST",
+              "path": "/v1/management/secrets/decommission/dry-run",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_management_secrets_decommission_apply",
+              "method": "POST",
+              "path": "/v1/management/secrets/decommission/apply",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_management_secrets_decommission_restore",
+              "method": "POST",
+              "path": "/v1/management/secrets/decommission/restore",
               "maturity": "unavailable",
               "classification": "mutation",
               "authenticationRequired": true,

--- a/contract/v1/openapi.json
+++ b/contract/v1/openapi.json
@@ -776,6 +776,227 @@
         ],
         "type": "object"
       },
+      "decommissionPlan": {
+        "additionalProperties": true,
+        "properties": {
+          "dependencySnapshot": {
+            "type": "string"
+          },
+          "dependencyStatus": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dependencySnapshot",
+          "dependencyStatus",
+          "expectedVersion",
+          "expiresAt",
+          "operationId",
+          "ref",
+          "signature"
+        ],
+        "type": "object"
+      },
+      "decommissionRequest": {
+        "additionalProperties": true,
+        "properties": {
+          "confirm": {
+            "type": "boolean"
+          },
+          "dependencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dependencySnapshot": {
+            "type": "string"
+          },
+          "dependencyStatus": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          },
+          "plan": {
+            "$ref": "#/components/schemas/decommissionPlan"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "serviceId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "confirm",
+          "dependencies",
+          "dependencySnapshot",
+          "dependencyStatus",
+          "expectedVersion",
+          "operationId",
+          "reason",
+          "ref",
+          "requestId",
+          "serviceId"
+        ],
+        "type": "object"
+      },
+      "decommissionResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "affectedRefs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "affectedServices": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "apiVersion": {
+            "type": "string"
+          },
+          "applied": {
+            "type": "boolean"
+          },
+          "auditStatus": {
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dependencySnapshot": {
+            "type": "string"
+          },
+          "dependencyStatus": {
+            "type": "string"
+          },
+          "expectedVersion": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "nextAction": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "plan": {
+            "$ref": "#/components/schemas/decommissionPlan"
+          },
+          "policyResult": {
+            "type": "string"
+          },
+          "recoverable": {
+            "type": "boolean"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "requiresConfirmation": {
+            "type": "boolean"
+          },
+          "serviceId": {
+            "type": "string"
+          },
+          "tombstone": {
+            "$ref": "#/components/schemas/decommissionTombstoneMetadata"
+          }
+        },
+        "required": [
+          "affectedRefs",
+          "affectedServices",
+          "apiVersion",
+          "applied",
+          "auditStatus",
+          "dependencies",
+          "dependencyStatus",
+          "mode",
+          "operation",
+          "outcome",
+          "policyResult",
+          "recoverable",
+          "ref",
+          "requiresConfirmation",
+          "serviceId"
+        ],
+        "type": "object"
+      },
+      "decommissionTombstoneMetadata": {
+        "additionalProperties": true,
+        "properties": {
+          "decommissionOperationId": {
+            "type": "string"
+          },
+          "decommissionedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "restoreOperationId": {
+            "type": "string"
+          },
+          "restoredAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "decommissionOperationId",
+          "decommissionedAt",
+          "state",
+          "version"
+        ],
+        "type": "object"
+      },
       "eventSafety": {
         "additionalProperties": true,
         "properties": {
@@ -4597,6 +4818,219 @@
           "limitationCode": "in_memory_campaign_metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
+        }
+      }
+    },
+    "/v1/management/secrets/decommission/apply": {
+      "post": {
+        "operationId": "postv1_management_secrets_decommission_apply",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/decommissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/decommissionResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/decommissionResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Decommission a local secret into an encrypted tombstone",
+        "x-capability": {
+          "operationId": "postv1_management_secrets_decommission_apply",
+          "method": "POST",
+          "path": "/v1/management/secrets/decommission/apply",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "broker-local",
+          "providerKinds": [
+            "local-encrypted-store"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "encrypted_recoverable_tombstone",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      }
+    },
+    "/v1/management/secrets/decommission/dry-run": {
+      "post": {
+        "operationId": "postv1_management_secrets_decommission_dry_run",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/decommissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/decommissionResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/decommissionResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Plan a local secret decommission",
+        "x-capability": {
+          "operationId": "postv1_management_secrets_decommission_dry_run",
+          "method": "POST",
+          "path": "/v1/management/secrets/decommission/dry-run",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "broker-local",
+          "providerKinds": [
+            "local-encrypted-store"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "signed_expected_version_dependency_plan",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      }
+    },
+    "/v1/management/secrets/decommission/restore": {
+      "post": {
+        "operationId": "postv1_management_secrets_decommission_restore",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/decommissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/decommissionResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/decommissionResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Restore a local secret from an encrypted tombstone",
+        "x-capability": {
+          "operationId": "postv1_management_secrets_decommission_restore",
+          "method": "POST",
+          "path": "/v1/management/secrets/decommission/restore",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "broker-local",
+          "providerKinds": [
+            "local-encrypted-store"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "encrypted_tombstone_restore",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
         }
       }
     },

--- a/contract/v1/openapi.json
+++ b/contract/v1/openapi.json
@@ -168,6 +168,13 @@
             ],
             "type": "string"
           },
+          "completionMode": {
+            "enum": [
+              "synchronous",
+              "asynchronous"
+            ],
+            "type": "string"
+          },
           "limitationCode": {
             "type": "string"
           },
@@ -214,12 +221,16 @@
               "mixed"
             ],
             "type": "string"
+          },
+          "statusPath": {
+            "type": "string"
           }
         },
         "required": [
           "auditRequired",
           "authenticationRequired",
           "classification",
+          "completionMode",
           "limitationCode",
           "maturity",
           "method",
@@ -3759,6 +3770,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "release_metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -3810,6 +3822,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "liveness_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -3861,6 +3874,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "readiness_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -3912,6 +3926,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -3963,6 +3978,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -4123,6 +4139,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -4191,6 +4208,7 @@
           "auditRequired": true,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "scoped_lockout_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -4269,6 +4287,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -4347,6 +4366,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "provider_mutations_not_executed",
           "reasonCode": "planning_only_not_executable",
           "nextAction": "do_not_enable_apply"
@@ -4425,6 +4445,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "plan_state_only",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -4503,6 +4524,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "plan_state_only",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -4571,6 +4593,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "in_memory_campaign_metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -4641,6 +4664,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "local_store_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -4719,6 +4743,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_secret_mutation",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -4797,6 +4822,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "policy_binding_not_persisted",
           "reasonCode": "planning_only_not_executable",
           "nextAction": "do_not_enable_apply"
@@ -4875,6 +4901,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_policy_mutation",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -4945,6 +4972,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "local_store_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -5023,6 +5051,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_secret_mutation",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5101,6 +5130,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "single_ref_ttl_bounded",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -5172,6 +5202,7 @@
             "local-encrypted-store",
             "aws-secrets-manager"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_rotation_apply_route",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5250,6 +5281,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_sync_apply_route",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5321,6 +5353,7 @@
             "local-encrypted-store",
             "aws-secrets-manager"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "values_never_returned",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -5382,6 +5415,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "provider_family_upper_bound",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -5460,6 +5494,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "configuration_not_persisted",
           "reasonCode": "planning_only_not_executable",
           "nextAction": "do_not_enable_apply"
@@ -5528,6 +5563,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -5606,6 +5642,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "configuration_validation_only",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5684,6 +5721,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "migration_items_not_copied",
           "reasonCode": "planning_only_not_executable",
           "nextAction": "do_not_enable_apply"
@@ -5762,6 +5800,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "local_target_only",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5832,6 +5871,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "broker_generated_local_values_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -5902,6 +5942,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "no_secret_mutation",
           "reasonCode": "implemented_dry_run",
           "nextAction": "review_plan_before_apply"
@@ -5988,6 +6029,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -6041,6 +6083,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "recovery_metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -6109,6 +6152,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only_no_share_material",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -6187,6 +6231,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "runtime_controls_revalidated",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -6257,6 +6302,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "local_store_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"
@@ -6318,6 +6364,7 @@
             "bitwarden-bws",
             "onepassword-cli"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -6369,6 +6416,7 @@
           "auditRequired": false,
           "scope": "broker-local",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "redacted_metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
@@ -6420,6 +6468,7 @@
           "auditRequired": false,
           "scope": "provider-remote",
           "providerKinds": [],
+          "completionMode": "synchronous",
           "limitationCode": "configured_exporter_only",
           "reasonCode": "implemented_executable",
           "nextAction": "satisfy_runtime_preconditions"
@@ -6490,6 +6539,7 @@
           "providerKinds": [
             "local-encrypted-store"
           ],
+          "completionMode": "synchronous",
           "limitationCode": "local_store_only",
           "reasonCode": "implemented_and_validated",
           "nextAction": "invoke_with_required_controls"

--- a/docs/operation-capability-manifest.md
+++ b/docs/operation-capability-manifest.md
@@ -61,6 +61,12 @@ Connection lifecycle wins over family capability. `source_auth_required`,
 states downgrade affected connection operations to `unavailable` with a safe
 recovery action.
 
+Local decommission is advertised as three synchronous operations: signed
+dependency/version dry-run, recoverable encrypted-tombstone apply, and exact-
+version restore. Provider-scoped matrices keep these operations unavailable
+unless the selected provider is the local encrypted store. Hard delete and
+disable are not advertised.
+
 ## Current provider operation matrix
 
 This table summarises the connection-ready baseline. The runtime arrays are the

--- a/docs/operation-capability-manifest.md
+++ b/docs/operation-capability-manifest.md
@@ -27,6 +27,9 @@ Every operation record contains:
 - `authenticationRequired`, `policyRequired`, and `auditRequired`;
 - `scope`: `broker-local`, `provider-remote`, `source-boundary`, or `mixed`;
 - explicit `providerKinds`;
+- `completionMode`: `synchronous` or `asynchronous`;
+- `statusPath`, only when an asynchronous operation status route is actually
+  implemented and advertised;
 - safe `limitationCode`, `reasonCode`, and `nextAction` values.
 
 `validated` is an executable implementation covered by contract/provider tests.
@@ -45,6 +48,13 @@ upper bound, an endpoint string, or a `planned`/`dry-run` record.
 For reads, the selected connection must report `read-only`, `executable`, or
 `validated` for the exact operation. Every invocation still re-evaluates its
 declared auth, policy, audit, confirmation, lockout, and identity controls.
+
+Current management routes complete synchronously. Service Admin must treat an
+empty `statusPath` as authoritative and must not poll a secret-operation status
+endpoint that is not present in this manifest. When the broker adds durable
+asynchronous delete, decommission, or provider mutation work, it must first add
+the implemented status route to the OpenAPI contract, advertised endpoint list,
+and operation manifest.
 
 Connection lifecycle wins over family capability. `source_auth_required`,
 `policy_denied`, `audit_unavailable`, locked, disabled, invalid, and degraded

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -481,25 +481,39 @@ response before it can be advertised as executable.
 
 ## Delete, disable and decommission
 
-No delete, disable, or decommission management route is implemented or
-advertised in this release. Admin must therefore hide destructive actions or
-show them as unavailable from the operation manifest instead of calling a
-non-existent endpoint.
+Delete, disable and decommission remain separate capabilities. Hard delete and
+disable are not implemented or advertised in this release. Admin must hide
+those actions or show them as unavailable instead of mapping them to the local
+decommission route.
 
-Future destructive routes must keep these semantics separate:
+The local encrypted store implements a recoverable decommission lifecycle:
 
-- `disable`: stop new use while retaining recoverable metadata and value
-  material according to retention policy.
-- `delete`: remove a managed secret only after dry-run dependency checks,
-  explicit confirmation, audit reason, policy approval, and recovery/retention
-  decision.
-- `decommission`: retire a service-owned secret set with dependency impact,
-  generated configuration impact, audit, tombstone, and recovery metadata.
+- `POST /v1/management/secrets/decommission/dry-run`
+- `POST /v1/management/secrets/decommission/apply`
+- `POST /v1/management/secrets/decommission/restore`
 
-Destructive dry-runs must be metadata-only and must report dependency, policy,
-audit, lockout, stale-plan, unsupported-provider, and recovery blockers before
-any apply route can mutate state. Apply requests must be idempotent through a
-server-issued plan or must return an explicit non-retry-safe result.
+The dry-run requires a caller-supplied authoritative dependency result:
+`dependencyStatus: "clear"`, no dependency ids, and a `sha256:` dependency
+graph snapshot. The Broker binds that snapshot, ref, current secret version,
+operation id, and five-minute expiry into an HMAC-signed plan. Apply requires
+the unmodified plan, explicit confirmation, and an audit reason. A changed
+active version, expired/tampered plan, or different operation id returns
+`stale_plan` without changing state. Unknown or non-clear dependencies return
+`dependency_blocked` and no plan.
+
+Successful apply moves the encrypted local entry out of the active secret map
+and into a durable encrypted tombstone. The response exposes only safe
+tombstone metadata; it never includes plaintext or encrypted payload fields.
+Retrying the same signed operation is idempotent. Restore requires explicit
+confirmation, audit reason, a new operation id, and the exact tombstone version;
+it reactivates the encrypted entry and is also retry-idempotent. Tombstone state
+survives Broker restart and is included in encrypted-store backup/restore.
+
+Dry-run, apply, and restore require the local API token and fail closed when the
+Broker is locked or audit/event evidence cannot be persisted. Remote/provider
+refs return `unsupported`; provider-specific destructive execution remains a
+later capability. Hard delete will require an explicit retention expiry and
+separate non-recoverable confirmation contract before it can be advertised.
 
 ## Typed outcomes
 

--- a/docs/secrets-management-api.md
+++ b/docs/secrets-management-api.md
@@ -466,6 +466,41 @@ Campaign apply is retry-safe by `idempotencyKey` and `operationItemId`. The firs
 
 Preview/apply policy changes. This first contract records the requested policy handle/status and returns metadata-only outcomes; provider-specific enforcement can be expanded behind the same response shape.
 
+## Operation lifecycle and status
+
+The current management endpoints are synchronous request/response operations.
+`GET /capabilities` is the machine-readable authority: every management
+operation record currently has `"completionMode": "synchronous"` and no
+`statusPath`.
+
+Service Admin must not invent or poll a secret-operation status endpoint unless
+the selected operation advertises `"completionMode": "asynchronous"` with a
+non-empty `statusPath`. A future asynchronous operation must return an operation
+id, correlation id, terminal state, retry safety, and metadata-only status
+response before it can be advertised as executable.
+
+## Delete, disable and decommission
+
+No delete, disable, or decommission management route is implemented or
+advertised in this release. Admin must therefore hide destructive actions or
+show them as unavailable from the operation manifest instead of calling a
+non-existent endpoint.
+
+Future destructive routes must keep these semantics separate:
+
+- `disable`: stop new use while retaining recoverable metadata and value
+  material according to retention policy.
+- `delete`: remove a managed secret only after dry-run dependency checks,
+  explicit confirmation, audit reason, policy approval, and recovery/retention
+  decision.
+- `decommission`: retire a service-owned secret set with dependency impact,
+  generated configuration impact, audit, tombstone, and recovery metadata.
+
+Destructive dry-runs must be metadata-only and must report dependency, policy,
+audit, lockout, stale-plan, unsupported-provider, and recovery blockers before
+any apply route can mutate state. Apply requests must be idempotent through a
+server-issued plan or must return an explicit non-retry-safe result.
+
 ## Typed outcomes
 
 Common outcomes: `ready`, `dry_run_ready`, `applied`, `migrated`, `partial_failure`, `missing_ref`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`, `stale`, `stale_plan`, `skipped`, `failed`.


### PR DESCRIPTION
## Issue
Closes #132

## Summary
- Defines explicit synchronous management-operation lifecycle metadata.
- Adds guarded local encrypted-store decommission dry-run, apply, and restore operations.
- Uses signed/version-bound dependency plans, operation IDs, five-minute freshness, expected-version guards, and explicit dependency blockers.
- Persists encrypted tombstone/recovery metadata with backup/restore and master-key re-encryption support.
- Makes decommission mutation idempotent and audit-fail-closed while keeping responses metadata-only.
- Keeps hard delete and remote-provider destructive operations explicitly unavailable.
- Regenerates OpenAPI and canonical conformance fixtures and updates management docs.

## Safety invariants
- No destructive apply without a fresh matching dry-run plan and expected version.
- Locked, stale, dependency-blocked, remote, or unauditable operations fail closed before store mutation.
- Retained encrypted tombstones support bounded restore and survive an independent broker restart.
- Responses, audit, and operation state expose no raw secret value.

## Validation
- focused decommission and contract tests — passed
- full `scripts/test.ps1` suite — passed
- independent broker subprocess restart proof repeated 10 times — passed
- `go vet ./...` — passed
- command builds — passed
- `git diff --check` — passed

## Approval trail
- Required: yes.
- Maintainer/Architect review remains required because this changes the published broker operation capability contract and adds executable local destructive-state transitions.

## Cleanup
- Branch `feat/132-management-operation-contracts` targets `develop`.
- Merge only after fresh hosted checks on `298fd6c` and required review.