### PR TITLE
feat(providers): add durable verified migration executor seam

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -56,21 +56,25 @@ type localBackend struct {
 	seenLaunchLeaseJTI       map[string]time.Time
 	decommissionMu           sync.Mutex
 	rotationMu               sync.Mutex
+	providerMigrationMu      sync.Mutex
+	providerExecutorMu       sync.RWMutex
+	providerExecutors        map[string]providerMigrationExecutor
 }
 
 type localStoreFile struct {
-	Version      int                             `json:"version"`
-	ServiceID    string                          `json:"serviceId"`
-	VaultID      string                          `json:"vaultId,omitempty"`
-	KeyID        string                          `json:"keyId,omitempty"`
-	KeyVersion   string                          `json:"keyVersion,omitempty"`
-	RootIdentity *vaultRootIdentityMetadata      `json:"rootIdentity,omitempty"`
-	CreatedAt    time.Time                       `json:"createdAt"`
-	UpdatedAt    time.Time                       `json:"updatedAt"`
-	Secrets      map[string]secretEntry          `json:"secrets"`
-	Tombstones   map[string]localSecretTombstone `json:"tombstones,omitempty"`
-	Rotations    map[string]rotationLedger       `json:"rotations,omitempty"`
-	Recovery     *recoveryPolicyMetadata         `json:"recoveryPolicy,omitempty"`
+	Version      int                                   `json:"version"`
+	ServiceID    string                                `json:"serviceId"`
+	VaultID      string                                `json:"vaultId,omitempty"`
+	KeyID        string                                `json:"keyId,omitempty"`
+	KeyVersion   string                                `json:"keyVersion,omitempty"`
+	RootIdentity *vaultRootIdentityMetadata            `json:"rootIdentity,omitempty"`
+	CreatedAt    time.Time                             `json:"createdAt"`
+	UpdatedAt    time.Time                             `json:"updatedAt"`
+	Secrets      map[string]secretEntry                `json:"secrets"`
+	Tombstones   map[string]localSecretTombstone       `json:"tombstones,omitempty"`
+	Rotations    map[string]rotationLedger             `json:"rotations,omitempty"`
+	Migrations   map[string]providerMigrationOperation `json:"migrations,omitempty"`
+	Recovery     *recoveryPolicyMetadata               `json:"recoveryPolicy,omitempty"`
 }
 
 type secretEntry struct {
@@ -235,7 +239,7 @@ type auditEvent struct {
 }
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
-	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, telemetry: newTelemetryRequestRecorder(50), seenLaunchLeaseJTI: map[string]time.Time{}}
+	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, telemetry: newTelemetryRequestRecorder(50), seenLaunchLeaseJTI: map[string]time.Time{}, providerExecutors: map[string]providerMigrationExecutor{}}
 	backend.lockouts = newLockoutStore(func() time.Time {
 		if backend.now == nil {
 			return time.Now().UTC()
@@ -874,7 +878,7 @@ func (b *localBackend) resolve(req resolveRequest) resolveResponse {
 
 func (b *localBackend) loadStore() (localStoreFile, error) {
 	now := b.now()
-	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}, Tombstones: map[string]localSecretTombstone{}, Rotations: map[string]rotationLedger{}}
+	store := localStoreFile{Version: localStoreVersion, ServiceID: serviceID, CreatedAt: now, UpdatedAt: now, Secrets: map[string]secretEntry{}, Tombstones: map[string]localSecretTombstone{}, Rotations: map[string]rotationLedger{}, Migrations: map[string]providerMigrationOperation{}}
 	bytes, err := os.ReadFile(b.storePath)
 	if errors.Is(err, os.ErrNotExist) {
 		return store, nil
@@ -896,6 +900,9 @@ func (b *localBackend) loadStore() (localStoreFile, error) {
 	}
 	if store.Rotations == nil {
 		store.Rotations = map[string]rotationLedger{}
+	}
+	if store.Migrations == nil {
+		store.Migrations = map[string]providerMigrationOperation{}
 	}
 	return store, nil
 }

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -46,6 +46,8 @@ var typedOutcomes = []string{
 	"applied",
 	"rolled_back",
 	"retired",
+	"rate_limited",
+	"verification_failed",
 	"identity_invalid",
 	"identity_expired",
 	"identity_replayed",

--- a/cmd/secretsbroker/operation_manifest.go
+++ b/cmd/secretsbroker/operation_manifest.go
@@ -146,7 +146,7 @@ func defaultOperationManifest() []OperationCapability {
 		manifestOperation(http.MethodPost, "/v1/providers/config/validate", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "configuration_validation_only"),
 		manifestOperation(http.MethodPost, "/v1/providers/config/apply", OperationMaturityPlanned, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "configuration_not_persisted"),
 		manifestOperation(http.MethodPost, "/v1/providers/migration/dry-run", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "local_target_only"),
-		manifestOperation(http.MethodPost, "/v1/providers/migration/apply", OperationMaturityPlanned, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "migration_items_not_copied"),
+		manifestOperation(http.MethodPost, "/v1/providers/migration/apply", OperationMaturityPlanned, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "registered_provider_executor_required"),
 		manifestOperation(http.MethodGet, "/v1/management/secrets", OperationMaturityReadOnly, OperationClassificationRead, true, false, false, OperationScopeMixed, providers, "metadata_only"),
 		manifestOperation(http.MethodGet, "/v1/management/secrets/value-search", OperationMaturityValidated, OperationClassificationRead, true, true, true, OperationScopeMixed, localAndAWS, "values_never_returned"),
 		manifestOperation(http.MethodPost, "/v1/management/secrets/reveal", OperationMaturityValidated, OperationClassificationRead, true, true, true, OperationScopeMixed, providers, "single_ref_ttl_bounded"),
@@ -326,7 +326,7 @@ func providerOperationLimitation(kind, path string, maturity OperationMaturity) 
 		return "provider_operation_not_implemented"
 	case OperationMaturityPlanned:
 		if path == "/v1/providers/migration/apply" {
-			return "migration_items_not_copied"
+			return "registered_provider_executor_required"
 		}
 		if path == "/v1/management/secrets/policy/apply" {
 			return "policy_binding_not_persisted"

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -106,6 +106,8 @@ type migrationItemStatus struct {
 	PolicyResult     string `json:"policyResult"`
 	AuditRequirement string `json:"auditRequirement"`
 	Recovery         string `json:"recovery"`
+	Verified         bool   `json:"verified"`
+	Attempts         int    `json:"attempts,omitempty"`
 }
 
 type migrationPlanResponse struct {
@@ -361,10 +363,33 @@ func (b *localBackend) buildMigrationPlan(req migrationPlanRequest, operation st
 		req.Refs = refs
 	}
 	if apply {
-		res.Outcome = "unsupported"
-		res.NextAction = "implement_provider_operation_executor"
-		res.Results = b.migrationItems(req, target, apply, res.Outcome)
-		return res, errUnsupportedProvider
+		conflict, conflictErr := b.providerMigrationPlanConflicts(req)
+		if conflictErr != nil {
+			res.Outcome = "degraded"
+			res.NextAction = "retry_or_inspect_source"
+			return res, errBackendDegraded
+		}
+		if conflict {
+			res.Outcome = "conflict"
+			res.NextAction = "create_new_operation_id_for_changed_plan"
+			res.Results = b.migrationItems(req, target, apply, res.Outcome)
+			return res, errMigrationPlanConflict
+		}
+		executor, ok := b.providerMigrationExecutor(req.TargetProviderID)
+		if !ok {
+			res.Outcome = "unsupported"
+			res.NextAction = "implement_provider_operation_executor"
+			res.Results = b.migrationItems(req, target, apply, res.Outcome)
+			return res, errUnsupportedProvider
+		}
+		if strings.TrimSpace(b.auditPath) == "" || b.audit("provider_migration_apply_authorized", req.TargetProviderID, "ready", req.ServiceID, req.RequestID) != nil {
+			res.Outcome = "audit_unavailable"
+			res.AuditStatus = "audit_unavailable"
+			res.NextAction = "restore_audit_and_retry"
+			res.Results = b.migrationItems(req, target, apply, res.Outcome)
+			return res, errProviderAuditUnavailable
+		}
+		return b.executeProviderMigration(req, target, executor, res)
 	}
 	res.Results = b.migrationItems(req, target, apply, "")
 	res.Outcome = migrationAggregateOutcome(res.Results)
@@ -693,6 +718,8 @@ func writeMigrationActionError(w http.ResponseWriter, err error, res migrationPl
 		status = http.StatusBadRequest
 	case errors.Is(err, errPolicyDenied):
 		status = http.StatusForbidden
+	case errors.Is(err, errMigrationPlanConflict):
+		status = http.StatusConflict
 	case errors.Is(err, errUnsupportedProvider):
 		status = http.StatusNotImplemented
 	}

--- a/cmd/secretsbroker/provider_operation_executor.go
+++ b/cmd/secretsbroker/provider_operation_executor.go
@@ -1,0 +1,335 @@
+package main
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+var errMigrationPlanConflict = errors.New("migration operation plan conflict")
+
+// providerMigrationExecutor is an explicit, in-process seam. Registering an
+// executor is the only way a remote migration target becomes executable; the
+// provider family capability remains planned when no executor is registered.
+// Implementations return typed outcomes only and must not return provider
+// response bodies or credential material.
+type providerMigrationExecutor interface {
+	Write(providerMigrationWriteRequest) providerMigrationExecutorResult
+	Verify(providerMigrationVerifyRequest) providerMigrationExecutorResult
+}
+
+type providerMigrationWriteRequest struct {
+	OperationID      string
+	IdempotencyKey   string
+	TargetProviderID string
+	Ref              string
+	Value            string
+}
+
+type providerMigrationVerifyRequest struct {
+	OperationID      string
+	IdempotencyKey   string
+	TargetProviderID string
+	Ref              string
+	ExpectedValue    string
+}
+
+type providerMigrationExecutorResult struct {
+	Outcome string
+}
+
+type providerMigrationOperation struct {
+	OperationID      string                                    `json:"operationId"`
+	PlanFingerprint  string                                    `json:"planFingerprint"`
+	SourceProviderID string                                    `json:"sourceProviderId"`
+	TargetProviderID string                                    `json:"targetProviderId"`
+	Outcome          string                                    `json:"outcome"`
+	Items            map[string]providerMigrationOperationItem `json:"items"`
+	CreatedAt        time.Time                                 `json:"createdAt"`
+	UpdatedAt        time.Time                                 `json:"updatedAt"`
+}
+
+type providerMigrationOperationItem struct {
+	Ref                  string    `json:"ref"`
+	State                string    `json:"state"`
+	Outcome              string    `json:"outcome"`
+	WriteApplied         bool      `json:"writeApplied"`
+	Verified             bool      `json:"verified"`
+	Attempts             int       `json:"attempts"`
+	VerificationAttempts int       `json:"verificationAttempts"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+}
+
+func (b *localBackend) registerProviderMigrationExecutor(providerID string, executor providerMigrationExecutor) {
+	providerID = strings.TrimSpace(providerID)
+	if b == nil || providerID == "" || executor == nil {
+		return
+	}
+	b.providerExecutorMu.Lock()
+	defer b.providerExecutorMu.Unlock()
+	if b.providerExecutors == nil {
+		b.providerExecutors = map[string]providerMigrationExecutor{}
+	}
+	b.providerExecutors[providerID] = executor
+}
+
+func (b *localBackend) providerMigrationExecutor(providerID string) (providerMigrationExecutor, bool) {
+	if b == nil {
+		return nil, false
+	}
+	b.providerExecutorMu.RLock()
+	defer b.providerExecutorMu.RUnlock()
+	executor, ok := b.providerExecutors[strings.TrimSpace(providerID)]
+	return executor, ok && executor != nil
+}
+
+func (b *localBackend) providerMigrationPlanConflicts(req migrationPlanRequest) (bool, error) {
+	store, err := b.loadStore()
+	if err != nil {
+		return false, err
+	}
+	operation, exists := store.Migrations[strings.TrimSpace(req.OperationID)]
+	return exists && operation.PlanFingerprint != providerMigrationPlanFingerprint(req), nil
+}
+
+func (b *localBackend) executeProviderMigration(req migrationPlanRequest, target providerConfigStatus, executor providerMigrationExecutor, res migrationPlanResponse) (migrationPlanResponse, error) {
+	b.providerMigrationMu.Lock()
+	defer b.providerMigrationMu.Unlock()
+
+	refs := safeList(req.Refs)
+	sort.Strings(refs)
+	req.Refs = refs
+	res.Results = b.migrationItems(req, target, false, "")
+	fingerprint := providerMigrationPlanFingerprint(req)
+	operationID := strings.TrimSpace(req.OperationID)
+	now := b.now()
+
+	store, err := b.loadStore()
+	if err != nil {
+		return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+	}
+	operation, exists := store.Migrations[operationID]
+	if exists && operation.PlanFingerprint != fingerprint {
+		res.Outcome = "conflict"
+		res.NextAction = "create_new_operation_id_for_changed_plan"
+		res.Applied = false
+		for index := range res.Results {
+			res.Results[index].State = "failed"
+			res.Results[index].Outcome = "conflict"
+			res.Results[index].PolicyResult = "denied"
+		}
+		return res, errMigrationPlanConflict
+	}
+	if !exists {
+		operation = providerMigrationOperation{
+			OperationID:      operationID,
+			PlanFingerprint:  fingerprint,
+			SourceProviderID: firstNonEmpty(req.SourceProviderID, "local"),
+			TargetProviderID: strings.TrimSpace(req.TargetProviderID),
+			Outcome:          "in_progress",
+			Items:            map[string]providerMigrationOperationItem{},
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		store.Migrations[operationID] = operation
+		store.UpdatedAt = now
+		if err := b.saveStore(store); err != nil {
+			return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+		}
+	}
+	if operation.Items == nil {
+		operation.Items = map[string]providerMigrationOperationItem{}
+	}
+
+	for index := range res.Results {
+		status := &res.Results[index]
+		if status.Outcome != "dry_run_ready" {
+			continue
+		}
+		persisted := operation.Items[status.Ref]
+		if persisted.Verified {
+			applyPersistedMigrationStatus(status, persisted)
+			continue
+		}
+		value, sourceOutcome := b.localMigrationSourceValue(store, operation.SourceProviderID, status.Ref)
+		if sourceOutcome != "ready" {
+			persisted = failedMigrationOperationItem(persisted, status.Ref, sourceOutcome, now)
+			operation.Items[status.Ref] = persisted
+			applyPersistedMigrationStatus(status, persisted)
+			if err := b.persistProviderMigrationOperation(&store, &operation); err != nil {
+				return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+			}
+			continue
+		}
+
+		idempotencyKey := providerMigrationItemIdempotencyKey(operationID, operation.TargetProviderID, status.Ref)
+		if !persisted.WriteApplied {
+			writeResult := executor.Write(providerMigrationWriteRequest{OperationID: operationID, IdempotencyKey: idempotencyKey, TargetProviderID: operation.TargetProviderID, Ref: status.Ref, Value: value})
+			persisted.Ref = status.Ref
+			persisted.Attempts++
+			persisted.UpdatedAt = b.now()
+			if normalizeProviderExecutorWriteOutcome(writeResult.Outcome) != "applied" {
+				persisted.State = "failed"
+				persisted.Outcome = normalizeProviderExecutorWriteOutcome(writeResult.Outcome)
+				operation.Items[status.Ref] = persisted
+				applyPersistedMigrationStatus(status, persisted)
+				if err := b.persistProviderMigrationOperation(&store, &operation); err != nil {
+					return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+				}
+				continue
+			}
+			persisted.WriteApplied = true
+			persisted.State = "verifying"
+			persisted.Outcome = "verification_pending"
+			operation.Items[status.Ref] = persisted
+			if err := b.persistProviderMigrationOperation(&store, &operation); err != nil {
+				return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+			}
+		}
+
+		verifyResult := executor.Verify(providerMigrationVerifyRequest{OperationID: operationID, IdempotencyKey: idempotencyKey, TargetProviderID: operation.TargetProviderID, Ref: status.Ref, ExpectedValue: value})
+		persisted.VerificationAttempts++
+		persisted.UpdatedAt = b.now()
+		verifyOutcome := normalizeProviderExecutorVerifyOutcome(verifyResult.Outcome)
+		if verifyOutcome == "verified" {
+			persisted.Verified = true
+			persisted.State = "migrated"
+			persisted.Outcome = "migrated"
+		} else {
+			persisted.State = "failed"
+			persisted.Outcome = verifyOutcome
+		}
+		operation.Items[status.Ref] = persisted
+		applyPersistedMigrationStatus(status, persisted)
+		if err := b.persistProviderMigrationOperation(&store, &operation); err != nil {
+			return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+		}
+	}
+
+	res.Outcome = providerMigrationApplyOutcome(res.Results)
+	res.Applied = res.Outcome == "applied"
+	res.RequiresConfirmation = false
+	if !res.Applied {
+		res.NextAction = "retry_failed_refs_after_fix"
+	}
+	if operation.Outcome != res.Outcome {
+		operation.Outcome = res.Outcome
+		if err := b.persistProviderMigrationOperation(&store, &operation); err != nil {
+			return migrationExecutionFailure(res, "degraded", "retry_or_inspect_source"), errBackendDegraded
+		}
+	}
+	return res, nil
+}
+
+func (b *localBackend) persistProviderMigrationOperation(store *localStoreFile, operation *providerMigrationOperation) error {
+	operation.UpdatedAt = b.now()
+	store.Migrations[operation.OperationID] = *operation
+	store.UpdatedAt = operation.UpdatedAt
+	return b.saveStore(*store)
+}
+
+func (b *localBackend) localMigrationSourceValue(store localStoreFile, sourceProviderID, ref string) (string, string) {
+	sourceProviderID = firstNonEmpty(strings.TrimSpace(sourceProviderID), "local")
+	if sourceProviderID != "local" && sourceProviderID != "local-encrypted-store" {
+		return "", "unsupported"
+	}
+	entry, ok := store.Secrets[ref]
+	if !ok {
+		return "", "missing_ref"
+	}
+	value, err := b.decrypt(entry.Payload)
+	if err != nil {
+		return "", "degraded"
+	}
+	return value, "ready"
+}
+
+func providerMigrationPlanFingerprint(req migrationPlanRequest) string {
+	refs := safeList(req.Refs)
+	sort.Strings(refs)
+	return hashAuditRef(strings.Join([]string{firstNonEmpty(req.SourceProviderID, "local"), strings.TrimSpace(req.TargetProviderID), strings.Join(refs, "\n")}, "\n"))
+}
+
+func providerMigrationItemIdempotencyKey(operationID, targetProviderID, ref string) string {
+	return hashAuditRef(strings.Join([]string{strings.TrimSpace(operationID), strings.TrimSpace(targetProviderID), strings.TrimSpace(ref)}, "\n"))
+}
+
+func failedMigrationOperationItem(item providerMigrationOperationItem, ref, outcome string, now time.Time) providerMigrationOperationItem {
+	item.Ref = ref
+	item.State = "failed"
+	item.Outcome = outcome
+	item.UpdatedAt = now
+	return item
+}
+
+func applyPersistedMigrationStatus(status *migrationItemStatus, item providerMigrationOperationItem) {
+	status.State = item.State
+	status.Outcome = item.Outcome
+	status.Verified = item.Verified
+	status.Attempts = item.Attempts
+	if item.Verified {
+		status.ExpectedAction = "none"
+		status.Recovery = "source_retained_after_target_verification"
+	} else {
+		status.ExpectedAction = providerMigrationRetryAction(item.Outcome)
+	}
+}
+
+func providerMigrationRetryAction(outcome string) string {
+	switch outcome {
+	case "source_auth_required":
+		return "refresh_provider_auth_and_retry"
+	case "rate_limited":
+		return "retry_after_provider_backoff"
+	case "verification_failed", "verification_pending":
+		return "retry_target_verification"
+	case "source_unavailable", "degraded":
+		return "restore_provider_availability_and_retry"
+	case "unsupported":
+		return "implement_provider_operation_executor"
+	default:
+		return "review_failed_ref_and_retry"
+	}
+}
+
+func normalizeProviderExecutorWriteOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "applied":
+		return "applied"
+	case "source_auth_required", "rate_limited", "source_unavailable", "policy_denied", "degraded":
+		return strings.TrimSpace(outcome)
+	default:
+		return "degraded"
+	}
+}
+
+func normalizeProviderExecutorVerifyOutcome(outcome string) string {
+	switch strings.TrimSpace(outcome) {
+	case "verified":
+		return "verified"
+	case "source_auth_required", "rate_limited", "source_unavailable", "policy_denied", "degraded", "verification_failed":
+		return strings.TrimSpace(outcome)
+	default:
+		return "verification_failed"
+	}
+}
+
+func providerMigrationApplyOutcome(items []migrationItemStatus) string {
+	if len(items) == 0 {
+		return "applied"
+	}
+	for _, item := range items {
+		if item.Outcome != "migrated" || !item.Verified {
+			return "partial_failure"
+		}
+	}
+	return "applied"
+}
+
+func migrationExecutionFailure(res migrationPlanResponse, outcome, nextAction string) migrationPlanResponse {
+	res.Outcome = outcome
+	res.Applied = false
+	res.NextAction = nextAction
+	return res
+}

--- a/cmd/secretsbroker/provider_operation_executor_test.go
+++ b/cmd/secretsbroker/provider_operation_executor_test.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+const testProviderResponseBody = "provider-response-body-must-never-leak"
+
+type deterministicMigrationExecutor struct {
+	mu             sync.Mutex
+	values         map[string]string
+	writeCalls     map[string]int
+	verifyCalls    map[string]int
+	writeOutcomes  map[string]string
+	verifyOutcomes map[string]string
+}
+
+func newDeterministicMigrationExecutor() *deterministicMigrationExecutor {
+	return &deterministicMigrationExecutor{
+		values:         map[string]string{},
+		writeCalls:     map[string]int{},
+		verifyCalls:    map[string]int{},
+		writeOutcomes:  map[string]string{},
+		verifyOutcomes: map[string]string{},
+	}
+}
+
+func (e *deterministicMigrationExecutor) Write(req providerMigrationWriteRequest) providerMigrationExecutorResult {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.writeCalls[req.Ref]++
+	outcome := firstNonEmpty(e.writeOutcomes[req.Ref], "applied")
+	if outcome == "applied" {
+		e.values[req.Ref] = req.Value
+	}
+	return providerMigrationExecutorResult{Outcome: outcome}
+}
+
+func (e *deterministicMigrationExecutor) Verify(req providerMigrationVerifyRequest) providerMigrationExecutorResult {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.verifyCalls[req.Ref]++
+	if outcome := e.verifyOutcomes[req.Ref]; outcome != "" {
+		return providerMigrationExecutorResult{Outcome: outcome}
+	}
+	if e.values[req.Ref] != req.ExpectedValue {
+		return providerMigrationExecutorResult{Outcome: "verification_failed"}
+	}
+	return providerMigrationExecutorResult{Outcome: "verified"}
+}
+
+func TestProviderMigrationExecutorEndToEndIsVerifiedDurableAndIdempotent(t *testing.T) {
+	backend, executor, refs, values := executableMigrationTestBackend(t)
+	req := migrationPlanRequest{RequestID: "req-executor-success", ServiceID: "@serviceadmin", OperationID: "migration-executor-success", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: refs, Confirm: true, Reason: "approved deterministic migration"}
+
+	applied, err := backend.migrationApply(req)
+	if err != nil || !applied.Applied || applied.Outcome != "applied" || applied.AuditStatus != "audit_recorded" {
+		t.Fatalf("applied=%#v err=%v", applied, err)
+	}
+	for _, item := range applied.Results {
+		if item.Outcome != "migrated" || !item.Verified || item.Attempts != 1 {
+			t.Fatalf("item=%#v", item)
+		}
+		if executor.values[item.Ref] != values[item.Ref] || executor.writeCalls[item.Ref] != 1 || executor.verifyCalls[item.Ref] != 1 {
+			t.Fatalf("executor state ref=%s writes=%d verifies=%d", item.Ref, executor.writeCalls[item.Ref], executor.verifyCalls[item.Ref])
+		}
+	}
+	assertMigrationSourcesUnchanged(t, backend, values)
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), values[refs[0]], values[refs[1]], providerCredentialValue, testProviderResponseBody)
+
+	storeBeforeRetry := readRotationStore(t, backend)
+	retried, err := backend.migrationApply(req)
+	if err != nil || !retried.Applied || retried.Outcome != "applied" {
+		t.Fatalf("retried=%#v err=%v", retried, err)
+	}
+	if !bytes.Equal(storeBeforeRetry, readRotationStore(t, backend)) {
+		t.Fatal("exact verified retry rewrote durable operation state")
+	}
+	for _, ref := range refs {
+		if executor.writeCalls[ref] != 1 || executor.verifyCalls[ref] != 1 {
+			t.Fatalf("exact retry repeated executor calls for %s: writes=%d verifies=%d", ref, executor.writeCalls[ref], executor.verifyCalls[ref])
+		}
+	}
+}
+
+func TestProviderMigrationPartialFailureResumesAfterRestartWithoutRewritingVerifiedRefs(t *testing.T) {
+	backend, executor, refs, values := executableMigrationTestBackend(t)
+	executor.writeOutcomes[refs[1]] = "rate_limited"
+	req := migrationPlanRequest{RequestID: "req-executor-partial", ServiceID: "@serviceadmin", OperationID: "migration-executor-partial", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: refs, Confirm: true, Reason: "approved resumable migration"}
+
+	partial, err := backend.migrationApply(req)
+	if err != nil || partial.Applied || partial.Outcome != "partial_failure" {
+		t.Fatalf("partial=%#v err=%v", partial, err)
+	}
+	if !partial.Results[0].Verified || partial.Results[1].Outcome != "rate_limited" {
+		t.Fatalf("partial results=%#v", partial.Results)
+	}
+	assertMigrationSourcesUnchanged(t, backend, values)
+
+	restarted := newLocalBackend(backend.storePath, backend.auditPath, backend.masterKey)
+	restarted.sources = backend.sources
+	restarted.registerProviderMigrationExecutor("vault-test-double", executor)
+	executor.writeOutcomes[refs[1]] = "applied"
+	resumed, err := restarted.migrationApply(req)
+	if err != nil || !resumed.Applied || resumed.Outcome != "applied" {
+		t.Fatalf("resumed=%#v err=%v", resumed, err)
+	}
+	if executor.writeCalls[refs[0]] != 1 || executor.verifyCalls[refs[0]] != 1 {
+		t.Fatalf("verified ref was repeated after restart: writes=%d verifies=%d", executor.writeCalls[refs[0]], executor.verifyCalls[refs[0]])
+	}
+	if executor.writeCalls[refs[1]] != 2 || executor.verifyCalls[refs[1]] != 1 {
+		t.Fatalf("failed ref did not resume exactly once: writes=%d verifies=%d", executor.writeCalls[refs[1]], executor.verifyCalls[refs[1]])
+	}
+	assertMigrationSourcesUnchanged(t, restarted, values)
+	assertMigrationPersistenceIsMetadataOnly(t, restarted, values)
+}
+
+func TestProviderMigrationVerificationRetryDoesNotRewriteTarget(t *testing.T) {
+	backend, executor, refs, _ := executableMigrationTestBackend(t)
+	ref := refs[0]
+	executor.verifyOutcomes[ref] = "verification_failed"
+	req := migrationPlanRequest{RequestID: "req-verify-retry", ServiceID: "@serviceadmin", OperationID: "migration-verify-retry", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: []string{ref}, Confirm: true, Reason: "approved verification retry"}
+
+	partial, err := backend.migrationApply(req)
+	if err != nil || partial.Outcome != "partial_failure" || partial.Results[0].Outcome != "verification_failed" {
+		t.Fatalf("partial=%#v err=%v", partial, err)
+	}
+	executor.verifyOutcomes[ref] = "verified"
+	resumed, err := backend.migrationApply(req)
+	if err != nil || resumed.Outcome != "applied" || !resumed.Results[0].Verified {
+		t.Fatalf("resumed=%#v err=%v", resumed, err)
+	}
+	if executor.writeCalls[ref] != 1 || executor.verifyCalls[ref] != 2 {
+		t.Fatalf("verification retry calls writes=%d verifies=%d", executor.writeCalls[ref], executor.verifyCalls[ref])
+	}
+}
+
+func TestProviderMigrationChangedPlanConflictsWithoutExecutorCalls(t *testing.T) {
+	backend, executor, refs, _ := executableMigrationTestBackend(t)
+	req := migrationPlanRequest{RequestID: "req-plan-conflict", ServiceID: "@serviceadmin", OperationID: "migration-plan-conflict", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: []string{refs[0]}, Confirm: true, Reason: "approved migration"}
+	if _, err := backend.migrationApply(req); err != nil {
+		t.Fatal(err)
+	}
+	req.Refs = refs
+	conflict, err := backend.migrationApply(req)
+	if !errors.Is(err, errMigrationPlanConflict) || conflict.Outcome != "conflict" || conflict.Applied || conflict.NextAction != "create_new_operation_id_for_changed_plan" {
+		t.Fatalf("conflict=%#v err=%v", conflict, err)
+	}
+	if executor.writeCalls[refs[0]] != 1 || executor.writeCalls[refs[1]] != 0 {
+		t.Fatalf("changed plan reached executor: %#v", executor.writeCalls)
+	}
+	req.Refs = []string{refs[0]}
+	req.TargetProviderID = "openbao-without-executor"
+	conflict, err = backend.migrationApply(req)
+	if !errors.Is(err, errMigrationPlanConflict) || conflict.Outcome != "conflict" {
+		t.Fatalf("changed target conflict=%#v err=%v", conflict, err)
+	}
+}
+
+func TestProviderMigrationAuditPreflightFailsClosedBeforeExecutor(t *testing.T) {
+	backend, executor, refs, values := executableMigrationTestBackend(t)
+	blockedAudit := filepath.Join(t.TempDir(), "audit-is-directory")
+	if err := os.Mkdir(blockedAudit, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	backend.auditPath = blockedAudit
+	res, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-audit-preflight", ServiceID: "@serviceadmin", OperationID: "migration-audit-preflight", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: refs, Confirm: true, Reason: "approved migration"})
+	if !errors.Is(err, errProviderAuditUnavailable) || res.Outcome != "audit_unavailable" || res.Applied {
+		t.Fatalf("res=%#v err=%v", res, err)
+	}
+	for _, ref := range refs {
+		if executor.writeCalls[ref] != 0 || executor.verifyCalls[ref] != 0 {
+			t.Fatalf("audit preflight failure reached executor for %s", ref)
+		}
+	}
+	assertMigrationSourcesUnchanged(t, backend, values)
+}
+
+func TestProviderMigrationEmptyAuditPathFailsClosedBeforeExecutor(t *testing.T) {
+	backend, executor, refs, _ := executableMigrationTestBackend(t)
+	backend.auditPath = ""
+	res, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-empty-audit", ServiceID: "@serviceadmin", OperationID: "migration-empty-audit", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: refs, Confirm: true, Reason: "approved migration"})
+	if !errors.Is(err, errProviderAuditUnavailable) || res.Outcome != "audit_unavailable" || res.Applied {
+		t.Fatalf("res=%#v err=%v", res, err)
+	}
+	for _, ref := range refs {
+		if executor.writeCalls[ref] != 0 || executor.verifyCalls[ref] != 0 {
+			t.Fatalf("empty audit path reached executor for %s", ref)
+		}
+	}
+}
+
+func TestProviderMigrationExecutorHTTPApplyAndPlanConflictAreTypedAndRedacted(t *testing.T) {
+	backend, _, refs, values := executableMigrationTestBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+	req := migrationPlanRequest{RequestID: "req-http-executor", ServiceID: "@serviceadmin", OperationID: "migration-http-executor", SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: []string{refs[0]}, Confirm: true, Reason: "approved HTTP migration"}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applied := postRotationTestRequest(t, server.URL+"/v1/providers/migration/apply", body)
+	if applied.StatusCode != http.StatusOK || !bytes.Contains(applied.Body, []byte(`"outcome":"applied"`)) || !bytes.Contains(applied.Body, []byte(`"verified":true`)) {
+		t.Fatalf("status=%d body=%s", applied.StatusCode, applied.Body)
+	}
+	assertNoSecretMaterial(t, applied.Body, values[refs[0]], providerCredentialValue, testProviderResponseBody, "test-token")
+
+	req.Refs = refs
+	body, err = json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflict := postRotationTestRequest(t, server.URL+"/v1/providers/migration/apply", body)
+	if conflict.StatusCode != http.StatusConflict || !bytes.Contains(conflict.Body, []byte(`"outcome":"conflict"`)) || !bytes.Contains(conflict.Body, []byte(`"applied":false`)) {
+		t.Fatalf("status=%d body=%s", conflict.StatusCode, conflict.Body)
+	}
+	assertNoSecretMaterial(t, conflict.Body, values[refs[0]], values[refs[1]], providerCredentialValue, testProviderResponseBody, "test-token")
+}
+
+func TestProviderMigrationTypedExecutorFailuresAreMetadataOnly(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		writeOutcome  string
+		verifyOutcome string
+		want          string
+	}{
+		{name: "auth expired", writeOutcome: "source_auth_required", want: "source_auth_required"},
+		{name: "rate limited", writeOutcome: "rate_limited", want: "rate_limited"},
+		{name: "unavailable", writeOutcome: "source_unavailable", want: "source_unavailable"},
+		{name: "verification", verifyOutcome: "verification_failed", want: "verification_failed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend, executor, refs, values := executableMigrationTestBackend(t)
+			ref := refs[0]
+			executor.writeOutcomes[ref] = test.writeOutcome
+			executor.verifyOutcomes[ref] = test.verifyOutcome
+			res, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-typed-failure", ServiceID: "@serviceadmin", OperationID: "migration-typed-" + safeOperationToken(test.name), SourceProviderID: "local", TargetProviderID: "vault-test-double", Refs: []string{ref}, Confirm: true, Reason: "approved failure proof"})
+			if err != nil || res.Outcome != "partial_failure" || res.Applied || len(res.Results) != 1 || res.Results[0].Outcome != test.want {
+				t.Fatalf("res=%#v err=%v", res, err)
+			}
+			assertNoSecretMaterial(t, mustManagedJSON(t, res), values[ref], providerCredentialValue, testProviderResponseBody)
+			assertMigrationPersistenceIsMetadataOnly(t, backend, values)
+		})
+	}
+}
+
+func executableMigrationTestBackend(t *testing.T) (*localBackend, *deterministicMigrationExecutor, []string, map[string]string) {
+	t.Helper()
+	backend := managedTestBackend(t)
+	refs := []string{"services/@serviceadmin/runtime/API_KEY", "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"}
+	values := map[string]string{refs[0]: "executor-source-secret-one", refs[1]: "executor-source-secret-two"}
+	for _, ref := range refs {
+		writeManagedTestSecret(t, backend, ref, values[ref])
+	}
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "vault-test-double", Kind: "vault", Enabled: true, Address: "https://vault.invalid", Token: providerCredentialValue,
+		Refs: map[string]sourceRefConfig{"services/fixture/runtime/TARGET": {Path: "secret/data/fixture", Field: "value"}},
+	}, {
+		SourceID: "openbao-without-executor", Kind: "openbao", Enabled: true, Address: "https://openbao.invalid", Token: providerCredentialValue,
+		Refs: map[string]sourceRefConfig{"services/fixture/runtime/TARGET": {Path: "secret/data/fixture", Field: "value"}},
+	}}}
+	executor := newDeterministicMigrationExecutor()
+	backend.registerProviderMigrationExecutor("vault-test-double", executor)
+	return backend, executor, refs, values
+}
+
+func assertMigrationSourcesUnchanged(t *testing.T, backend *localBackend, values map[string]string) {
+	t.Helper()
+	refs := make([]string, 0, len(values))
+	for ref := range values {
+		refs = append(refs, ref)
+	}
+	resolved := backend.resolve(resolveRequest{RequestID: "req-source-recovery-proof", ServiceID: "@serviceadmin", Purpose: "migration source recovery proof", Refs: refs})
+	for _, result := range resolved.Results {
+		if result.Outcome != "ready" || result.Value != values[result.Ref] {
+			t.Fatalf("source changed or became unrecoverable: %#v", result)
+		}
+	}
+}
+
+func assertMigrationPersistenceIsMetadataOnly(t *testing.T, backend *localBackend, values map[string]string) {
+	t.Helper()
+	storeBytes, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditBytes, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range values {
+		assertNoSecretMaterial(t, storeBytes, value)
+		assertNoSecretMaterial(t, auditBytes, value)
+	}
+	assertNoSecretMaterial(t, storeBytes, providerCredentialValue, testProviderResponseBody)
+	assertNoSecretMaterial(t, auditBytes, providerCredentialValue, testProviderResponseBody)
+}

--- a/conformance/fixtures/contract-states.json
+++ b/conformance/fixtures/contract-states.json
@@ -547,7 +547,7 @@
               "onepassword-cli"
             ],
             "completionMode": "synchronous",
-            "limitationCode": "migration_items_not_copied",
+            "limitationCode": "registered_provider_executor_required",
             "reasonCode": "planning_only_not_executable",
             "nextAction": "do_not_enable_apply"
           },
@@ -1120,6 +1120,8 @@
           "applied",
           "rolled_back",
           "retired",
+          "rate_limited",
+          "verification_failed",
           "identity_invalid",
           "identity_expired",
           "identity_replayed",
@@ -1667,7 +1669,7 @@
                   "local-encrypted-store"
                 ],
                 "completionMode": "synchronous",
-                "limitationCode": "migration_items_not_copied",
+                "limitationCode": "registered_provider_executor_required",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
               },
@@ -2164,7 +2166,7 @@
                   "openbao"
                 ],
                 "completionMode": "synchronous",
-                "limitationCode": "migration_items_not_copied",
+                "limitationCode": "registered_provider_executor_required",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
               },
@@ -2664,7 +2666,7 @@
                   "aws-secrets-manager"
                 ],
                 "completionMode": "synchronous",
-                "limitationCode": "migration_items_not_copied",
+                "limitationCode": "registered_provider_executor_required",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
               },
@@ -3163,7 +3165,7 @@
                   "vault"
                 ],
                 "completionMode": "synchronous",
-                "limitationCode": "migration_items_not_copied",
+                "limitationCode": "registered_provider_executor_required",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
               },
@@ -3662,7 +3664,7 @@
                   "vault"
                 ],
                 "completionMode": "synchronous",
-                "limitationCode": "migration_items_not_copied",
+                "limitationCode": "registered_provider_executor_required",
                 "reasonCode": "planning_only_not_executable",
                 "nextAction": "do_not_enable_apply"
               },

--- a/contract/v1/openapi.json
+++ b/contract/v1/openapi.json
@@ -1583,6 +1583,9 @@
       "migrationItemStatus": {
         "additionalProperties": true,
         "properties": {
+          "attempts": {
+            "type": "integer"
+          },
           "auditRequirement": {
             "type": "string"
           },
@@ -1615,6 +1618,9 @@
           },
           "targetProviderId": {
             "type": "string"
+          },
+          "verified": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -1628,7 +1634,8 @@
           "risk",
           "sourceProviderId",
           "state",
-          "targetProviderId"
+          "targetProviderId",
+          "verified"
         ],
         "type": "object"
       },
@@ -6700,7 +6707,7 @@
             "onepassword-cli"
           ],
           "completionMode": "synchronous",
-          "limitationCode": "migration_items_not_copied",
+          "limitationCode": "registered_provider_executor_required",
           "reasonCode": "planning_only_not_executable",
           "nextAction": "do_not_enable_apply"
         }

--- a/docs/operation-capability-manifest.md
+++ b/docs/operation-capability-manifest.md
@@ -89,10 +89,12 @@ machine-readable authority.
 | Secrets Sync dry-run | dry-run | dry-run | dry-run | dry-run |
 
 The current provider configuration apply handler validates and reports an apply
-result but does not persist a connection. Migration and bulk campaign apply
-handlers report metadata outcomes but do not copy or mutate provider values.
-Those operations are deliberately `planned`, regardless of legacy response
-wording.
+result but does not persist a connection. Migration apply has a durable,
+idempotent executor seam, but no real remote provider executor is registered in
+the release runtime; bulk campaign apply likewise does not mutate provider
+values. Those operations remain deliberately `planned`. A test-only or future
+explicit executor registration does not let Service Admin infer executable
+capability from the provider-family upper bound.
 
 ## Drift and conformance gates
 

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -128,23 +128,42 @@ user information, path, query, and fragment are stripped so accidentally
 embedded credentials or request details cannot enter Admin responses, audit
 evidence, or diagnostics. Invalid/non-HTTP provider addresses fail validation.
 
-The Broker records every migration dry-run and apply attempt in the configured
-metadata-only audit/event sinks before returning an auditable result. If either
+The Broker records every migration dry-run in the configured metadata-only
+audit/event sinks. Apply requires a durable metadata-only authorization record
+before an executor can receive source material, then records the typed outcome
+after durable operation state is updated. If either
 sink cannot accept the record, the response fails closed with
 `outcome: "audit_unavailable"`, `auditStatus: "audit_unavailable"`,
 `applied: false`, and `nextAction: "restore_audit_and_retry"`. Per-ref items are
 also marked `audit_unavailable`; provider credentials, source values, and raw
 provider bodies are never returned.
 
-### `POST /v1/providers/migration/apply` (planned)
+### `POST /v1/providers/migration/apply` (executor-gated; advertised as planned)
 
-The current handler validates confirmation, operation id and audit reason, but
-it does not copy local values or perform remote provider writes. Every target
-therefore fails closed with `outcome: "unsupported"`, `applied: false`, and
-`nextAction: "implement_provider_operation_executor"` until a provider-specific
-executor is wired and validated. Its manifest maturity is `planned`; per-ref
-items are metadata-only evidence and never indicate a completed copy.
+The handler validates confirmation, operation id, audit reason, selected-source
+inventory, provider readiness, and exact target capability. It then requires an
+explicit in-process executor registration for the selected provider id. Without
+that registration every target fails closed with `outcome: "unsupported"`,
+`applied: false`, and `nextAction: "implement_provider_operation_executor"`.
+Vault/OpenBao and AWS have no production executor registration in this release,
+so their operation manifest maturity remains `planned` and Service Admin must
+not enable apply from the family capability alone.
+
+The executor seam receives an operation-scoped idempotency key and source value
+inside the Broker process. A ref is reported `migrated` only after a separate
+target verification succeeds. Durable operation state contains only provider
+ids, refs, a plan fingerprint, typed outcomes, attempt counts and verification
+flags. It never contains a source value, credential, ciphertext copy, or remote
+response body.
+
+An exact retry skips already verified refs. A retry after `partial_failure`
+resumes failed refs; a ref whose write succeeded but verification failed retries
+verification without issuing a duplicate write. This state survives Broker
+restart. Reusing an operation id with different source, target, or refs returns
+HTTP 409 with `outcome: "conflict"` and
+`nextAction: "create_new_operation_id_for_changed_plan"`. Source entries remain
+unchanged and recoverable after both partial and successful migration.
 
 ## Typed outcomes
 
-Common outcomes: `ready`, `applied`, `dry_run_ready`, `partial_failure`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `source_unavailable`, `unsupported`, `degraded`, `audit_unavailable`.
+Common outcomes: `ready`, `applied`, `dry_run_ready`, `partial_failure`, `conflict`, `invalid_ref`, `locked`, `policy_denied`, `source_auth_required`, `rate_limited`, `source_unavailable`, `verification_failed`, `unsupported`, `degraded`, `audit_unavailable`.


### PR DESCRIPTION
## Summary

- add an explicit per-provider migration executor seam without registering any real Vault/OpenBao/AWS executor
- persist metadata-only operation fingerprints and per-ref write/verification state for restart-safe idempotency
- require durable audit authorization before executor access to source values
- skip verified refs on exact retry, resume retryable failures, and retry verification without duplicate writes
- return stable conflict for changed plans and typed metadata-only partial failures
- keep source entries unchanged and real provider capability advertised as planned

## Safety boundary

No source value, provider credential, ciphertext copy, or provider response body is persisted in migration operation state or returned by the API. Source values cross only the in-process executor seam. Real remote providers remain unsupported unless explicitly registered by future implementation work under #134.

## Validation

- `go test ./cmd/secretsbroker -run '^TestProviderMigration(ExecutorEndToEndIsVerifiedDurableAndIdempotent|PartialFailureResumesAfterRestartWithoutRewritingVerifiedRefs|VerificationRetryDoesNotRewriteTarget|ChangedPlanConflictsWithoutExecutorCalls|AuditPreflightFailsClosedBeforeExecutor|EmptyAuditPathFailsClosedBeforeExecutor|ExecutorHTTPApplyAndPlanConflictAreTypedAndRedacted|TypedExecutorFailuresAreMetadataOnly)$' -count=10`
- `go test ./...`
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- `go vet ./...`
- `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve`
- contract regeneration plus `go test ./cmd/secretsbroker -run '^TestContractArtefactsAreCurrent$' -count=1`
- `git diff --check`

Closes #144
Parent: #134