### PR TITLE
#134 plan remote provider migration targets

### DIFF
--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -326,11 +326,17 @@ func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation st
 		return res, errLocked
 	}
 	target := b.lookupProvider(req.TargetProviderID)
-	if !providerCanBeMigrationTarget(target.ProviderKind) || target.Outcome != "ready" {
+	if !providerCanPlanMigrationTarget(target.ProviderKind) || target.Outcome != "ready" {
 		res.Outcome = providerMigrationOutcome(target)
 		res.NextAction = providerNextAction(res.Outcome)
 		res.Results = b.migrationItems(req, target, apply, res.Outcome)
 		return res, outcomeErrorForProvider(res.Outcome)
+	}
+	if apply && !providerCanApplyMigrationTarget(target.ProviderKind) {
+		res.Outcome = "unsupported"
+		res.NextAction = "implement_provider_operation_executor"
+		res.Results = b.migrationItems(req, target, apply, res.Outcome)
+		return res, errUnsupportedProvider
 	}
 	res.Results = b.migrationItems(req, target, apply, "")
 	res.Outcome = migrationAggregateOutcome(res.Results, apply)
@@ -358,7 +364,7 @@ func (b *localBackend) migrationItems(req migrationPlanRequest, target providerC
 	sort.Strings(refs)
 	items := make([]migrationItemStatus, 0, len(refs))
 	for _, ref := range refs {
-		item := migrationItemStatus{Ref: ref, SourceProviderID: firstNonEmpty(req.SourceProviderID, "local"), TargetProviderID: req.TargetProviderID, OwnerServiceID: ownerFromRef(ref), Risk: "low", ExpectedAction: "copy_value_inside_broker", PolicyResult: "allowed", AuditRequirement: "required", Recovery: "retry_after_fix_or_restore_from_backup"}
+		item := migrationItemStatus{Ref: ref, SourceProviderID: firstNonEmpty(req.SourceProviderID, "local"), TargetProviderID: req.TargetProviderID, OwnerServiceID: ownerFromRef(ref), Risk: migrationRiskForTarget(target.ProviderKind), ExpectedAction: migrationExpectedActionForTarget(target.ProviderKind, apply, forcedOutcome), PolicyResult: "allowed", AuditRequirement: "required", Recovery: migrationRecoveryForTarget(target.ProviderKind)}
 		if forcedOutcome != "" {
 			item.State = "failed"
 			item.Outcome = forcedOutcome
@@ -401,8 +407,44 @@ func (b *localBackend) lookupProvider(providerID string) providerConfigStatus {
 	return providerStatusWithOperations(providerConfigStatus{ProviderID: providerID, ProviderKind: kind, DisplayName: providerID, State: "unsupported", Outcome: "unsupported", Capabilities: capability.Capabilities, Namespaces: []string{}, AuditStatus: "audit_available"})
 }
 
-func providerCanBeMigrationTarget(kind string) bool {
+func providerCanPlanMigrationTarget(kind string) bool {
+	if kind == "local-encrypted-store" {
+		return true
+	}
+	contract, ok := adapterContractForKind(kind)
+	return ok && adapterHasCapability(contract, AdapterCapabilityMigration) && adapterHasCapability(contract, AdapterCapabilityWrite)
+}
+
+func providerCanApplyMigrationTarget(kind string) bool {
 	return kind == "local-encrypted-store"
+}
+
+func providerUsesRemoteMutationPath(kind string) bool {
+	return providerCanPlanMigrationTarget(kind) && !providerCanApplyMigrationTarget(kind)
+}
+
+func migrationRiskForTarget(kind string) string {
+	if providerUsesRemoteMutationPath(kind) {
+		return "medium"
+	}
+	return "low"
+}
+
+func migrationExpectedActionForTarget(kind string, apply bool, forcedOutcome string) string {
+	if providerUsesRemoteMutationPath(kind) {
+		if apply || forcedOutcome != "" {
+			return "implement_provider_operation_executor"
+		}
+		return "write_value_to_remote_provider_after_revalidation"
+	}
+	return "copy_value_inside_broker"
+}
+
+func migrationRecoveryForTarget(kind string) string {
+	if providerUsesRemoteMutationPath(kind) {
+		return "source_retained_until_target_verification_succeeds"
+	}
+	return "retry_after_fix_or_restore_from_backup"
 }
 
 func providerMigrationOutcome(target providerConfigStatus) string {

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -182,44 +183,53 @@ func providerStatusFromSource(source SourceStatus, backend *localBackend) provid
 
 func (b *localBackend) validateProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {
 	res := baseProviderConfigResponse(req, "validate")
-	status, err := providerStatusFromConfigRequest(req, false)
+	status, err := providerStatusFromConfigRequest(req)
 	res.Provider = status
 	if err != nil {
 		res.Outcome = outcomeForError(err)
 		res.NextAction = providerNextAction(res.Outcome)
-		_ = b.audit("provider_config_validate", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
-		return res, err
+		return b.finalizeProviderConfigAudit("provider_config_validate", req, res, err)
 	}
 	res.Outcome = "ready"
-	res.AuditStatus = "audit_recorded"
-	_ = b.audit("provider_config_validate", req.ProviderID, "ready", req.ServiceID, req.RequestID)
-	return res, nil
+	return b.finalizeProviderConfigAudit("provider_config_validate", req, res, nil)
 }
 
 func (b *localBackend) applyProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {
 	res := baseProviderConfigResponse(req, "configure")
-	status, err := providerStatusFromConfigRequest(req, true)
+	status, err := providerStatusFromConfigRequest(req)
 	res.Provider = status
 	if err != nil {
 		res.Outcome = outcomeForError(err)
 		res.NextAction = providerNextAction(res.Outcome)
-		_ = b.audit("provider_config_apply", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
-		return res, err
+		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, err)
 	}
 	if !req.Confirm || strings.TrimSpace(req.Reason) == "" || strings.TrimSpace(req.OperationID) == "" {
 		res.Outcome = "policy_denied"
 		res.NextAction = "confirm_with_operation_id_and_audit_reason"
-		_ = b.audit("provider_config_apply", req.ProviderID, res.Outcome, req.ServiceID, req.RequestID)
-		return res, errPolicyDenied
+		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errPolicyDenied)
 	}
-	res.Outcome = "applied"
-	res.Applied = true
-	res.AuditStatus = "audit_recorded"
-	_ = b.audit("provider_config_apply", req.ProviderID, "applied", req.ServiceID, req.RequestID)
-	return res, nil
+	res.Outcome = "unsupported"
+	res.Applied = false
+	res.RequiresConfirmation = false
+	res.NextAction = "implement_persisted_provider_configuration"
+	res.UnsupportedCapability = "provider_configuration_persistence"
+	return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errUnsupportedProvider)
 }
 
-func providerStatusFromConfigRequest(req providerConfigRequest, apply bool) (providerConfigStatus, error) {
+func (b *localBackend) finalizeProviderConfigAudit(operation string, req providerConfigRequest, res providerConfigActionResponse, operationErr error) (providerConfigActionResponse, error) {
+	if b == nil || strings.TrimSpace(b.auditPath) == "" || b.audit(operation, req.ProviderID, res.Outcome, req.ServiceID, req.RequestID) != nil {
+		res.Outcome = "audit_unavailable"
+		res.Applied = false
+		res.AuditStatus = "audit_unavailable"
+		res.Provider.AuditStatus = "audit_unavailable"
+		res.NextAction = "restore_audit_and_retry"
+		return res, errProviderAuditUnavailable
+	}
+	res.AuditStatus = "audit_recorded"
+	return res, operationErr
+}
+
+func providerStatusFromConfigRequest(req providerConfigRequest) (providerConfigStatus, error) {
 	providerID := strings.TrimSpace(req.ProviderID)
 	kind := strings.TrimSpace(req.ProviderKind)
 	capability := providerCapabilitiesByKind(kind)
@@ -244,16 +254,13 @@ func providerStatusFromConfigRequest(req providerConfigRequest, apply bool) (pro
 		status.Outcome = "source_auth_required"
 		return providerStatusWithOperations(status), errSourceAuthRequired
 	}
-	if (kind == "vault" || kind == "openbao" || kind == "bitwarden-bws" || kind == "aws-secrets-manager") && strings.TrimSpace(req.Address) == "" {
+	if (kind == "vault" || kind == "openbao" || kind == "bitwarden-bws" || kind == "aws-secrets-manager") && status.Address == "" {
 		status.State = "config_error"
 		status.Outcome = "invalid_ref"
 		return providerStatusWithOperations(status), errInvalidRef
 	}
 	status.State = "connected"
 	status.Outcome = "ready"
-	if apply {
-		status.Outcome = "applied"
-	}
 	if len(status.Namespaces) == 0 {
 		status.Namespaces = []string{"*"}
 	}
@@ -281,7 +288,12 @@ func safeProviderAddress(address string) string {
 	if address == "" {
 		return ""
 	}
-	return strings.TrimRight(address, "/")
+	parsed, err := url.Parse(address)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" {
+		return ""
+	}
+	parsed.User = nil
+	return strings.ToLower(parsed.Scheme) + "://" + parsed.Host
 }
 
 func baseProviderConfigResponse(req providerConfigRequest, operation string) providerConfigActionResponse {
@@ -290,22 +302,29 @@ func baseProviderConfigResponse(req providerConfigRequest, operation string) pro
 
 func (b *localBackend) migrationDryRun(req migrationPlanRequest) (migrationPlanResponse, error) {
 	res, err := b.buildMigrationPlan(req, "migration_dry_run", false)
-	if err != nil {
-		_ = b.audit("provider_migration_dry_run", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
-		return res, err
-	}
-	_ = b.audit("provider_migration_dry_run", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
-	return res, nil
+	return b.finalizeMigrationAudit("provider_migration_dry_run", req, res, err)
 }
 
 func (b *localBackend) migrationApply(req migrationPlanRequest) (migrationPlanResponse, error) {
 	res, err := b.buildMigrationPlan(req, "migration_apply", true)
-	if err != nil {
-		_ = b.audit("provider_migration_apply", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
-		return res, err
+	return b.finalizeMigrationAudit("provider_migration_apply", req, res, err)
+}
+
+func (b *localBackend) finalizeMigrationAudit(operation string, req migrationPlanRequest, res migrationPlanResponse, operationErr error) (migrationPlanResponse, error) {
+	if b == nil || strings.TrimSpace(b.auditPath) == "" || b.audit(operation, req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID) != nil {
+		res.Outcome = "audit_unavailable"
+		res.Applied = false
+		res.AuditStatus = "audit_unavailable"
+		res.NextAction = "restore_audit_and_retry"
+		for index := range res.Results {
+			res.Results[index].State = "failed"
+			res.Results[index].Outcome = "audit_unavailable"
+			res.Results[index].PolicyResult = "denied"
+		}
+		return res, errProviderAuditUnavailable
 	}
-	_ = b.audit("provider_migration_apply", req.TargetProviderID, res.Outcome, req.ServiceID, req.RequestID)
-	return res, nil
+	res.AuditStatus = "audit_recorded"
+	return res, operationErr
 }
 
 func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation string, apply bool) (migrationPlanResponse, error) {
@@ -332,19 +351,23 @@ func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation st
 		res.Results = b.migrationItems(req, target, apply, res.Outcome)
 		return res, outcomeErrorForProvider(res.Outcome)
 	}
-	if apply && !providerCanApplyMigrationTarget(target.ProviderKind) {
+	if len(safeList(req.Refs)) == 0 {
+		refs, sourceOutcome := b.migrationSourceRefs(firstNonEmpty(req.SourceProviderID, "local"))
+		if sourceOutcome != "ready" {
+			res.Outcome = sourceOutcome
+			res.NextAction = providerNextAction(sourceOutcome)
+			return res, outcomeErrorForProvider(sourceOutcome)
+		}
+		req.Refs = refs
+	}
+	if apply {
 		res.Outcome = "unsupported"
 		res.NextAction = "implement_provider_operation_executor"
 		res.Results = b.migrationItems(req, target, apply, res.Outcome)
 		return res, errUnsupportedProvider
 	}
 	res.Results = b.migrationItems(req, target, apply, "")
-	res.Outcome = migrationAggregateOutcome(res.Results, apply)
-	res.AuditStatus = "audit_recorded"
-	if apply && res.Outcome != "policy_denied" {
-		res.Applied = true
-		res.RequiresConfirmation = false
-	}
+	res.Outcome = migrationAggregateOutcome(res.Results)
 	if res.Outcome == "partial_failure" || res.Outcome == "policy_denied" {
 		res.NextAction = "review_denied_or_failed_refs"
 	}
@@ -353,14 +376,6 @@ func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation st
 
 func (b *localBackend) migrationItems(req migrationPlanRequest, target providerConfigStatus, apply bool, forcedOutcome string) []migrationItemStatus {
 	refs := safeList(req.Refs)
-	if len(refs) == 0 {
-		listed, err := b.listManagedSecrets("", false)
-		if err == nil {
-			for _, record := range listed.Results {
-				refs = append(refs, record.Ref)
-			}
-		}
-	}
 	sort.Strings(refs)
 	items := make([]migrationItemStatus, 0, len(refs))
 	for _, ref := range refs {
@@ -373,6 +388,11 @@ func (b *localBackend) migrationItems(req migrationPlanRequest, target providerC
 			item.State = "denied"
 			item.Outcome = "invalid_ref"
 			item.PolicyResult = "denied"
+		} else if sourceOutcome := b.migrationSourceOutcome(item.SourceProviderID, ref); sourceOutcome != "ready" {
+			item.State = "failed"
+			item.Outcome = sourceOutcome
+			item.PolicyResult = "denied"
+			item.ExpectedAction = providerNextAction(sourceOutcome)
 		} else if strings.Contains(strings.ToLower(ref), "deny") {
 			item.State = "denied"
 			item.Outcome = "policy_denied"
@@ -390,6 +410,63 @@ func (b *localBackend) migrationItems(req migrationPlanRequest, target providerC
 		items = append(items, item)
 	}
 	return items
+}
+
+func (b *localBackend) migrationSourceRefs(sourceProviderID string) ([]string, string) {
+	sourceProviderID = firstNonEmpty(strings.TrimSpace(sourceProviderID), "local")
+	refs := []string{}
+	if sourceProviderID == "local" || sourceProviderID == "local-encrypted-store" {
+		store, err := b.loadStore()
+		if err != nil {
+			return refs, outcomeForError(err)
+		}
+		for ref := range store.Secrets {
+			refs = append(refs, ref)
+		}
+		return refs, "ready"
+	}
+	status := b.lookupProvider(sourceProviderID)
+	if status.Outcome != "ready" {
+		return refs, providerMigrationOutcome(status)
+	}
+	for _, source := range b.sources.enabledSources() {
+		if source.SourceID != sourceProviderID {
+			continue
+		}
+		for ref := range source.Refs {
+			refs = append(refs, ref)
+		}
+		break
+	}
+	return refs, "ready"
+}
+
+func (b *localBackend) migrationSourceOutcome(sourceProviderID, ref string) string {
+	sourceProviderID = firstNonEmpty(strings.TrimSpace(sourceProviderID), "local")
+	if sourceProviderID == "local" || sourceProviderID == "local-encrypted-store" {
+		store, err := b.loadStore()
+		if err != nil {
+			return "degraded"
+		}
+		if _, ok := store.Secrets[ref]; !ok {
+			return "missing_ref"
+		}
+		return "ready"
+	}
+	status := b.lookupProvider(sourceProviderID)
+	if status.Outcome != "ready" {
+		return providerMigrationOutcome(status)
+	}
+	for _, source := range b.sources.enabledSources() {
+		if source.SourceID != sourceProviderID {
+			continue
+		}
+		if _, ok := source.Refs[ref]; !ok {
+			return "missing_ref"
+		}
+		return "ready"
+	}
+	return "missing_ref"
 }
 
 func (b *localBackend) lookupProvider(providerID string) providerConfigStatus {
@@ -431,8 +508,14 @@ func migrationRiskForTarget(kind string) string {
 }
 
 func migrationExpectedActionForTarget(kind string, apply bool, forcedOutcome string) string {
+	if apply && forcedOutcome == "unsupported" {
+		return "implement_provider_operation_executor"
+	}
+	if forcedOutcome != "" {
+		return providerNextAction(forcedOutcome)
+	}
 	if providerUsesRemoteMutationPath(kind) {
-		if apply || forcedOutcome != "" {
+		if apply {
 			return "implement_provider_operation_executor"
 		}
 		return "write_value_to_remote_provider_after_revalidation"
@@ -460,7 +543,7 @@ func providerMigrationOutcome(target providerConfigStatus) string {
 	return "unsupported"
 }
 
-func migrationAggregateOutcome(items []migrationItemStatus, apply bool) string {
+func migrationAggregateOutcome(items []migrationItemStatus) string {
 	if len(items) == 0 {
 		return "ready"
 	}
@@ -476,13 +559,13 @@ func migrationAggregateOutcome(items []migrationItemStatus, apply bool) string {
 	if denied || failed {
 		return "partial_failure"
 	}
-	if apply {
-		return "applied"
-	}
 	return "dry_run_ready"
 }
 
-var errUnsupportedProvider = errors.New("unsupported provider capability")
+var (
+	errUnsupportedProvider      = errors.New("unsupported provider capability")
+	errProviderAuditUnavailable = errors.New("provider action audit unavailable")
+)
 
 func outcomeErrorForProvider(outcome string) error {
 	switch outcome {
@@ -494,6 +577,8 @@ func outcomeErrorForProvider(outcome string) error {
 		return errInvalidRef
 	case "policy_denied":
 		return errPolicyDenied
+	case "degraded", "source_unavailable", "missing_ref":
+		return errBackendDegraded
 	default:
 		return errUnsupportedProvider
 	}

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -124,17 +124,62 @@ func TestMigrationUnsupportedTargetAndLockedFailClosed(t *testing.T) {
 	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
 	backend.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "vault-readonly", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: "token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"}}}}}
 
-	unsupported, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-vault-target", ServiceID: "@serviceadmin", OperationID: "migration-op-b", TargetProviderID: "vault-readonly"})
-	if err == nil || unsupported.Outcome != "unsupported" || len(unsupported.Results) == 0 {
-		t.Fatalf("unsupported target response = %#v err=%v", unsupported, err)
+	planned, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-vault-target", ServiceID: "@serviceadmin", OperationID: "migration-op-b", TargetProviderID: "vault-readonly"})
+	if err != nil || planned.Outcome != "dry_run_ready" || len(planned.Results) == 0 {
+		t.Fatalf("remote target dry-run response = %#v err=%v", planned, err)
 	}
-	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), managedSecretValue, "token-fixture")
+	assertNoSecretMaterial(t, mustManagedJSON(t, planned), managedSecretValue, "token-fixture")
 
 	locked := newLocalBackend(t.TempDir()+"/store.json", t.TempDir()+"/audit.jsonl", "")
 	lockedPlan, err := locked.migrationDryRun(migrationPlanRequest{RequestID: "req-locked", ServiceID: "@serviceadmin", OperationID: "migration-op-c", TargetProviderID: "local"})
 	if err == nil || lockedPlan.Outcome != "locked" || len(lockedPlan.Results) != 0 {
 		t.Fatalf("locked migration response = %#v err=%v", lockedPlan, err)
 	}
+}
+
+func TestMigrationDryRunPlansConfiguredRemoteProviderTargets(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{
+		{SourceID: "vault-ready", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: "vault-token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"}}},
+		{SourceID: "openbao-ready", Kind: "openbao", Enabled: true, Address: "https://openbao.invalid", Token: "openbao-token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"}}},
+		{SourceID: "aws-ready", Kind: "aws-secrets-manager", Enabled: true, Address: "https://aws.invalid", Token: "aws-token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "service-lasso/api/token"}}},
+	}}
+
+	for _, target := range []string{"vault-ready", "openbao-ready", "aws-ready"} {
+		t.Run(target, func(t *testing.T) {
+			plan, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-remote-plan", ServiceID: "@serviceadmin", OperationID: "migration-op-remote", SourceProviderID: "local", TargetProviderID: target, Refs: []string{"services/@serviceadmin/runtime/SESSION_SIGNING_KEY"}})
+			if err != nil || plan.Outcome != "dry_run_ready" || plan.Applied || len(plan.Results) != 1 {
+				t.Fatalf("remote migration dry-run = %#v err=%v", plan, err)
+			}
+			item := plan.Results[0]
+			if item.State != "planned" || item.Outcome != "dry_run_ready" || item.Risk != "medium" || item.ExpectedAction != "write_value_to_remote_provider_after_revalidation" {
+				t.Fatalf("remote migration item = %#v", item)
+			}
+			if item.Recovery != "source_retained_until_target_verification_succeeds" {
+				t.Fatalf("remote migration recovery should preserve source until verification: %#v", item)
+			}
+			assertNoSecretMaterial(t, mustManagedJSON(t, plan), managedSecretValue, "vault-token-fixture", "openbao-token-fixture", "aws-token-fixture")
+		})
+	}
+}
+
+func TestMigrationApplyRemoteProviderFailsClosedUntilExecutorExists(t *testing.T) {
+	backend := managedTestBackend(t)
+	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "aws-ready", Kind: "aws-secrets-manager", Enabled: true, Address: "https://aws.invalid", Token: "aws-token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "service-lasso/api/token"}},
+	}}}
+
+	apply, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-remote-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-remote", SourceProviderID: "local", TargetProviderID: "aws-ready", Refs: []string{"services/@serviceadmin/runtime/SESSION_SIGNING_KEY"}, Confirm: true, Reason: "approved remote migration"})
+	if err == nil || apply.Applied || apply.Outcome != "unsupported" || apply.NextAction != "implement_provider_operation_executor" || len(apply.Results) != 1 {
+		t.Fatalf("remote migration apply should fail closed: %#v err=%v", apply, err)
+	}
+	item := apply.Results[0]
+	if item.State != "failed" || item.Outcome != "unsupported" || item.ExpectedAction != "implement_provider_operation_executor" {
+		t.Fatalf("remote migration apply item = %#v", item)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, apply), managedSecretValue, "aws-token-fixture")
 }
 
 func TestProviderConfigMigrationHTTPContract(t *testing.T) {

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -71,7 +76,31 @@ func TestProviderConfigValidationRejectsPlaintextAndCoversAuthUnsupported(t *tes
 	}
 }
 
-func TestProviderConfigApplyRequiresConfirmationOperationAndReason(t *testing.T) {
+func TestProviderConfigAddressMetadataStripsCredentialAndRequestDetails(t *testing.T) {
+	backend := managedTestBackend(t)
+	const addressUser = "provider-user-fixture"
+	const addressPassword = "provider-password-fixture"
+	const addressQueryToken = "provider-query-token-fixture"
+	res, err := backend.validateProviderConfig(providerConfigRequest{
+		RequestID:     "req-address-redaction",
+		ServiceID:     "@serviceadmin",
+		ProviderID:    "vault-prod",
+		ProviderKind:  "vault",
+		Address:       "https://" + addressUser + ":" + addressPassword + "@vault.example.invalid/secret/private?token=" + addressQueryToken + "#fragment",
+		CredentialRef: "secret://local/provider/vault-prod/token",
+	})
+	if err != nil || res.Outcome != "ready" || res.Provider.Address != "https://vault.example.invalid" {
+		t.Fatalf("provider address response = %#v err=%v", res, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), addressUser, addressPassword, addressQueryToken, "secret/private")
+
+	invalid, err := backend.validateProviderConfig(providerConfigRequest{RequestID: "req-address-invalid", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "not-a-provider-url", CredentialRef: "secret://local/provider/vault-prod/token"})
+	if err == nil || invalid.Outcome != "invalid_ref" || invalid.Provider.Address != "" {
+		t.Fatalf("invalid provider address = %#v err=%v", invalid, err)
+	}
+}
+
+func TestProviderConfigApplyRequiresConfirmationAndNeverClaimsUnpersistedSuccess(t *testing.T) {
 	backend := managedTestBackend(t)
 	req := providerConfigRequest{RequestID: "req-apply", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialRef: "secret://local/provider/vault-prod/token"}
 
@@ -83,11 +112,41 @@ func TestProviderConfigApplyRequiresConfirmationOperationAndReason(t *testing.T)
 	req.Confirm = true
 	req.Reason = "operator approved provider migration setup"
 	req.OperationID = "provider-config-2026-05-08-a"
-	applied, err := backend.applyProviderConfig(req)
-	if err != nil || !applied.Applied || applied.Outcome != "applied" {
-		t.Fatalf("provider apply = %#v err=%v", applied, err)
+	unsupported, err := backend.applyProviderConfig(req)
+	if !errors.Is(err, errUnsupportedProvider) || unsupported.Applied || unsupported.Outcome != "unsupported" || unsupported.UnsupportedCapability != "provider_configuration_persistence" || unsupported.NextAction != "implement_persisted_provider_configuration" || unsupported.AuditStatus != "audit_recorded" {
+		t.Fatalf("unpersisted provider apply = %#v err=%v", unsupported, err)
 	}
-	assertNoSecretMaterial(t, mustManagedJSON(t, applied), providerCredentialValue)
+	for _, provider := range backend.providerConfigStatusResponse().Providers {
+		if provider.ProviderID == req.ProviderID {
+			t.Fatalf("planned provider configuration was unexpectedly persisted: %#v", provider)
+		}
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), providerCredentialValue)
+}
+
+func TestProviderConfigValidationAndApplyFailClosedWhenAuditUnavailable(t *testing.T) {
+	backend := managedTestBackend(t)
+	blockedAudit := filepath.Join(t.TempDir(), "audit-is-directory")
+	if err := os.Mkdir(blockedAudit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend.auditPath = blockedAudit
+	req := providerConfigRequest{RequestID: "req-config-audit-down", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialRef: "secret://local/provider/vault-prod/token"}
+
+	validated, err := backend.validateProviderConfig(req)
+	if !errors.Is(err, errProviderAuditUnavailable) || validated.Applied || validated.Outcome != "audit_unavailable" || validated.AuditStatus != "audit_unavailable" || validated.Provider.AuditStatus != "audit_unavailable" || validated.NextAction != "restore_audit_and_retry" {
+		t.Fatalf("provider validate with unavailable audit = %#v err=%v", validated, err)
+	}
+
+	req.Confirm = true
+	req.Reason = "operator approved provider migration setup"
+	req.OperationID = "provider-config-audit-down"
+	unsupported, err := backend.applyProviderConfig(req)
+	if !errors.Is(err, errProviderAuditUnavailable) || unsupported.Applied || unsupported.Outcome != "audit_unavailable" || unsupported.AuditStatus != "audit_unavailable" || unsupported.NextAction != "restore_audit_and_retry" {
+		t.Fatalf("provider apply with unavailable audit = %#v err=%v", unsupported, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, validated), providerCredentialValue)
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), providerCredentialValue)
 }
 
 func TestMigrationDryRunMetadataOnlyPartialDenialAndApplyGating(t *testing.T) {
@@ -109,14 +168,11 @@ func TestMigrationDryRunMetadataOnlyPartialDenialAndApplyGating(t *testing.T) {
 		t.Fatalf("unconfirmed migration apply should fail closed: %#v err=%v", blocked, err)
 	}
 
-	applied, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local", Confirm: true, Reason: "approved migration"})
-	if err != nil {
-		t.Fatal(err)
+	unsupported, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local", Confirm: true, Reason: "approved migration"})
+	if !errors.Is(err, errUnsupportedProvider) || unsupported.Applied || unsupported.Outcome != "unsupported" || unsupported.NextAction != "implement_provider_operation_executor" || len(unsupported.Results) != 2 {
+		t.Fatalf("non-executable migration apply = %#v err=%v", unsupported, err)
 	}
-	if !applied.Applied || applied.Outcome != "partial_failure" || len(applied.Results) != 2 {
-		t.Fatalf("migration apply = %#v", applied)
-	}
-	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "deny-value-fixture")
+	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), managedSecretValue, "deny-value-fixture")
 }
 
 func TestMigrationUnsupportedTargetAndLockedFailClosed(t *testing.T) {
@@ -182,6 +238,108 @@ func TestMigrationApplyRemoteProviderFailsClosedUntilExecutorExists(t *testing.T
 	assertNoSecretMaterial(t, mustManagedJSON(t, apply), managedSecretValue, "aws-token-fixture")
 }
 
+func TestMigrationPlanningAndRemoteApplyFailClosedWhenAuditUnavailable(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "vault-ready", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: "vault-token-fixture", Refs: map[string]sourceRefConfig{"services/api/runtime/API_TOKEN": {Path: "secret/data/api", Field: "token"}},
+	}}}
+	blockedAudit := filepath.Join(t.TempDir(), "audit-is-directory")
+	if err := os.Mkdir(blockedAudit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend.auditPath = blockedAudit
+
+	dryRun, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-audit-down-plan", ServiceID: "@serviceadmin", OperationID: "migration-audit-down", SourceProviderID: "local", TargetProviderID: "vault-ready", Refs: []string{ref}})
+	if !errors.Is(err, errProviderAuditUnavailable) || dryRun.Outcome != "audit_unavailable" || dryRun.Applied || dryRun.AuditStatus != "audit_unavailable" || dryRun.NextAction != "restore_audit_and_retry" || len(dryRun.Results) != 1 || dryRun.Results[0].Outcome != "audit_unavailable" {
+		t.Fatalf("audit unavailable dry-run = %#v err=%v", dryRun, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, dryRun), managedSecretValue, "vault-token-fixture")
+
+	apply, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-audit-down-apply", ServiceID: "@serviceadmin", OperationID: "migration-audit-down", SourceProviderID: "local", TargetProviderID: "vault-ready", Refs: []string{ref}, Reason: "approved", Confirm: true})
+	if !errors.Is(err, errProviderAuditUnavailable) || apply.Outcome != "audit_unavailable" || apply.Applied || apply.AuditStatus != "audit_unavailable" || len(apply.Results) != 1 || apply.Results[0].Outcome != "audit_unavailable" {
+		t.Fatalf("audit unavailable apply = %#v err=%v", apply, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, apply), managedSecretValue, "vault-token-fixture")
+}
+
+func TestMigrationPlanFailsRefsClosedWhenSourceIsMissingOrNotReady(t *testing.T) {
+	backend := managedTestBackend(t)
+	readyRef := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	missingRef := "services/@serviceadmin/runtime/MISSING_KEY"
+	writeManagedTestSecret(t, backend, readyRef, managedSecretValue)
+
+	localPlan, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-source-missing", ServiceID: "@serviceadmin", OperationID: "migration-source-missing", SourceProviderID: "local", TargetProviderID: "local", Refs: []string{readyRef, missingRef}})
+	if err != nil || localPlan.Outcome != "partial_failure" || len(localPlan.Results) != 2 {
+		t.Fatalf("local source plan = %#v err=%v", localPlan, err)
+	}
+	byRef := map[string]migrationItemStatus{}
+	for _, item := range localPlan.Results {
+		byRef[item.Ref] = item
+	}
+	if byRef[readyRef].Outcome != "dry_run_ready" || byRef[missingRef].Outcome != "missing_ref" || byRef[missingRef].ExpectedAction != "check_ref" {
+		t.Fatalf("local source results = %#v", localPlan.Results)
+	}
+
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{SourceID: "vault-auth-required", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Refs: map[string]sourceRefConfig{readyRef: {Path: "secret/data/serviceadmin", Field: "key"}}}}}
+	remotePlan, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-source-auth", ServiceID: "@serviceadmin", OperationID: "migration-source-auth", SourceProviderID: "vault-auth-required", TargetProviderID: "local", Refs: []string{readyRef}})
+	if err != nil || remotePlan.Outcome != "partial_failure" || len(remotePlan.Results) != 1 || remotePlan.Results[0].Outcome != "source_auth_required" || remotePlan.Results[0].ExpectedAction != "provide_credential_ref_or_reconnect_provider" {
+		t.Fatalf("remote source plan = %#v err=%v", remotePlan, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, remotePlan), managedSecretValue)
+}
+
+func TestMigrationPlanFailsClosedWhenSelectedSourceInventoryCannotBeRead(t *testing.T) {
+	backend := managedTestBackend(t)
+	if err := os.WriteFile(backend.storePath, []byte(`not-json`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := backend.migrationDryRun(migrationPlanRequest{RequestID: "req-source-degraded", ServiceID: "@serviceadmin", OperationID: "migration-source-degraded", SourceProviderID: "local", TargetProviderID: "local"})
+	if !errors.Is(err, errBackendDegraded) || plan.Outcome != "degraded" || plan.Applied || plan.AuditStatus != "audit_recorded" || len(plan.Results) != 0 {
+		t.Fatalf("unreadable source inventory plan = %#v err=%v", plan, err)
+	}
+}
+
+func TestMigrationHTTPAuditUnavailableReturnsSafeServiceUnavailable(t *testing.T) {
+	backend := managedTestBackend(t)
+	ref := "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+	writeManagedTestSecret(t, backend, ref, managedSecretValue)
+	blockedAudit := filepath.Join(t.TempDir(), "audit-is-directory")
+	if err := os.Mkdir(blockedAudit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend.auditPath = blockedAudit
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	body, err := json.Marshal(migrationPlanRequest{RequestID: "req-http-audit-down", ServiceID: "@serviceadmin", OperationID: "migration-http-audit-down", SourceProviderID: "local", TargetProviderID: "local", Refs: []string{ref}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/migration/dry-run", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer test-token")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusServiceUnavailable || !bytes.Contains(payload, []byte(`"outcome":"audit_unavailable"`)) {
+		t.Fatalf("status=%d body=%s", response.StatusCode, payload)
+	}
+	assertNoSecretMaterial(t, payload, managedSecretValue, "test-token")
+}
+
 func TestProviderConfigMigrationHTTPContract(t *testing.T) {
 	backend := managedTestBackend(t)
 	writeManagedTestSecret(t, backend, "services/@serviceadmin/runtime/SESSION_SIGNING_KEY", managedSecretValue)
@@ -221,6 +379,23 @@ func TestProviderConfigMigrationHTTPContract(t *testing.T) {
 	}
 	assertNoSecretMaterial(t, validatePayload, providerCredentialValue)
 
+	applyBody := []byte(`{"requestId":"req-http-apply","serviceId":"@serviceadmin","providerId":"vault-prod","providerKind":"vault","address":"https://vault.example.invalid","credentialRef":"secret://local/provider/vault-prod/token","operationId":"provider-config-http-a","reason":"approved","confirm":true}`)
+	applyReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/config/apply", bytes.NewReader(applyBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyReq.Header.Set("Content-Type", "application/json")
+	applyReq.Header.Set("Authorization", "Bearer test-token")
+	applyRes, err := http.DefaultClient.Do(applyReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyPayload := readClose(t, applyRes.Body)
+	if applyRes.StatusCode != http.StatusNotImplemented || !bytes.Contains(applyPayload, []byte(`"outcome":"unsupported"`)) || !bytes.Contains(applyPayload, []byte(`"applied":false`)) {
+		t.Fatalf("provider apply code=%d body=%s", applyRes.StatusCode, applyPayload)
+	}
+	assertNoSecretMaterial(t, applyPayload, providerCredentialValue, "test-token")
+
 	migrationBody := []byte(`{"requestId":"req-http-migrate","serviceId":"@serviceadmin","operationId":"migration-http-a","sourceProviderId":"local","targetProviderId":"local"}`)
 	migrationReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/migration/dry-run", bytes.NewReader(migrationBody))
 	if err != nil {
@@ -237,4 +412,21 @@ func TestProviderConfigMigrationHTTPContract(t *testing.T) {
 		t.Fatalf("migration code=%d body=%s", migrationRes.StatusCode, migrationPayload)
 	}
 	assertNoSecretMaterial(t, migrationPayload, managedSecretValue)
+
+	migrationApplyBody := []byte(`{"requestId":"req-http-migrate-apply","serviceId":"@serviceadmin","operationId":"migration-http-apply-a","sourceProviderId":"local","targetProviderId":"local","reason":"approved","confirm":true}`)
+	migrationApplyReq, err := http.NewRequest(http.MethodPost, server.URL+"/v1/providers/migration/apply", bytes.NewReader(migrationApplyBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationApplyReq.Header.Set("Content-Type", "application/json")
+	migrationApplyReq.Header.Set("Authorization", "Bearer test-token")
+	migrationApplyRes, err := http.DefaultClient.Do(migrationApplyReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationApplyPayload := readClose(t, migrationApplyRes.Body)
+	if migrationApplyRes.StatusCode != http.StatusNotImplemented || !bytes.Contains(migrationApplyPayload, []byte(`"outcome":"unsupported"`)) || !bytes.Contains(migrationApplyPayload, []byte(`"applied":false`)) {
+		t.Fatalf("migration apply code=%d body=%s", migrationApplyRes.StatusCode, migrationApplyPayload)
+	}
+	assertNoSecretMaterial(t, migrationApplyPayload, managedSecretValue, "test-token")
 }

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -106,11 +106,20 @@ Builds a metadata-only migration plan.
 }
 ```
 
+Configured remote targets whose adapter contract supports write/update and
+migration, including Vault/OpenBao and AWS Secrets Manager, are valid dry-run
+targets. Remote dry-runs return per-ref `planned` items with
+`expectedAction: "write_value_to_remote_provider_after_revalidation"` and
+`recovery: "source_retained_until_target_verification_succeeds"` so clients can
+show the exact remote operation path without copying or returning secret values.
+
 ### `POST /v1/providers/migration/apply` (planned)
 
 The current handler reports per-ref metadata outcomes after confirmation,
 operation id and audit reason. It does not copy local values or perform remote
-provider writes. Its manifest maturity is `planned`.
+provider writes. Remote targets fail closed with `outcome: "unsupported"` and
+`nextAction: "implement_provider_operation_executor"` until a provider-specific
+executor is wired and validated. Its manifest maturity is `planned`.
 
 ## Typed outcomes
 

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -86,10 +86,13 @@ Request:
 
 ### `POST /v1/providers/config/apply` (planned)
 
-The current handler validates confirmation, operation id and audit reason and
-reports an apply-shaped result, but it does not persist provider configuration.
-Its manifest maturity is `planned`; clients must not enable it as an executable
-configuration action.
+The current handler validates confirmation, operation id and audit reason, but
+it does not persist provider configuration. A fully authorized request therefore
+fails closed with `outcome: "unsupported"`, `applied: false`,
+`unsupportedCapability: "provider_configuration_persistence"`, and
+`nextAction: "implement_persisted_provider_configuration"`. Its manifest
+maturity is `planned`; clients must not enable it as an executable configuration
+action or interpret it as a successful mutation.
 
 ### `POST /v1/providers/migration/dry-run`
 
@@ -113,13 +116,34 @@ targets. Remote dry-runs return per-ref `planned` items with
 `recovery: "source_retained_until_target_verification_succeeds"` so clients can
 show the exact remote operation path without copying or returning secret values.
 
+Plans validate refs against the selected source provider rather than the union
+of all managed refs. An omitted `refs` list expands only from that source: local
+encrypted-store entries for `local`, or configured mappings for the named
+remote source. Missing refs and non-ready source auth/lifecycle states become
+per-ref failures, so a plan cannot describe a nonexistent or currently
+unreadable source value as ready to migrate.
+
+Provider configuration responses expose only the `http`/`https` origin. URL
+user information, path, query, and fragment are stripped so accidentally
+embedded credentials or request details cannot enter Admin responses, audit
+evidence, or diagnostics. Invalid/non-HTTP provider addresses fail validation.
+
+The Broker records every migration dry-run and apply attempt in the configured
+metadata-only audit/event sinks before returning an auditable result. If either
+sink cannot accept the record, the response fails closed with
+`outcome: "audit_unavailable"`, `auditStatus: "audit_unavailable"`,
+`applied: false`, and `nextAction: "restore_audit_and_retry"`. Per-ref items are
+also marked `audit_unavailable`; provider credentials, source values, and raw
+provider bodies are never returned.
+
 ### `POST /v1/providers/migration/apply` (planned)
 
-The current handler reports per-ref metadata outcomes after confirmation,
-operation id and audit reason. It does not copy local values or perform remote
-provider writes. Remote targets fail closed with `outcome: "unsupported"` and
+The current handler validates confirmation, operation id and audit reason, but
+it does not copy local values or perform remote provider writes. Every target
+therefore fails closed with `outcome: "unsupported"`, `applied: false`, and
 `nextAction: "implement_provider_operation_executor"` until a provider-specific
-executor is wired and validated. Its manifest maturity is `planned`.
+executor is wired and validated. Its manifest maturity is `planned`; per-ref
+items are metadata-only evidence and never indicate a completed copy.
 
 ## Typed outcomes
 


### PR DESCRIPTION
## Issue
Refs #134

## Summary
- Allows configured remote provider migration targets to produce metadata-only dry-run plans when the adapter contract supports both write/update and migration.
- Adds explicit remote planning metadata for Vault/OpenBao and AWS Secrets Manager targets: medium risk, provider-write expected action, and source-retained recovery semantics.
- Keeps remote migration apply fail-closed until a provider-specific operation executor is implemented and validated.

## Scope
- In scope: first #134 scaffold for remote provider migration planning and fail-closed apply gating.
- Out of scope: actual Vault/OpenBao/AWS write execution, provider credential resolution, destructive provider operations, bulk campaign remote apply, release matrix completion.

## Spec / contract / fixture impact
- Updated: provider configuration/migration API docs for remote dry-run targets and remote apply gating.
- Not changed: OpenAPI/conformance artifacts; `go test ./...` confirmed generated artifacts are current.

## Service Lasso invariant impact
- Invariant: provider credentials and raw secret values remain metadata-safe.
- Preservation proof: new regression tests assert migration responses omit managed secret values and fake provider tokens; remote apply remains unsupported until an executor exists.

## Validation
- PASS `go test ./cmd/secretsbroker -run 'TestMigration|TestProviderConfigMigration|TestProviderOperationMatrices|TestProviderAndSourceResponsesIncludeConnectionScopedOperations' -count=1` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-20260801-175443\issue-134-focused-go-test.stdout.log`.
- PASS `go test ./...` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-20260801-175443\issue-134-go-test-all.stdout.log`.
- PASS `git diff --check` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-20260801-175443\issue-134-git-diff-check.stdout.log`.
- PASS updated-code canonical Service Lasso `npm run build`, `demo-gate`, and `demo-verify-canonical` - evidence `C:\projects\service-lasso\.work-agent\logs\dev-20260801-175443\issue-134-postchange-demo-proof.json`.
- PASS loopback/LAN runtime health, Service Admin `/api/dashboard`, and Service Admin `/api/services` probes - evidence `issue-134-postchange-loopback-runtime-health.json`, `issue-134-postchange-lan-runtime-health.json`, `issue-134-postchange-admin-dashboard.json`, and `issue-134-postchange-admin-services.json` in the same run log.

## Approval trail
- Required: yes.
- Evidence: Maintainer review requested because this changes provider migration contract behavior for configured remote targets.

## Cleanup
- Branch `feat/134-provider-mutation-scaffold` targets `develop`.
- Post-review cleanup: merge when checks/review allow, then continue #134 with the provider operation executor slice.


## Release hardening supplement

Follow-up commit `acf9ca1` closes false-success and audit-integrity gaps in the scaffold:

- provider config validate/apply and migration dry-run/apply fail closed with typed `audit_unavailable` (503) when metadata-only evidence cannot be persisted;
- provider config apply returns `unsupported`/501 and `applied=false` until configuration persistence exists;
- migration apply returns `unsupported`/501 and `applied=false` for every target until a real executor exists;
- omitted refs expand only from the selected source, missing/auth-failed source refs are explicit, and unreadable inventory is degraded;
- provider addresses are reduced to sanitized HTTP(S) origins, stripping userinfo/path/query/fragment;
- HTTP tests prove safe 501/503 responses and no value, credential, or token leakage.

Validated with focused tests repeated 10 times, full `go test ./...`, `go vet ./...`, both command builds, `scripts/test.ps1`, and `git diff --check`.
