### PR TITLE
#125 migrate manifests to canonical endpoints

### DIFF
--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -12,7 +12,7 @@ It is meant to make the template usable without forcing service authors to recon
 - common top-level fields
 - `actions`
 - `execconfig`
-- env / dependencies / ports
+- env / dependencies / endpoints
 - `healthchecks[]` direction
 - examples
 - what is currently canonical vs still illustrative
@@ -93,14 +93,39 @@ The current sample in this repo is:
   },
   "execconfig": {
     "serviceorder": 100,
-    "serviceport": 0,
     "execcwd": "runtime",
     "executable": "echo-service",
     "env": {
-      "ECHO_MESSAGE": "hello from service-template"
+      "ECHO_MESSAGE": "hello from service-template",
+      "ECHO_PORT": "${endpoint.service.port}"
     },
     "depend_on": []
   },
+  "endpoints": [
+    {
+      "id": "service",
+      "kind": "network",
+      "label": "Service HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 0,
+        "strategy": "automatic"
+      },
+      "exposure": "local",
+      "primary": true
+    },
+    {
+      "id": "health",
+      "kind": "url",
+      "label": "Health",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/health",
+      "exposure": "local"
+    }
+  ],
   "healthchecks": [
     {
       "id": "process-health",
@@ -213,11 +238,6 @@ Example:
 ```json
 "serviceorder": 100
 ```
-
-### `serviceport`
-Primary service port.
-
-In the sample, `0` is being used as a simple first-pass placeholder/default meaning “no fixed service port required by this sample”.
 
 ### `execcwd`
 Execution working directory.
@@ -402,15 +422,35 @@ Current broader Service Lasso direction includes:
 
 The sample template keeps this minimal for now.
 
-### Ports and URLs
-Donor material shows additional fields such as:
-- `serviceportsecondary`
-- `serviceportconsole`
-- `serviceportdebug`
-- `portmapping`
-- `urls`
+### Endpoints
+`endpoints[]` is the canonical authoring surface for service interfaces and resources. A network listener should be represented by a `kind: "network"` endpoint, and a routable/operator-facing link should be represented by a `kind: "url"` endpoint.
 
-These are not all used in the minimal sample, but they remain relevant for more complex services.
+Use selector form `${endpoint.<id>.<field>}` in env, globalenv, command lines, healthchecks, and generated config. For example:
+
+```json
+{
+  "endpoints": [
+    {
+      "id": "service",
+      "kind": "network",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4010,
+        "strategy": "preferred"
+      }
+    },
+    {
+      "id": "health",
+      "kind": "url",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/health"
+    }
+  ]
+}
+```
+
+Legacy top-level `ports`, `portmapping`, `urls`, and `serviceport*` fields can still be understood by compatibility readers, but new package authoring in this repo should not use them. Keep compatibility aliases in `env` or `globalenv` when existing consumers still need uppercase values.
 
 ### Runtime-provider relationships
 Donor material also shows patterns such as:
@@ -429,6 +469,7 @@ The minimal sample does not use this yet.
 - `execconfig` as the execution contract section
 - explicit `env`
 - explicit `depend_on`
+- explicit `endpoints[]` for network, URL, mount, and device resources
 - default health model of `process`
 - explicit override to other health models when needed
 
@@ -444,9 +485,10 @@ The minimal sample does not use this yet.
 For the first template-based service:
 1. keep the manifest small
 2. use `process` health unless another model is clearly needed
-3. explicitly declare env and dependencies
-4. avoid donor baggage that mixes generated runtime state into package content
-5. prefer clarity over trying to model every advanced donor feature on day one
+3. explicitly declare env, dependencies, and endpoints
+4. use endpoint selectors instead of authoring new top-level port or URL fields
+5. avoid donor baggage that mixes generated runtime state into package content
+6. prefer clarity over trying to model every advanced donor feature on day one
 
 ## Related docs
 

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -14,6 +14,21 @@ try {
     throw 'service.json id mismatch'
   }
 
+  $manifestPaths = @('service.json') + (Get-ChildItem -Path (Join-Path $root 'services') -Recurse -Filter 'service.json' | ForEach-Object {
+    $_.FullName.Substring($root.Length + 1)
+  })
+  foreach ($manifestPath in $manifestPaths) {
+    $manifest = Get-Content (Join-Path $root $manifestPath) -Raw | ConvertFrom-Json
+    foreach ($legacyField in @('ports', 'urls', 'portmapping')) {
+      if ($manifest.PSObject.Properties.Name -contains $legacyField) {
+        throw "$manifestPath uses legacy top-level $legacyField; use endpoints[] plus env/globalenv aliases"
+      }
+    }
+    if ($manifestPath -in @('service.json', 'services\@nginx\service.json', 'services\@serviceadmin\service.json', 'services\@traefik\service.json', 'services\echo-service\service.json') -and -not $manifest.endpoints) {
+      throw "$manifestPath is missing endpoints[]"
+    }
+  }
+
   $contract = Get-Content (Join-Path $root 'verify\service-harness.json') -Raw | ConvertFrom-Json
   if ($contract.serviceId -ne '@secretsbroker') {
     throw 'service-harness.json serviceId mismatch'

--- a/service.json
+++ b/service.json
@@ -130,7 +130,6 @@
   },
   "execconfig": {
     "serviceorder": 5,
-    "serviceport": 17890,
     "execcwd": ".",
     "executable": "secretsbroker",
     "args": [
@@ -138,7 +137,7 @@
     ],
     "env": {
       "SECRETSBROKER_STATE": "setup_needed",
-      "SECRETSBROKER_LISTEN": "127.0.0.1:17890"
+      "SECRETSBROKER_LISTEN": "127.0.0.1:${endpoint.api.port}"
     },
     "depend_on": []
   },
@@ -146,8 +145,62 @@
     {
       "id": "secretsbroker-http-health",
       "type": "http",
-      "url": "http://127.0.0.1:17890/health",
+      "url": "${endpoint.health.url}",
       "timeoutSeconds": 5
+    }
+  ],
+  "endpoints": [
+    {
+      "id": "api",
+      "kind": "network",
+      "label": "Secrets Broker API",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 17890,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "health",
+      "kind": "url",
+      "label": "Health",
+      "target": "api",
+      "url": "http://${endpoint.api.bind}:${endpoint.api.port}/health",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "ready",
+      "kind": "url",
+      "label": "Readiness",
+      "target": "api",
+      "url": "http://${endpoint.api.bind}:${endpoint.api.port}/ready",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "status",
+      "kind": "url",
+      "label": "Status",
+      "target": "api",
+      "url": "http://${endpoint.api.bind}:${endpoint.api.port}/status",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "capabilities",
+      "kind": "url",
+      "label": "Capabilities",
+      "target": "api",
+      "url": "http://${endpoint.api.bind}:${endpoint.api.port}/capabilities",
+      "exposure": "local",
+      "required": true
     }
   ]
 }

--- a/services/@java/service.json
+++ b/services/@java/service.json
@@ -14,13 +14,6 @@
     "JAVA": "${SERVICE_ARTIFACT_COMMAND}",
     "JAVA_HOME": "${SERVICE_ARTIFACT_ROOT}"
   },
-  "urls": [
-    {
-      "label": "temurin",
-      "url": "https://adoptium.net/temurin/",
-      "kind": "external"
-    }
-  ],
   "artifact": {
     "kind": "archive",
     "source": {
@@ -54,5 +47,15 @@
         ]
       }
     }
-  }
+  },
+  "endpoints": [
+    {
+      "id": "temurin",
+      "kind": "url",
+      "label": "Temurin",
+      "url": "https://adoptium.net/temurin/",
+      "exposure": "public",
+      "required": false
+    }
+  ]
 }

--- a/services/@nginx/service.json
+++ b/services/@nginx/service.json
@@ -4,9 +4,6 @@
   "description": "Release-backed NGINX Open Source service for local Service Lasso routing dependencies.",
   "version": "1.30.0",
   "enabled": true,
-  "ports": {
-    "http": 18080
-  },
   "commandline": {
     "win32": " -p \"${SERVICE_ROOT}\" -c \"runtime\\nginx.conf\" -g \"daemon off;\"",
     "darwin": " -p \"${SERVICE_ROOT}\" -c \"runtime/nginx.conf\" -g \"daemon off;\"",
@@ -14,27 +11,15 @@
     "default": " -p \"${SERVICE_ROOT}\" -c \"runtime/nginx.conf\" -g \"daemon off;\""
   },
   "env": {
-    "NGINX_HTTP_PORT": "${HTTP_PORT}",
-    "NGINX_URL": "http://127.0.0.1:${HTTP_PORT}/",
+    "NGINX_HTTP_PORT": "${endpoint.http.port}",
+    "NGINX_URL": "${endpoint.web.url}",
     "NGINX_ROOT": "${SERVICE_ROOT}"
   },
   "globalenv": {
-    "NGINX_HTTP_PORT": "${HTTP_PORT}",
-    "NGINX_URL": "http://127.0.0.1:${HTTP_PORT}/",
+    "NGINX_HTTP_PORT": "${endpoint.http.port}",
+    "NGINX_URL": "${endpoint.web.url}",
     "NGINX_ROOT": "${SERVICE_ROOT}"
   },
-  "urls": [
-    {
-      "label": "health",
-      "url": "http://127.0.0.1:${HTTP_PORT}/health",
-      "kind": "local"
-    },
-    {
-      "label": "web",
-      "url": "http://127.0.0.1:${HTTP_PORT}/",
-      "kind": "local"
-    }
-  ],
   "artifact": {
     "kind": "archive",
     "source": {
@@ -47,19 +32,25 @@
         "assetName": "lasso-nginx-1.30.0-win32.zip",
         "archiveType": "zip",
         "command": ".\\nginx.exe",
-        "args": ["-v"]
+        "args": [
+          "-v"
+        ]
       },
       "linux": {
         "assetName": "lasso-nginx-1.30.0-linux.tar.gz",
         "archiveType": "tar.gz",
         "command": "./sbin/nginx",
-        "args": ["-v"]
+        "args": [
+          "-v"
+        ]
       },
       "darwin": {
         "assetName": "lasso-nginx-1.30.0-darwin.tar.gz",
         "archiveType": "tar.gz",
         "command": "./sbin/nginx",
-        "args": ["-v"]
+        "args": [
+          "-v"
+        ]
       }
     }
   },
@@ -87,7 +78,7 @@
     "files": [
       {
         "path": "./runtime/nginx.conf",
-        "content": "worker_processes  1;\nmaster_process off;\nerror_log  logs/error.log info;\npid        runtime/nginx.pid;\n\nevents {\n  worker_connections  256;\n}\n\nhttp {\n  access_log logs/access.log;\n  default_type  application/octet-stream;\n  sendfile      on;\n  keepalive_timeout  30;\n\n  server {\n    listen 127.0.0.1:${HTTP_PORT};\n    server_name localhost;\n\n    location / {\n      root runtime/www;\n      index index.html;\n    }\n  }\n}\n"
+        "content": "worker_processes  1;\nmaster_process off;\nerror_log  logs/error.log info;\npid        runtime/nginx.pid;\n\nevents {\n  worker_connections  256;\n}\n\nhttp {\n  access_log logs/access.log;\n  default_type  application/octet-stream;\n  sendfile      on;\n  keepalive_timeout  30;\n\n  server {\n    listen ${endpoint.http.bind}:${endpoint.http.port};\n    server_name localhost;\n\n    location / {\n      root runtime/www;\n      index index.html;\n    }\n  }\n}\n"
       }
     ]
   },
@@ -95,10 +86,47 @@
     {
       "id": "nginx-http-health",
       "type": "http",
-      "url": "http://127.0.0.1:${HTTP_PORT}/health",
+      "url": "${endpoint.health.url}",
       "expected_status": 200,
       "retries": 80,
       "interval": 250
+    }
+  ],
+  "endpoints": [
+    {
+      "id": "http",
+      "kind": "network",
+      "label": "HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 18080,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "health",
+      "kind": "url",
+      "label": "Health",
+      "target": "http",
+      "url": "http://${endpoint.http.bind}:${endpoint.http.port}/health",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "web",
+      "kind": "url",
+      "label": "Web",
+      "target": "http",
+      "url": "http://${endpoint.http.bind}:${endpoint.http.port}/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
     }
   ]
 }

--- a/services/@node/service.json
+++ b/services/@node/service.json
@@ -6,7 +6,9 @@
   "role": "provider",
   "enabled": true,
   "executable": "node",
-  "args": ["--version"],
+  "args": [
+    "--version"
+  ],
   "env": {
     "NODE_ENV": "development"
   },
@@ -14,13 +16,6 @@
     "NODE": "${SERVICE_ARTIFACT_COMMAND}",
     "NODE_HOME": "${SERVICE_ARTIFACT_ROOT}"
   },
-  "urls": [
-    {
-      "label": "docs",
-      "url": "https://nodejs.org",
-      "kind": "external"
-    }
-  ],
   "artifact": {
     "kind": "archive",
     "source": {
@@ -33,20 +28,36 @@
         "assetName": "lasso-node-v24.15.0-win32.zip",
         "archiveType": "zip",
         "command": ".\\node.exe",
-        "args": ["--version"]
+        "args": [
+          "--version"
+        ]
       },
       "linux": {
         "assetName": "lasso-node-v24.15.0-linux.tar.gz",
         "archiveType": "tar.gz",
         "command": "./bin/node",
-        "args": ["--version"]
+        "args": [
+          "--version"
+        ]
       },
       "darwin": {
         "assetName": "lasso-node-v24.15.0-darwin.tar.gz",
         "archiveType": "tar.gz",
         "command": "./bin/node",
-        "args": ["--version"]
+        "args": [
+          "--version"
+        ]
       }
     }
-  }
+  },
+  "endpoints": [
+    {
+      "id": "docs",
+      "kind": "url",
+      "label": "Docs",
+      "url": "https://nodejs.org",
+      "exposure": "public",
+      "required": false
+    }
+  ]
 }

--- a/services/@python/service.json
+++ b/services/@python/service.json
@@ -6,7 +6,9 @@
   "role": "provider",
   "enabled": false,
   "executable": "python",
-  "args": ["--version"],
+  "args": [
+    "--version"
+  ],
   "env": {
     "PYTHONUTF8": "1"
   },
@@ -15,13 +17,6 @@
     "PYTHON_HOME": "${SERVICE_ARTIFACT_ROOT}",
     "PYTHONPATH": "${SERVICE_ARTIFACT_ROOT}"
   },
-  "urls": [
-    {
-      "label": "docs",
-      "url": "https://docs.python.org/3/",
-      "kind": "external"
-    }
-  ],
   "artifact": {
     "kind": "archive",
     "source": {
@@ -34,8 +29,20 @@
         "assetName": "lasso-python-3.11.5-win32.zip",
         "archiveType": "zip",
         "command": ".\\python.exe",
-        "args": ["--version"]
+        "args": [
+          "--version"
+        ]
       }
     }
-  }
+  },
+  "endpoints": [
+    {
+      "id": "docs",
+      "kind": "url",
+      "label": "Docs",
+      "url": "https://docs.python.org/3/",
+      "exposure": "public",
+      "required": false
+    }
+  ]
 }

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -4,16 +4,8 @@
   "description": "Core operator/admin UI service backed by the canonical lasso-serviceadmin release artifact.",
   "version": "0.1.0",
   "enabled": true,
-  "depend_on": ["@node"],
-  "ports": {
-    "ui": 17700
-  },
-  "urls": [
-    {
-      "label": "ui",
-      "url": "http://127.0.0.1:${UI_PORT}/",
-      "kind": "local"
-    }
+  "depend_on": [
+    "@node"
   ],
   "artifact": {
     "kind": "archive",
@@ -27,19 +19,25 @@
         "assetName": "@serviceadmin-win32.zip",
         "archiveType": "zip",
         "command": "node",
-        "args": ["runtime/server.js"]
+        "args": [
+          "runtime/server.js"
+        ]
       },
       "linux": {
         "assetName": "@serviceadmin-linux.tar.gz",
         "archiveType": "tar.gz",
         "command": "node",
-        "args": ["runtime/server.js"]
+        "args": [
+          "runtime/server.js"
+        ]
       },
       "darwin": {
         "assetName": "@serviceadmin-darwin.tar.gz",
         "archiveType": "tar.gz",
         "command": "node",
-        "args": ["runtime/server.js"]
+        "args": [
+          "runtime/server.js"
+        ]
       }
     }
   },
@@ -47,6 +45,34 @@
     {
       "id": "serviceadmin-process-health",
       "type": "process"
+    }
+  ],
+  "endpoints": [
+    {
+      "id": "ui",
+      "kind": "network",
+      "label": "Service Admin UI",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 17700,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "ui_url",
+      "kind": "url",
+      "label": "UI",
+      "target": "ui",
+      "url": "http://${endpoint.ui.bind}:${endpoint.ui.port}/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
     }
   ]
 }

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -8,105 +8,78 @@
     "@localcert",
     "@nginx"
   ],
-  "ports": {
-    "web": 19080,
-    "websecure": 19443,
-    "admin": 19081,
-    "https_traefik": 19082,
-    "https_nginx": 19090,
-    "https_cms": 19100,
-    "https_flow": 19110,
-    "https_flowtms": 19120,
-    "https_api": 19130,
-    "https_files": 19140,
-    "https_bpmn": 19150,
-    "mongo": 19160,
-    "typedb": 19170
-  },
-  "portmapping": {
-    "HTTP": "${WEB_PORT}",
-    "HTTPS": "${WEBSECURE_PORT}",
-    "HTTPS_TRAEFIK": "${HTTPS_TRAEFIK_PORT}",
-    "HTTPS_NGINX": "${HTTPS_NGINX_PORT}",
-    "HTTPS_CMS": "${HTTPS_CMS_PORT}",
-    "HTTPS_FLOW": "${HTTPS_FLOW_PORT}",
-    "HTTPS_FLOWTMS": "${HTTPS_FLOWTMS_PORT}",
-    "HTTPS_API": "${HTTPS_API_PORT}",
-    "HTTPS_FILES": "${HTTPS_FILES_PORT}",
-    "HTTPS_BPMN": "${HTTPS_BPMN_PORT}",
-    "TCP_MOGNO": "${MONGO_PORT}",
-    "TCP_TYPEDB": "${TYPEDB_PORT}"
-  },
   "commandline": {
-    "win32": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
-    "darwin": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
-    "linux": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
-    "default": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true"
+    "win32": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${endpoint.web.port}\" --entryPoints.websecure.address=\":${endpoint.websecure.port}\" --entryPoints.traefik.address=\":${endpoint.admin.port}\" --entryPoints.httpsTraefik.address=\":${endpoint.https_traefik.port}\" --entryPoints.httpsNginx.address=\":${endpoint.https_nginx.port}\" --entryPoints.httpsCms.address=\":${endpoint.https_cms.port}\" --entryPoints.httpsFlow.address=\":${endpoint.https_flow.port}\" --entryPoints.httpsFlowtms.address=\":${endpoint.https_flowtms.port}\" --entryPoints.httpsApi.address=\":${endpoint.https_api.port}\" --entryPoints.httpsFiles.address=\":${endpoint.https_files.port}\" --entryPoints.httpsBpmn.address=\":${endpoint.https_bpmn.port}\" --entryPoints.mongo.address=\":${endpoint.mongo.port}\" --entryPoints.typedb.address=\":${endpoint.typedb.port}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "darwin": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${endpoint.web.port}\" --entryPoints.websecure.address=\":${endpoint.websecure.port}\" --entryPoints.traefik.address=\":${endpoint.admin.port}\" --entryPoints.httpsTraefik.address=\":${endpoint.https_traefik.port}\" --entryPoints.httpsNginx.address=\":${endpoint.https_nginx.port}\" --entryPoints.httpsCms.address=\":${endpoint.https_cms.port}\" --entryPoints.httpsFlow.address=\":${endpoint.https_flow.port}\" --entryPoints.httpsFlowtms.address=\":${endpoint.https_flowtms.port}\" --entryPoints.httpsApi.address=\":${endpoint.https_api.port}\" --entryPoints.httpsFiles.address=\":${endpoint.https_files.port}\" --entryPoints.httpsBpmn.address=\":${endpoint.https_bpmn.port}\" --entryPoints.mongo.address=\":${endpoint.mongo.port}\" --entryPoints.typedb.address=\":${endpoint.typedb.port}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "linux": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${endpoint.web.port}\" --entryPoints.websecure.address=\":${endpoint.websecure.port}\" --entryPoints.traefik.address=\":${endpoint.admin.port}\" --entryPoints.httpsTraefik.address=\":${endpoint.https_traefik.port}\" --entryPoints.httpsNginx.address=\":${endpoint.https_nginx.port}\" --entryPoints.httpsCms.address=\":${endpoint.https_cms.port}\" --entryPoints.httpsFlow.address=\":${endpoint.https_flow.port}\" --entryPoints.httpsFlowtms.address=\":${endpoint.https_flowtms.port}\" --entryPoints.httpsApi.address=\":${endpoint.https_api.port}\" --entryPoints.httpsFiles.address=\":${endpoint.https_files.port}\" --entryPoints.httpsBpmn.address=\":${endpoint.https_bpmn.port}\" --entryPoints.mongo.address=\":${endpoint.mongo.port}\" --entryPoints.typedb.address=\":${endpoint.typedb.port}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "default": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${endpoint.web.port}\" --entryPoints.websecure.address=\":${endpoint.websecure.port}\" --entryPoints.traefik.address=\":${endpoint.admin.port}\" --entryPoints.httpsTraefik.address=\":${endpoint.https_traefik.port}\" --entryPoints.httpsNginx.address=\":${endpoint.https_nginx.port}\" --entryPoints.httpsCms.address=\":${endpoint.https_cms.port}\" --entryPoints.httpsFlow.address=\":${endpoint.https_flow.port}\" --entryPoints.httpsFlowtms.address=\":${endpoint.https_flowtms.port}\" --entryPoints.httpsApi.address=\":${endpoint.https_api.port}\" --entryPoints.httpsFiles.address=\":${endpoint.https_files.port}\" --entryPoints.httpsBpmn.address=\":${endpoint.https_bpmn.port}\" --entryPoints.mongo.address=\":${endpoint.mongo.port}\" --entryPoints.typedb.address=\":${endpoint.typedb.port}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true"
   },
   "env": {
-    "TRAEFIK_HTTP_PORT": "${WEB_PORT}",
-    "TRAEFIK_HTTPS_PORT": "${WEBSECURE_PORT}",
-    "TRAEFIK_INTERNAL_PORT": "${ADMIN_PORT}",
-    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${HTTPS_TRAEFIK_PORT}",
-    "TRAEFIK_HTTPS_NGINX_PORT": "${HTTPS_NGINX_PORT}",
-    "TRAEFIK_HTTPS_CMS_PORT": "${HTTPS_CMS_PORT}",
-    "TRAEFIK_HTTPS_FLOW_PORT": "${HTTPS_FLOW_PORT}",
-    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${HTTPS_FLOWTMS_PORT}",
-    "TRAEFIK_HTTPS_API_PORT": "${HTTPS_API_PORT}",
-    "TRAEFIK_HTTPS_FILES_PORT": "${HTTPS_FILES_PORT}",
-    "TRAEFIK_HTTPS_BPMN_PORT": "${HTTPS_BPMN_PORT}",
-    "TRAEFIK_MONGO_PORT": "${MONGO_PORT}",
-    "TRAEFIK_TYPEDB_PORT": "${TYPEDB_PORT}",
-    "TRAEFIK_WEB_URL": "http://127.0.0.1:${WEB_PORT}/",
-    "TRAEFIK_WEBSECURE_URL": "https://127.0.0.1:${WEBSECURE_PORT}/",
-    "TRAEFIK_DASHBOARD_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
-    "TRAEFIK_PING_URL": "http://127.0.0.1:${ADMIN_PORT}/ping"
+    "HTTP": "${endpoint.web.port}",
+    "HTTPS": "${endpoint.websecure.port}",
+    "HTTPS_TRAEFIK": "${endpoint.https_traefik.port}",
+    "HTTPS_NGINX": "${endpoint.https_nginx.port}",
+    "HTTPS_CMS": "${endpoint.https_cms.port}",
+    "HTTPS_FLOW": "${endpoint.https_flow.port}",
+    "HTTPS_FLOWTMS": "${endpoint.https_flowtms.port}",
+    "HTTPS_API": "${endpoint.https_api.port}",
+    "HTTPS_FILES": "${endpoint.https_files.port}",
+    "HTTPS_BPMN": "${endpoint.https_bpmn.port}",
+    "TCP_MOGNO": "${endpoint.mongo.port}",
+    "TCP_TYPEDB": "${endpoint.typedb.port}",
+    "TRAEFIK_HTTP_PORT": "${endpoint.web.port}",
+    "TRAEFIK_HTTPS_PORT": "${endpoint.websecure.port}",
+    "TRAEFIK_INTERNAL_PORT": "${endpoint.admin.port}",
+    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${endpoint.https_traefik.port}",
+    "TRAEFIK_HTTPS_NGINX_PORT": "${endpoint.https_nginx.port}",
+    "TRAEFIK_HTTPS_CMS_PORT": "${endpoint.https_cms.port}",
+    "TRAEFIK_HTTPS_FLOW_PORT": "${endpoint.https_flow.port}",
+    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${endpoint.https_flowtms.port}",
+    "TRAEFIK_HTTPS_API_PORT": "${endpoint.https_api.port}",
+    "TRAEFIK_HTTPS_FILES_PORT": "${endpoint.https_files.port}",
+    "TRAEFIK_HTTPS_BPMN_PORT": "${endpoint.https_bpmn.port}",
+    "TRAEFIK_MONGO_PORT": "${endpoint.mongo.port}",
+    "TRAEFIK_TYPEDB_PORT": "${endpoint.typedb.port}",
+    "TRAEFIK_WEB_URL": "${endpoint.web_url.url}",
+    "TRAEFIK_WEBSECURE_URL": "${endpoint.websecure_url.url}",
+    "TRAEFIK_DASHBOARD_URL": "${endpoint.dashboard.url}",
+    "TRAEFIK_PING_URL": "${endpoint.ping.url}"
   },
   "globalenv": {
-    "TRAEFIK_HTTP_PORT": "${WEB_PORT}",
-    "TRAEFIK_HTTPS_PORT": "${WEBSECURE_PORT}",
-    "TRAEFIK_INTERNAL_PORT": "${ADMIN_PORT}",
-    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${HTTPS_TRAEFIK_PORT}",
-    "TRAEFIK_HTTPS_NGINX_PORT": "${HTTPS_NGINX_PORT}",
-    "TRAEFIK_HTTPS_CMS_PORT": "${HTTPS_CMS_PORT}",
-    "TRAEFIK_HTTPS_FLOW_PORT": "${HTTPS_FLOW_PORT}",
-    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${HTTPS_FLOWTMS_PORT}",
-    "TRAEFIK_HTTPS_API_PORT": "${HTTPS_API_PORT}",
-    "TRAEFIK_HTTPS_FILES_PORT": "${HTTPS_FILES_PORT}",
-    "TRAEFIK_HTTPS_BPMN_PORT": "${HTTPS_BPMN_PORT}",
-    "TRAEFIK_MONGO_PORT": "${MONGO_PORT}",
-    "TRAEFIK_TYPEDB_PORT": "${TYPEDB_PORT}",
-    "TRAEFIK_WEB_URL": "http://127.0.0.1:${WEB_PORT}/",
-    "TRAEFIK_WEBSECURE_URL": "https://127.0.0.1:${WEBSECURE_PORT}/",
-    "TRAEFIK_DASHBOARD_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
-    "TRAEFIK_PING_URL": "http://127.0.0.1:${ADMIN_PORT}/ping",
-    "TRAEFIK_TRAEFIK_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+    "HTTP": "${endpoint.web.port}",
+    "HTTPS": "${endpoint.websecure.port}",
+    "HTTPS_TRAEFIK": "${endpoint.https_traefik.port}",
+    "HTTPS_NGINX": "${endpoint.https_nginx.port}",
+    "HTTPS_CMS": "${endpoint.https_cms.port}",
+    "HTTPS_FLOW": "${endpoint.https_flow.port}",
+    "HTTPS_FLOWTMS": "${endpoint.https_flowtms.port}",
+    "HTTPS_API": "${endpoint.https_api.port}",
+    "HTTPS_FILES": "${endpoint.https_files.port}",
+    "HTTPS_BPMN": "${endpoint.https_bpmn.port}",
+    "TCP_MOGNO": "${endpoint.mongo.port}",
+    "TCP_TYPEDB": "${endpoint.typedb.port}",
+    "TRAEFIK_HTTP_PORT": "${endpoint.web.port}",
+    "TRAEFIK_HTTPS_PORT": "${endpoint.websecure.port}",
+    "TRAEFIK_INTERNAL_PORT": "${endpoint.admin.port}",
+    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${endpoint.https_traefik.port}",
+    "TRAEFIK_HTTPS_NGINX_PORT": "${endpoint.https_nginx.port}",
+    "TRAEFIK_HTTPS_CMS_PORT": "${endpoint.https_cms.port}",
+    "TRAEFIK_HTTPS_FLOW_PORT": "${endpoint.https_flow.port}",
+    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${endpoint.https_flowtms.port}",
+    "TRAEFIK_HTTPS_API_PORT": "${endpoint.https_api.port}",
+    "TRAEFIK_HTTPS_FILES_PORT": "${endpoint.https_files.port}",
+    "TRAEFIK_HTTPS_BPMN_PORT": "${endpoint.https_bpmn.port}",
+    "TRAEFIK_MONGO_PORT": "${endpoint.mongo.port}",
+    "TRAEFIK_TYPEDB_PORT": "${endpoint.typedb.port}",
+    "TRAEFIK_WEB_URL": "${endpoint.web_url.url}",
+    "TRAEFIK_WEBSECURE_URL": "${endpoint.websecure_url.url}",
+    "TRAEFIK_DASHBOARD_URL": "${endpoint.dashboard.url}",
+    "TRAEFIK_PING_URL": "${endpoint.ping.url}",
+    "TRAEFIK_TRAEFIK_URL": "${endpoint.dashboard.url}",
     "TRAEFIK_HOST_DOMAIN": "localhost",
     "TRAEFIK_HOST_DOMAIN_URL": "localhost",
     "TRAEFIK_HOST_DOMAIN_SUFFIX": "localhost"
   },
-  "urls": [
-    {
-      "label": "dashboard",
-      "url": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
-      "kind": "local"
-    },
-    {
-      "label": "ping",
-      "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
-      "kind": "local"
-    },
-    {
-      "label": "web",
-      "url": "http://127.0.0.1:${WEB_PORT}/",
-      "kind": "local"
-    },
-    {
-      "label": "websecure",
-      "url": "https://127.0.0.1:${WEBSECURE_PORT}/",
-      "kind": "local"
-    }
-  ],
   "artifact": {
     "kind": "archive",
     "source": {
@@ -119,19 +92,25 @@
         "assetName": "lasso-traefik-win32.zip",
         "archiveType": "zip",
         "command": ".\\traefik.exe",
-        "args": ["--configFile=runtime/traefik.yml"]
+        "args": [
+          "--configFile=runtime/traefik.yml"
+        ]
       },
       "linux": {
         "assetName": "lasso-traefik-linux.tar.gz",
         "archiveType": "tar.gz",
         "command": "./traefik",
-        "args": ["--configFile=runtime/traefik.yml"]
+        "args": [
+          "--configFile=runtime/traefik.yml"
+        ]
       },
       "darwin": {
         "assetName": "lasso-traefik-darwin.tar.gz",
         "archiveType": "tar.gz",
         "command": "./traefik",
-        "args": ["--configFile=runtime/traefik.yml"]
+        "args": [
+          "--configFile=runtime/traefik.yml"
+        ]
       }
     }
   },
@@ -147,7 +126,7 @@
     "files": [
       {
         "path": "./runtime/traefik.yml",
-        "content": "entryPoints:\n  web:\n    address: \"127.0.0.1:${WEB_PORT}\"\n  websecure:\n    address: \"127.0.0.1:${WEBSECURE_PORT}\"\n  traefik:\n    address: \"127.0.0.1:${ADMIN_PORT}\"\n  httpsTraefik:\n    address: \"127.0.0.1:${HTTPS_TRAEFIK_PORT}\"\n  httpsNginx:\n    address: \"127.0.0.1:${HTTPS_NGINX_PORT}\"\n  httpsCms:\n    address: \"127.0.0.1:${HTTPS_CMS_PORT}\"\n  httpsFlow:\n    address: \"127.0.0.1:${HTTPS_FLOW_PORT}\"\n  httpsFlowtms:\n    address: \"127.0.0.1:${HTTPS_FLOWTMS_PORT}\"\n  httpsApi:\n    address: \"127.0.0.1:${HTTPS_API_PORT}\"\n  httpsFiles:\n    address: \"127.0.0.1:${HTTPS_FILES_PORT}\"\n  httpsBpmn:\n    address: \"127.0.0.1:${HTTPS_BPMN_PORT}\"\n  mongo:\n    address: \"127.0.0.1:${MONGO_PORT}\"\n  typedb:\n    address: \"127.0.0.1:${TYPEDB_PORT}\"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: \"./runtime/dynamic.yml\"\n    watch: true\nlog:\n  level: INFO\n"
+        "content": "entryPoints:\n  web:\n    address: \"${endpoint.web.bind}:${endpoint.web.port}\"\n  websecure:\n    address: \"${endpoint.websecure.bind}:${endpoint.websecure.port}\"\n  traefik:\n    address: \"${endpoint.admin.bind}:${endpoint.admin.port}\"\n  httpsTraefik:\n    address: \"${endpoint.https_traefik.bind}:${endpoint.https_traefik.port}\"\n  httpsNginx:\n    address: \"${endpoint.https_nginx.bind}:${endpoint.https_nginx.port}\"\n  httpsCms:\n    address: \"${endpoint.https_cms.bind}:${endpoint.https_cms.port}\"\n  httpsFlow:\n    address: \"${endpoint.https_flow.bind}:${endpoint.https_flow.port}\"\n  httpsFlowtms:\n    address: \"${endpoint.https_flowtms.bind}:${endpoint.https_flowtms.port}\"\n  httpsApi:\n    address: \"${endpoint.https_api.bind}:${endpoint.https_api.port}\"\n  httpsFiles:\n    address: \"${endpoint.https_files.bind}:${endpoint.https_files.port}\"\n  httpsBpmn:\n    address: \"${endpoint.https_bpmn.bind}:${endpoint.https_bpmn.port}\"\n  mongo:\n    address: \"${endpoint.mongo.bind}:${endpoint.mongo.port}\"\n  typedb:\n    address: \"${endpoint.typedb.bind}:${endpoint.typedb.port}\"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: \"./runtime/dynamic.yml\"\n    watch: true\nlog:\n  level: INFO\n"
       }
     ]
   },
@@ -155,10 +134,247 @@
     {
       "id": "traefik-ping-health",
       "type": "http",
-      "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
+      "url": "${endpoint.ping.url}",
       "expected_status": 200,
       "retries": 80,
       "interval": 250
+    }
+  ],
+  "endpoints": [
+    {
+      "id": "web",
+      "kind": "network",
+      "label": "Web HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19080,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "websecure",
+      "kind": "network",
+      "label": "Web HTTPS",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19443,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "admin",
+      "kind": "network",
+      "label": "Traefik admin API",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19081,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "https_traefik",
+      "kind": "network",
+      "label": "Traefik HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19082,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_nginx",
+      "kind": "network",
+      "label": "Nginx HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19090,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_cms",
+      "kind": "network",
+      "label": "CMS HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19100,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_flow",
+      "kind": "network",
+      "label": "Flow HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19110,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_flowtms",
+      "kind": "network",
+      "label": "FlowTMS HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19120,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_api",
+      "kind": "network",
+      "label": "API HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19130,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_files",
+      "kind": "network",
+      "label": "Files HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19140,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "https_bpmn",
+      "kind": "network",
+      "label": "BPMN HTTPS route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "https",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19150,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "mongo",
+      "kind": "network",
+      "label": "Mongo TCP route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "tcp",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19160,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "typedb",
+      "kind": "network",
+      "label": "TypeDB TCP route",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "tcp",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 19170,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "dashboard",
+      "kind": "url",
+      "label": "Traefik dashboard",
+      "target": "admin",
+      "url": "http://${endpoint.admin.bind}:${endpoint.admin.port}/dashboard/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "ping",
+      "kind": "url",
+      "label": "Traefik ping",
+      "target": "admin",
+      "url": "http://${endpoint.admin.bind}:${endpoint.admin.port}/ping",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "web_url",
+      "kind": "url",
+      "label": "Web",
+      "target": "web",
+      "url": "http://${endpoint.web.bind}:${endpoint.web.port}/",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "websecure_url",
+      "kind": "url",
+      "label": "Websecure",
+      "target": "websecure",
+      "url": "https://${endpoint.websecure.bind}:${endpoint.websecure.port}/",
+      "exposure": "local",
+      "required": true
     }
   ]
 }

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -5,10 +5,12 @@
   "version": "0.3.0",
   "enabled": true,
   "executable": "node",
-  "args": ["runtime/fixture-harness.mjs"],
+  "args": [
+    "runtime/fixture-harness.mjs"
+  ],
   "env": {
     "ECHO_MESSAGE": "hello from echo-service harness",
-    "ECHO_PORT": "${SERVICE_PORT}",
+    "ECHO_PORT": "${endpoint.service.port}",
     "ECHO_LOG_PATH": "./runtime/echo.log",
     "ECHO_STATE_PATH": "./runtime/state.json",
     "ECHO_DB_PATH": "./runtime/echo.sqlite"
@@ -50,29 +52,51 @@
     "files": [
       {
         "path": "./runtime/config.json",
-        "content": "{\n  \"serviceId\": \"${SERVICE_ID}\",\n  \"port\": \"${SERVICE_PORT}\",\n  \"logPath\": \"${ECHO_LOG_PATH}\",\n  \"statePath\": \"${ECHO_STATE_PATH}\",\n  \"dbPath\": \"${ECHO_DB_PATH}\"\n}\n"
+        "content": "{\n  \"serviceId\": \"${SERVICE_ID}\",\n  \"port\": \"${endpoint.service.port}\",\n  \"logPath\": \"${ECHO_LOG_PATH}\",\n  \"statePath\": \"${ECHO_STATE_PATH}\",\n  \"dbPath\": \"${ECHO_DB_PATH}\"\n}\n"
       }
     ]
   },
-  "ports": {
-    "service": 4010
-  },
-  "urls": [
-    {
-      "label": "ui",
-      "url": "http://127.0.0.1:${SERVICE_PORT}/",
-      "kind": "local"
-    },
-    {
-      "label": "service",
-      "url": "http://127.0.0.1:${SERVICE_PORT}/health",
-      "kind": "local"
-    }
-  ],
   "healthchecks": [
     {
       "id": "echo-process-health",
       "type": "process"
+    }
+  ],
+  "endpoints": [
+    {
+      "id": "service",
+      "kind": "network",
+      "label": "Service HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4010,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "ui",
+      "kind": "url",
+      "label": "UI",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "health",
+      "kind": "url",
+      "label": "Health",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/health",
+      "exposure": "local",
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
## Issue
Closes #125

## Summary
- Migrates the root @secretsbroker manifest and checked-in service inventory from legacy top-level `ports`/`urls`/`portmapping` authoring to canonical `endpoints[]`.
- Rewrites env/globalenv, healthcheck, commandline, and generated-config selectors to use `${endpoint.<id>.<field>}` while preserving compatibility aliases outside endpoint entries.
- Updates the local service.json reference and adds a Windows test guard that fails if top-level legacy manifest fields return.

## Scope
- In scope: `service.json`, `services/*/service.json`, local manifest reference docs, and package test validation.
- Out of scope: runtime endpoint negotiation semantics owned by Service Lasso core and release tag upgrades for third-party service artifacts.

## Spec / contract / fixture impact
- Updated: package manifests now author concrete service interfaces/resources through `endpoints[]`.
- Updated: docs describe endpoint selector authoring and legacy compatibility placement.
- Updated: `scripts/test.ps1` checks manifest JSON and rejects top-level `ports`, `urls`, and `portmapping`.

## Service Lasso invariant impact
- Invariant: endpoint metadata and package verification must remain metadata-only and must not expose raw secret/config material.
- Preservation proof: changes only move safe port/url metadata and selectors; secret-bearing broker docs/code paths are unchanged.

## Validation
- PASS `git diff --check`.
- PASS JSON endpoint/legacy-field inspection for 9 manifests.
- PASS `pwsh -NoLogo -NoProfile -File scripts\test.ps1` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-20260811T163701+1000\issue-125-final-scripts-test.stdout.log`.
- PASS `pwsh -NoLogo -NoProfile -File scripts\package.ps1` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-20260811T163701+1000\issue-125-final-scripts-package.stdout.log`.
- PASS `SERVICE_LASSO_HARNESS_BIN=... pwsh -NoLogo -NoProfile -File scripts\verify.ps1` - evidence `C:\projects\service-lasso\.work-agent\logs\cron-20260811T163701+1000\issue-125-final-scripts-verify.stdout.log`.
- PASS startup canonical demo gate before selection - evidence `C:\projects\service-lasso\.work-agent\logs\cron-20260811T163701+1000\demo-gate.stdout.json`.

## Approval trail
- Required: no explicit approval gate found in the issue. Review requested for manifest contract migration before merge if branch policy requires it.

## Cleanup
- Branch `fix/125-canonical-endpoints` targets `develop`.
- Post-merge cleanup: close #125, return local checkout to clean `develop`, and keep generated package/verify outputs out of tracked status.