### PR TITLE
feat(providers): execute verified Vault/OpenBao KV v2 migrations

### DIFF
--- a/cmd/secretsbroker/admin_cli.go
+++ b/cmd/secretsbroker/admin_cli.go
@@ -649,6 +649,7 @@ func backendFromAdminOptions(opts *adminCommonOptions) (*localBackend, keyMateri
 		return nil, material, sourceErr
 	}
 	backend.sources = sources
+	backend.configureProviderMigrationExecutors()
 	return backend, material, err
 }
 

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -408,6 +408,7 @@ func serve(args []string) error {
 		return err
 	}
 	backend.sources = sources
+	backend.configureProviderMigrationExecutors()
 
 	binding, err := resolveServeTransport(serveTransportOptions{
 		Mode:                        *mode,

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -180,7 +180,9 @@ func providerStatusFromSource(source SourceStatus, backend *localBackend) provid
 		}
 	}
 	auditStatus := firstNonEmpty(source.AuditStatus, "audit_available")
-	return providerConfigStatus{ProviderID: source.SourceID, ProviderKind: source.Kind, DisplayName: source.DisplayName, State: source.State, Outcome: source.Outcome, CredentialHandle: credential, Address: address, Namespaces: safeList(source.Namespaces), Capabilities: providerCapabilitiesByKind(source.Kind).Capabilities, Operations: providerOperationCapabilitiesForSource(source.Kind, source.Lifecycle, auditStatus), NextAction: source.NextAction, AuditStatus: auditStatus}
+	operations := providerOperationCapabilitiesForSource(source.Kind, source.Lifecycle, auditStatus)
+	operations = backend.connectionProviderOperations(source.SourceID, source.Lifecycle, auditStatus, operations)
+	return providerConfigStatus{ProviderID: source.SourceID, ProviderKind: source.Kind, DisplayName: source.DisplayName, State: source.State, Outcome: source.Outcome, CredentialHandle: credential, Address: address, Namespaces: safeList(source.Namespaces), Capabilities: providerCapabilitiesByKind(source.Kind).Capabilities, Operations: operations, NextAction: source.NextAction, AuditStatus: auditStatus}
 }
 
 func (b *localBackend) validateProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {

--- a/cmd/secretsbroker/provider_operation_executor.go
+++ b/cmd/secretsbroker/provider_operation_executor.go
@@ -84,6 +84,21 @@ func (b *localBackend) providerMigrationExecutor(providerID string) (providerMig
 	return executor, ok && executor != nil
 }
 
+func (b *localBackend) connectionProviderOperations(providerID string, lifecycle SourceLifecycle, auditStatus string, operations []OperationCapability) []OperationCapability {
+	if _, ok := b.providerMigrationExecutor(providerID); !ok || lifecycle.Outcome != "ready" || auditStatus != "audit_available" {
+		return operations
+	}
+	for index := range operations {
+		if operations[index].Path != "/v1/providers/migration/apply" {
+			continue
+		}
+		operations[index].Maturity = OperationMaturityValidated
+		operations[index].ReasonCode, operations[index].NextAction = maturityCodes(OperationMaturityValidated)
+		operations[index].LimitationCode = ""
+	}
+	return operations
+}
+
 func (b *localBackend) providerMigrationPlanConflicts(req migrationPlanRequest) (bool, error) {
 	store, err := b.loadStore()
 	if err != nil {
@@ -284,6 +299,10 @@ func providerMigrationRetryAction(outcome string) string {
 		return "retry_after_provider_backoff"
 	case "verification_failed", "verification_pending":
 		return "retry_target_verification"
+	case "conflict":
+		return "refresh_target_version_and_retry"
+	case "invalid_ref":
+		return "fix_target_mapping"
 	case "source_unavailable", "degraded":
 		return "restore_provider_availability_and_retry"
 	case "unsupported":
@@ -297,7 +316,7 @@ func normalizeProviderExecutorWriteOutcome(outcome string) string {
 	switch strings.TrimSpace(outcome) {
 	case "applied":
 		return "applied"
-	case "source_auth_required", "rate_limited", "source_unavailable", "policy_denied", "degraded":
+	case "source_auth_required", "rate_limited", "source_unavailable", "policy_denied", "conflict", "invalid_ref", "degraded":
 		return strings.TrimSpace(outcome)
 	default:
 		return "degraded"

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -24,21 +24,22 @@ type sourceConfigFile struct {
 }
 
 type sourceConfig struct {
-	SourceID            string                     `json:"sourceId"`
-	Kind                string                     `json:"kind"`
-	DisplayName         string                     `json:"displayName"`
-	Enabled             bool                       `json:"enabled"`
-	Critical            bool                       `json:"critical"`
-	Priority            int                        `json:"priority"`
-	Namespaces          []string                   `json:"namespaces"`
-	TrustedDirs         []string                   `json:"trustedDirs"`
-	AllowSymlinkCommand bool                       `json:"allowSymlinkCommand"`
-	Address             string                     `json:"address"`
-	Region              string                     `json:"region"`
-	AccountID           string                     `json:"accountId"`
-	Token               string                     `json:"token"`
-	TokenEnv            string                     `json:"tokenEnv"`
-	Refs                map[string]sourceRefConfig `json:"refs"`
+	SourceID              string                     `json:"sourceId"`
+	Kind                  string                     `json:"kind"`
+	DisplayName           string                     `json:"displayName"`
+	Enabled               bool                       `json:"enabled"`
+	Critical              bool                       `json:"critical"`
+	Priority              int                        `json:"priority"`
+	Namespaces            []string                   `json:"namespaces"`
+	TrustedDirs           []string                   `json:"trustedDirs"`
+	AllowSymlinkCommand   bool                       `json:"allowSymlinkCommand"`
+	EnableMigrationTarget bool                       `json:"enableMigrationTarget,omitempty"`
+	Address               string                     `json:"address"`
+	Region                string                     `json:"region"`
+	AccountID             string                     `json:"accountId"`
+	Token                 string                     `json:"token"`
+	TokenEnv              string                     `json:"tokenEnv"`
+	Refs                  map[string]sourceRefConfig `json:"refs"`
 }
 
 type sourceRefConfig struct {

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -92,6 +92,7 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 				AffectedServices: []string{},
 			}
 			status.Operations = providerOperationCapabilitiesForSource(status.Kind, status.Lifecycle, status.AuditStatus)
+			status.Operations = backend.connectionProviderOperations(status.SourceID, status.Lifecycle, status.AuditStatus, status.Operations)
 			if len(status.Namespaces) == 0 {
 				status.Namespaces = []string{"*"}
 			}
@@ -134,6 +135,11 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 		}
 		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
 			return normalizeSourceLifecycle("source_auth_required")
+		}
+		if source.EnableMigrationTarget {
+			if _, err := newVaultKVMigrationExecutor(source); err != nil {
+				return normalizeSourceLifecycle("invalid_ref")
+			}
 		}
 	case "bitwarden-bws":
 		if len(source.Refs) == 0 {

--- a/cmd/secretsbroker/vault_kv_executor.go
+++ b/cmd/secretsbroker/vault_kv_executor.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultVaultKVMigrationTimeout  = 3 * time.Second
+	maximumVaultKVMigrationTimeout  = 30 * time.Second
+	defaultVaultKVMigrationMaxBytes = 64 * 1024
+	maximumVaultKVMigrationMaxBytes = 1024 * 1024
+)
+
+type vaultKVMigrationExecutor struct {
+	source  sourceConfig
+	baseURL url.URL
+	client  *http.Client
+}
+
+type vaultKVReadResult struct {
+	Data    map[string]any
+	Version int
+	Outcome string
+}
+
+func (b *localBackend) configureProviderMigrationExecutors() {
+	if b == nil {
+		return
+	}
+	for _, source := range b.sources.enabledSources() {
+		if !source.EnableMigrationTarget {
+			continue
+		}
+		executor, err := newVaultKVMigrationExecutor(source)
+		if err != nil {
+			continue
+		}
+		b.registerProviderMigrationExecutor(source.SourceID, executor)
+	}
+}
+
+func newVaultKVMigrationExecutor(source sourceConfig) (*vaultKVMigrationExecutor, error) {
+	kind := strings.ToLower(strings.TrimSpace(source.Kind))
+	if !source.Enabled || !source.EnableMigrationTarget || (kind != "vault" && kind != "openbao") {
+		return nil, errors.New("vault migration target is not explicitly enabled")
+	}
+	baseURL, err := validatedVaultKVBaseURL(source.Address)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
+		return nil, errors.New("vault migration target authentication is missing")
+	}
+	if len(source.Refs) == 0 {
+		return nil, errors.New("vault migration target has no ref mappings")
+	}
+	for ref, mapping := range source.Refs {
+		if !validSecretRef(ref) || !validVaultKVMapping(mapping) {
+			return nil, errors.New("vault migration target mapping is invalid")
+		}
+	}
+	return &vaultKVMigrationExecutor{
+		source:  source,
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: maximumVaultKVMigrationTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
+}
+
+func validatedVaultKVBaseURL(address string) (url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(address))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return url.URL{}, errors.New("vault migration target address is invalid")
+	}
+	if parsed.Scheme == "http" && !vaultKVLoopbackHost(parsed.Hostname()) {
+		return url.URL{}, errors.New("vault migration target requires HTTPS outside loopback")
+	}
+	return url.URL{Scheme: parsed.Scheme, Host: parsed.Host}, nil
+}
+
+func vaultKVLoopbackHost(host string) bool {
+	if strings.EqualFold(strings.TrimSpace(host), "localhost") {
+		return true
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsLoopback()
+}
+
+func validVaultKVMapping(mapping sourceRefConfig) bool {
+	path := strings.Trim(strings.TrimSpace(mapping.Path), "/")
+	field := strings.TrimSpace(mapping.Field)
+	if path == "" || len(path) > 2048 || field == "" || len(field) > 256 || strings.ContainsAny(path, "\\?#%") || strings.ContainsAny(field, "\r\n") {
+		return false
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return strings.Contains("/"+path+"/", "/data/")
+}
+
+func (e *vaultKVMigrationExecutor) Write(req providerMigrationWriteRequest) providerMigrationExecutorResult {
+	mapping, ok := e.source.Refs[req.Ref]
+	if !ok || !validVaultKVMapping(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	current := e.read(mapping)
+	if current.Outcome != "ready" && current.Outcome != "missing_ref" {
+		return providerMigrationExecutorResult{Outcome: current.Outcome}
+	}
+	if current.Outcome == "ready" {
+		if value, ok := current.Data[mapping.Field].(string); ok && value == req.Value {
+			return providerMigrationExecutorResult{Outcome: "applied"}
+		}
+	} else {
+		current.Data = map[string]any{}
+		current.Version = 0
+	}
+	current.Data[mapping.Field] = req.Value
+	payload, err := json.Marshal(map[string]any{
+		"data":    current.Data,
+		"options": map[string]int{"cas": current.Version},
+	})
+	if err != nil || len(payload) > vaultKVMigrationMaxBytes(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	status, _, outcome := e.request(http.MethodPost, mapping, bytes.NewReader(payload), req.IdempotencyKey)
+	if outcome != "ready" {
+		return providerMigrationExecutorResult{Outcome: outcome}
+	}
+	if status < 200 || status >= 300 {
+		return providerMigrationExecutorResult{Outcome: vaultKVStatusOutcome(status, true)}
+	}
+	return providerMigrationExecutorResult{Outcome: "applied"}
+}
+
+func (e *vaultKVMigrationExecutor) Verify(req providerMigrationVerifyRequest) providerMigrationExecutorResult {
+	mapping, ok := e.source.Refs[req.Ref]
+	if !ok || !validVaultKVMapping(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	current := e.read(mapping)
+	if current.Outcome != "ready" {
+		if current.Outcome == "missing_ref" || current.Outcome == "invalid_ref" {
+			return providerMigrationExecutorResult{Outcome: "verification_failed"}
+		}
+		return providerMigrationExecutorResult{Outcome: current.Outcome}
+	}
+	value, ok := current.Data[mapping.Field].(string)
+	if !ok || value != req.ExpectedValue {
+		return providerMigrationExecutorResult{Outcome: "verification_failed"}
+	}
+	return providerMigrationExecutorResult{Outcome: "verified"}
+}
+
+func (e *vaultKVMigrationExecutor) read(mapping sourceRefConfig) vaultKVReadResult {
+	status, body, outcome := e.request(http.MethodGet, mapping, nil, "")
+	if outcome != "ready" {
+		return vaultKVReadResult{Outcome: outcome}
+	}
+	if status < 200 || status >= 300 {
+		return vaultKVReadResult{Outcome: vaultKVStatusOutcome(status, false)}
+	}
+	var payload struct {
+		Data struct {
+			Data     map[string]any `json:"data"`
+			Metadata struct {
+				Version int `json:"version"`
+			} `json:"metadata"`
+		} `json:"data"`
+	}
+	if len(body) == 0 || json.Unmarshal(body, &payload) != nil || payload.Data.Data == nil || payload.Data.Metadata.Version <= 0 {
+		return vaultKVReadResult{Outcome: "source_unavailable"}
+	}
+	return vaultKVReadResult{Data: payload.Data.Data, Version: payload.Data.Metadata.Version, Outcome: "ready"}
+}
+
+func (e *vaultKVMigrationExecutor) request(method string, mapping sourceRefConfig, body io.Reader, idempotencyKey string) (int, []byte, string) {
+	endpoint, err := e.endpoint(mapping.Path)
+	if err != nil {
+		return 0, nil, "invalid_ref"
+	}
+	token := strings.TrimSpace(firstNonEmpty(e.source.Token, os.Getenv(e.source.TokenEnv)))
+	if token == "" {
+		return 0, nil, "source_auth_required"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), vaultKVMigrationTimeout(mapping))
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return 0, nil, "invalid_ref"
+	}
+	req.Header.Set("X-Vault-Token", token)
+	if method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+		if strings.TrimSpace(idempotencyKey) != "" {
+			req.Header.Set("X-Service-Lasso-Idempotency-Key", idempotencyKey)
+		}
+	}
+	res, err := e.client.Do(req)
+	if err != nil {
+		return 0, nil, "source_unavailable"
+	}
+	defer res.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(res.Body, int64(vaultKVMigrationMaxBytes(mapping))+1))
+	if err != nil || len(responseBody) > vaultKVMigrationMaxBytes(mapping) {
+		return res.StatusCode, nil, "source_unavailable"
+	}
+	return res.StatusCode, responseBody, "ready"
+}
+
+func (e *vaultKVMigrationExecutor) endpoint(path string) (string, error) {
+	mapping := sourceRefConfig{Path: path, Field: "value"}
+	if !validVaultKVMapping(mapping) {
+		return "", errors.New("vault migration target path is invalid")
+	}
+	endpoint := e.baseURL
+	endpoint.Path = "/v1/" + strings.Trim(strings.TrimSpace(path), "/")
+	return endpoint.String(), nil
+}
+
+func vaultKVStatusOutcome(status int, write bool) string {
+	switch status {
+	case http.StatusUnauthorized:
+		return "source_auth_required"
+	case http.StatusForbidden:
+		return "policy_denied"
+	case http.StatusTooManyRequests:
+		return "rate_limited"
+	case http.StatusConflict, http.StatusPreconditionFailed:
+		return "conflict"
+	case http.StatusBadRequest:
+		if write {
+			return "conflict"
+		}
+		return "invalid_ref"
+	case http.StatusNotFound:
+		if write {
+			return "invalid_ref"
+		}
+		return "missing_ref"
+	}
+	if status >= 500 || status == http.StatusRequestTimeout || (status >= 300 && status < 400) {
+		return "source_unavailable"
+	}
+	return "invalid_ref"
+}
+
+func vaultKVMigrationTimeout(mapping sourceRefConfig) time.Duration {
+	timeout := time.Duration(firstPositive(mapping.TimeoutMs, int(defaultVaultKVMigrationTimeout/time.Millisecond))) * time.Millisecond
+	if timeout < 100*time.Millisecond {
+		return 100 * time.Millisecond
+	}
+	if timeout > maximumVaultKVMigrationTimeout {
+		return maximumVaultKVMigrationTimeout
+	}
+	return timeout
+}
+
+func vaultKVMigrationMaxBytes(mapping sourceRefConfig) int {
+	limit := firstPositive(mapping.MaxBytes, firstPositive(mapping.MaxStdoutBytes, defaultVaultKVMigrationMaxBytes))
+	if limit > maximumVaultKVMigrationMaxBytes {
+		return maximumVaultKVMigrationMaxBytes
+	}
+	return limit
+}

--- a/cmd/secretsbroker/vault_kv_executor_test.go
+++ b/cmd/secretsbroker/vault_kv_executor_test.go
@@ -1,0 +1,427 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	vaultMigrationToken       = "vault-migration-token-sentinel"
+	vaultMigrationSecret      = "vault-migration-secret-sentinel"
+	vaultMigrationRemoteBody  = "vault-remote-body-sentinel"
+	vaultMigrationMappedPath  = "secret/data/serviceadmin"
+	vaultMigrationMappedField = "session_key"
+)
+
+type vaultKVProtocolFixture struct {
+	mu              sync.Mutex
+	token           string
+	data            map[string]any
+	version         int
+	getCount        int
+	postCount       int
+	forceGetStatus  int
+	forcePostStatus int
+	mismatchRead    bool
+	lastCAS         int
+	lastIdempotency string
+}
+
+func (f *vaultKVProtocolFixture) handler(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if r.URL.Path != "/v1/"+vaultMigrationMappedPath {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if r.Header.Get("X-Vault-Token") != f.token {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		f.getCount++
+		if f.forceGetStatus != 0 {
+			w.WriteHeader(f.forceGetStatus)
+			fmt.Fprint(w, vaultMigrationRemoteBody)
+			return
+		}
+		if f.version == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		data := make(map[string]any, len(f.data))
+		for key, value := range f.data {
+			data[key] = value
+		}
+		if f.mismatchRead {
+			data[vaultMigrationMappedField] = "different-remote-value"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"data": data, "metadata": map[string]any{"version": f.version}}})
+	case http.MethodPost:
+		f.postCount++
+		f.lastIdempotency = r.Header.Get("X-Service-Lasso-Idempotency-Key")
+		if f.forcePostStatus != 0 {
+			w.WriteHeader(f.forcePostStatus)
+			fmt.Fprint(w, vaultMigrationRemoteBody)
+			return
+		}
+		var payload struct {
+			Data    map[string]any `json:"data"`
+			Options struct {
+				CAS int `json:"cas"`
+			} `json:"options"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.lastCAS = payload.Options.CAS
+		if payload.Options.CAS != f.version {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.data = payload.Data
+		f.version++
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"version": f.version}})
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func TestVaultKVMigrationExecutorPreservesFieldsUsesCASAndVerifies(t *testing.T) {
+	for _, kind := range []string{"vault", "openbao"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, version: 7, data: map[string]any{"sibling": "preserve-me", vaultMigrationMappedField: "old-value"}}
+			server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+			defer server.Close()
+			executor := mustVaultKVMigrationExecutor(t, vaultMigrationSource(kind, server.URL, true))
+			write := executor.Write(providerMigrationWriteRequest{OperationID: "vault-kv-write", IdempotencyKey: "safe-idempotency-key", TargetProviderID: kind + "-target", Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+			if write.Outcome != "applied" {
+				t.Fatalf("write=%#v", write)
+			}
+			verified := executor.Verify(providerMigrationVerifyRequest{OperationID: "vault-kv-write", IdempotencyKey: "safe-idempotency-key", TargetProviderID: kind + "-target", Ref: vaultMigrationRef(), ExpectedValue: vaultMigrationSecret})
+			if verified.Outcome != "verified" {
+				t.Fatalf("verify=%#v", verified)
+			}
+			fixture.mu.Lock()
+			defer fixture.mu.Unlock()
+			if fixture.lastCAS != 7 || fixture.version != 8 || fixture.data["sibling"] != "preserve-me" || fixture.data[vaultMigrationMappedField] != vaultMigrationSecret || fixture.lastIdempotency != "safe-idempotency-key" {
+				t.Fatalf("protocol state=%#v", fixture)
+			}
+			if fixture.getCount != 2 || fixture.postCount != 1 {
+				t.Fatalf("calls get=%d post=%d", fixture.getCount, fixture.postCount)
+			}
+		})
+	}
+}
+
+func TestVaultKVMigrationExecutorAlreadyEqualSkipsWrite(t *testing.T) {
+	fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, version: 3, data: map[string]any{vaultMigrationMappedField: vaultMigrationSecret}}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustVaultKVMigrationExecutor(t, vaultMigrationSource("vault", server.URL, true))
+	result := executor.Write(providerMigrationWriteRequest{IdempotencyKey: "safe-idempotency-key", Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+	if result.Outcome != "applied" || fixture.postCount != 0 || fixture.getCount != 1 {
+		t.Fatalf("result=%#v get=%d post=%d", result, fixture.getCount, fixture.postCount)
+	}
+}
+
+func TestVaultKVMigrationExecutorRefreshesTokenEnvPerOperation(t *testing.T) {
+	t.Setenv("VAULT_MIGRATION_TEST_TOKEN", "initial-token")
+	fixture := &vaultKVProtocolFixture{token: "refreshed-token", data: map[string]any{}}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	source := vaultMigrationSource("vault", server.URL, true)
+	source.Token = ""
+	source.TokenEnv = "VAULT_MIGRATION_TEST_TOKEN"
+	executor := mustVaultKVMigrationExecutor(t, source)
+	t.Setenv("VAULT_MIGRATION_TEST_TOKEN", "refreshed-token")
+	result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+	if result.Outcome != "applied" || fixture.postCount != 1 {
+		t.Fatalf("result=%#v posts=%d", result, fixture.postCount)
+	}
+}
+
+func TestVaultKVMigrationApplyIsConnectionScopedVerifiedAndRestartSafe(t *testing.T) {
+	fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, data: map[string]any{}}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	backend := managedTestBackend(t)
+	ref := vaultMigrationRef()
+	writeManagedTestSecret(t, backend, ref, vaultMigrationSecret)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{vaultMigrationSource("vault", server.URL, true)}}
+	backend.configureProviderMigrationExecutors()
+
+	status := backend.providerConfigStatusResponse()
+	provider := providerStatusByID(t, status, "vault-migration-target")
+	if migrationApplyMaturity(provider.Operations) != OperationMaturityValidated {
+		t.Fatalf("connection operations=%#v", provider.Operations)
+	}
+	if migrationApplyMaturity(providerCapabilitiesByKind("vault").Operations) != OperationMaturityPlanned {
+		t.Fatal("provider family capability must remain planned")
+	}
+
+	req := migrationPlanRequest{RequestID: "req-vault-migration", ServiceID: "@serviceadmin", OperationID: "vault-migration-operation", SourceProviderID: "local", TargetProviderID: "vault-migration-target", Refs: []string{ref}, Reason: "approved Vault migration", Confirm: true}
+	applied, err := backend.migrationApply(req)
+	if err != nil || !applied.Applied || applied.Outcome != "applied" || len(applied.Results) != 1 || !applied.Results[0].Verified {
+		t.Fatalf("applied=%#v err=%v", applied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), vaultMigrationSecret, vaultMigrationToken, vaultMigrationRemoteBody)
+	assertVaultMigrationSourceUnchanged(t, backend, ref)
+	fixture.mu.Lock()
+	getCount, postCount := fixture.getCount, fixture.postCount
+	fixture.mu.Unlock()
+
+	restarted := newLocalBackend(backend.storePath, backend.auditPath, backend.masterKey)
+	restarted.sources = backend.sources
+	restarted.configureProviderMigrationExecutors()
+	retried, err := restarted.migrationApply(req)
+	if err != nil || !retried.Applied || retried.Outcome != "applied" {
+		t.Fatalf("retried=%#v err=%v", retried, err)
+	}
+	fixture.mu.Lock()
+	if fixture.getCount != getCount || fixture.postCount != postCount {
+		t.Fatalf("restart retry repeated remote calls: before=%d/%d after=%d/%d", getCount, postCount, fixture.getCount, fixture.postCount)
+	}
+	fixture.mu.Unlock()
+	assertVaultMigrationPersistenceRedacted(t, restarted)
+}
+
+func TestVaultKVMigrationRegistrationFailsClosedUnlessFullyConfigured(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*sourceConfig)
+		want   string
+	}{
+		{name: "disabled capability", mutate: func(source *sourceConfig) { source.EnableMigrationTarget = false }, want: "ready"},
+		{name: "missing token", mutate: func(source *sourceConfig) { source.Token = "" }, want: "source_auth_required"},
+		{name: "unsafe address", mutate: func(source *sourceConfig) {
+			source.Address = "https://user:password@vault.invalid/tenant?credential=value"
+		}, want: "invalid_ref"},
+		{name: "remote plaintext HTTP", mutate: func(source *sourceConfig) { source.Address = "http://vault.invalid" }, want: "invalid_ref"},
+		{name: "invalid mapping", mutate: func(source *sourceConfig) {
+			source.Refs[vaultMigrationRef()] = sourceRefConfig{Path: "../escape", Field: vaultMigrationMappedField}
+		}, want: "invalid_ref"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := managedTestBackend(t)
+			source := vaultMigrationSource("vault", "https://vault.invalid", true)
+			test.mutate(&source)
+			backend.sources = sourceConfigFile{Sources: []sourceConfig{source}}
+			backend.configureProviderMigrationExecutors()
+			if _, ok := backend.providerMigrationExecutor(source.SourceID); ok {
+				t.Fatal("invalid or disabled source registered an executor")
+			}
+			registry := defaultSourceRegistry(backend)
+			if len(registry.Sources) != 2 || registry.Sources[1].Outcome != test.want || migrationApplyMaturity(registry.Sources[1].Operations) == OperationMaturityValidated {
+				t.Fatalf("source status=%#v", registry.Sources)
+			}
+		})
+	}
+}
+
+func TestVaultKVMigrationExecutorMapsRemoteFailuresWithoutLeakingBodies(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{name: "auth", status: http.StatusUnauthorized, want: "source_auth_required"},
+		{name: "policy", status: http.StatusForbidden, want: "policy_denied"},
+		{name: "rate limit", status: http.StatusTooManyRequests, want: "rate_limited"},
+		{name: "unavailable", status: http.StatusServiceUnavailable, want: "source_unavailable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, forceGetStatus: test.status}
+			server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+			defer server.Close()
+			executor := mustVaultKVMigrationExecutor(t, vaultMigrationSource("vault", server.URL, true))
+			result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+			if result.Outcome != test.want {
+				t.Fatalf("result=%#v", result)
+			}
+			assertNoSecretMaterial(t, mustManagedJSON(t, result), vaultMigrationSecret, vaultMigrationToken, vaultMigrationRemoteBody)
+		})
+	}
+}
+
+func TestVaultKVMigrationExecutorMapsCASAndVerificationConflict(t *testing.T) {
+	fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, version: 2, data: map[string]any{vaultMigrationMappedField: "old-value"}, forcePostStatus: http.StatusBadRequest}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustVaultKVMigrationExecutor(t, vaultMigrationSource("vault", server.URL, true))
+	result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+	if result.Outcome != "conflict" {
+		t.Fatalf("CAS result=%#v", result)
+	}
+	fixture.forcePostStatus = 0
+	if result = executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret}); result.Outcome != "applied" {
+		t.Fatalf("write result=%#v", result)
+	}
+	fixture.mismatchRead = true
+	verified := executor.Verify(providerMigrationVerifyRequest{Ref: vaultMigrationRef(), ExpectedValue: vaultMigrationSecret})
+	if verified.Outcome != "verification_failed" {
+		t.Fatalf("verify result=%#v", verified)
+	}
+}
+
+func TestVaultKVMigrationExecutorRejectsRedirectsOversizeAndTimeout(t *testing.T) {
+	t.Run("redirect", func(t *testing.T) {
+		redirected := 0
+		target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { redirected++ }))
+		defer target.Close()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+		executor := mustVaultKVMigrationExecutor(t, vaultMigrationSource("vault", server.URL, true))
+		result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+		if result.Outcome != "source_unavailable" || redirected != 0 {
+			t.Fatalf("redirect result=%#v followed=%d", result, redirected)
+		}
+	})
+
+	t.Run("oversize", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, strings.Repeat("x", 65)) }))
+		defer server.Close()
+		source := vaultMigrationSource("vault", server.URL, true)
+		mapping := source.Refs[vaultMigrationRef()]
+		mapping.MaxBytes = 64
+		source.Refs[vaultMigrationRef()] = mapping
+		executor := mustVaultKVMigrationExecutor(t, source)
+		if result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret}); result.Outcome != "source_unavailable" {
+			t.Fatalf("oversize result=%#v", result)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { time.Sleep(250 * time.Millisecond) }))
+		defer server.Close()
+		source := vaultMigrationSource("vault", server.URL, true)
+		mapping := source.Refs[vaultMigrationRef()]
+		mapping.TimeoutMs = 100
+		source.Refs[vaultMigrationRef()] = mapping
+		executor := mustVaultKVMigrationExecutor(t, source)
+		started := time.Now()
+		result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: vaultMigrationSecret})
+		if result.Outcome != "source_unavailable" || time.Since(started) > time.Second {
+			t.Fatalf("timeout result=%#v elapsed=%s", result, time.Since(started))
+		}
+	})
+}
+
+func TestVaultKVMigrationCASConflictIsTypedThroughMigrationAPI(t *testing.T) {
+	fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, version: 1, data: map[string]any{vaultMigrationMappedField: "old"}, forcePostStatus: http.StatusBadRequest}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	backend := managedTestBackend(t)
+	ref := vaultMigrationRef()
+	writeManagedTestSecret(t, backend, ref, vaultMigrationSecret)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{vaultMigrationSource("openbao", server.URL, true)}}
+	backend.configureProviderMigrationExecutors()
+	req := migrationPlanRequest{RequestID: "req-openbao-conflict", ServiceID: "@serviceadmin", OperationID: "openbao-cas-conflict", SourceProviderID: "local", TargetProviderID: "vault-migration-target", Refs: []string{ref}, Reason: "approved conflict proof", Confirm: true}
+	res, err := backend.migrationApply(req)
+	if err != nil || res.Outcome != "partial_failure" || res.Applied || len(res.Results) != 1 || res.Results[0].Outcome != "conflict" || res.Results[0].ExpectedAction != "refresh_target_version_and_retry" {
+		t.Fatalf("res=%#v err=%v", res, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, res), vaultMigrationSecret, vaultMigrationToken, vaultMigrationRemoteBody)
+	fixture.mu.Lock()
+	fixture.forcePostStatus = 0
+	fixture.mu.Unlock()
+	res, err = backend.migrationApply(req)
+	if err != nil || !res.Applied || res.Outcome != "applied" || !res.Results[0].Verified || res.Results[0].Attempts != 2 {
+		t.Fatalf("retried=%#v err=%v", res, err)
+	}
+}
+
+func vaultMigrationSource(kind, address string, enabled bool) sourceConfig {
+	return sourceConfig{
+		SourceID: "vault-migration-target", Kind: kind, DisplayName: "Vault migration target", Enabled: true, EnableMigrationTarget: enabled,
+		Address: address, Token: vaultMigrationToken,
+		Refs: map[string]sourceRefConfig{vaultMigrationRef(): {Path: vaultMigrationMappedPath, Field: vaultMigrationMappedField, TimeoutMs: 1000, MaxBytes: 4096}},
+	}
+}
+
+func vaultMigrationRef() string {
+	return "services/@serviceadmin/runtime/SESSION_SIGNING_KEY"
+}
+
+func mustVaultKVMigrationExecutor(t *testing.T, source sourceConfig) *vaultKVMigrationExecutor {
+	t.Helper()
+	executor, err := newVaultKVMigrationExecutor(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return executor
+}
+
+func providerStatusByID(t *testing.T, status providerConfigStatusResponse, providerID string) providerConfigStatus {
+	t.Helper()
+	for _, provider := range status.Providers {
+		if provider.ProviderID == providerID {
+			return provider
+		}
+	}
+	t.Fatalf("missing provider %s", providerID)
+	return providerConfigStatus{}
+}
+
+func migrationApplyMaturity(operations []OperationCapability) OperationMaturity {
+	for _, operation := range operations {
+		if operation.Path == "/v1/providers/migration/apply" {
+			return operation.Maturity
+		}
+	}
+	return OperationMaturityUnavailable
+}
+
+func assertVaultMigrationSourceUnchanged(t *testing.T, backend *localBackend, ref string) {
+	t.Helper()
+	resolved := backend.resolve(resolveRequest{RequestID: "req-vault-source-proof", ServiceID: "@serviceadmin", Purpose: "source recovery proof", Refs: []string{ref}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != vaultMigrationSecret {
+		t.Fatalf("source not recoverable: %#v", resolved.Results)
+	}
+}
+
+func assertVaultMigrationPersistenceRedacted(t *testing.T, backend *localBackend) {
+	t.Helper()
+	store, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, store, vaultMigrationSecret, vaultMigrationToken, vaultMigrationRemoteBody, vaultMigrationMappedPath)
+	assertNoSecretMaterial(t, audit, vaultMigrationSecret, vaultMigrationToken, vaultMigrationRemoteBody, vaultMigrationMappedPath)
+	if strings.Contains(string(store), filepath.Clean(vaultMigrationMappedPath)) {
+		t.Fatal("provider path leaked into durable operation state")
+	}
+}
+
+func TestVaultKVMigrationRequestBodyBoundIsEnforced(t *testing.T) {
+	fixture := &vaultKVProtocolFixture{token: vaultMigrationToken, data: map[string]any{}}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	source := vaultMigrationSource("vault", server.URL, true)
+	mapping := source.Refs[vaultMigrationRef()]
+	mapping.MaxBytes = 64
+	source.Refs[vaultMigrationRef()] = mapping
+	executor := mustVaultKVMigrationExecutor(t, source)
+	result := executor.Write(providerMigrationWriteRequest{Ref: vaultMigrationRef(), Value: strings.Repeat("s", 256)})
+	if result.Outcome != "invalid_ref" || fixture.postCount != 0 {
+		t.Fatalf("result=%#v posts=%d", result, fixture.postCount)
+	}
+	assertNoSecretMaterial(t, bytes.TrimSpace(mustManagedJSON(t, result)), strings.Repeat("s", 256), vaultMigrationToken)
+}

--- a/docs/operation-capability-manifest.md
+++ b/docs/operation-capability-manifest.md
@@ -85,16 +85,17 @@ machine-readable authority.
 | Policy preview | dry-run | dry-run | dry-run | unavailable |
 | Policy apply | planned | planned | planned | unavailable |
 | Migration dry-run | dry-run | dry-run | dry-run | dry-run |
-| Migration apply | planned | planned | planned | planned |
+| Migration apply | planned | validated* | planned | planned |
 | Secrets Sync dry-run | dry-run | dry-run | dry-run | dry-run |
 
+`validated*` applies only to a Vault/OpenBao connection whose source config
+explicitly sets `enableMigrationTarget: true` and passes address, auth and KV v2
+mapping validation. The family capability and every disabled/incomplete
+connection remain `planned`.
+
 The current provider configuration apply handler validates and reports an apply
-result but does not persist a connection. Migration apply has a durable,
-idempotent executor seam, but no real remote provider executor is registered in
-the release runtime; bulk campaign apply likewise does not mutate provider
-values. Those operations remain deliberately `planned`. A test-only or future
-explicit executor registration does not let Service Admin infer executable
-capability from the provider-family upper bound.
+result but does not persist a connection. AWS and bulk campaign apply do not yet
+mutate provider values. Provider-family upper bounds never authorize apply.
 
 ## Drift and conformance gates
 

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -145,9 +145,12 @@ inventory, provider readiness, and exact target capability. It then requires an
 explicit in-process executor registration for the selected provider id. Without
 that registration every target fails closed with `outcome: "unsupported"`,
 `applied: false`, and `nextAction: "implement_provider_operation_executor"`.
-Vault/OpenBao and AWS have no production executor registration in this release,
-so their operation manifest maturity remains `planned` and Service Admin must
-not enable apply from the family capability alone.
+Vault/OpenBao KV v2 sources can register the production executor only when the
+exact source sets `enableMigrationTarget: true` and its address, token/token env,
+and every ref path/field mapping pass validation. That connection reports
+validated migration apply. Disabled or incomplete Vault/OpenBao sources, AWS,
+and all provider-family upper bounds remain `planned`; Service Admin must not
+enable apply from those records.
 
 The executor seam receives an operation-scoped idempotency key and source value
 inside the Broker process. A ref is reported `migrated` only after a separate
@@ -155,6 +158,14 @@ target verification succeeds. Durable operation state contains only provider
 ids, refs, a plan fingerprint, typed outcomes, attempt counts and verification
 flags. It never contains a source value, credential, ciphertext copy, or remote
 response body.
+
+The Vault/OpenBao executor uses a bounded, no-redirect HTTP client. It performs
+an authenticated KV v2 read, preserves sibling fields, and writes with CAS 0 or
+the observed metadata version. A separately authenticated bounded readback must
+match before the operation is verified. HTTP 401/403/429, CAS conflicts,
+unavailable endpoints and readback mismatch become typed metadata-only results;
+the provider body, token, mapped provider path and transport error are not
+returned or persisted.
 
 An exact retry skips already verified refs. A retry after `partial_failure`
 resumes failed refs; a ref whose write succeeded but verification failed retries

--- a/docs/vault-openbao-source.md
+++ b/docs/vault-openbao-source.md
@@ -1,7 +1,7 @@
 # Vault and OpenBao Source Adapter
 
-Status: contract-backed adapter MVP
-Issue: #47
+Status: validated read adapter plus explicitly enabled KV v2 migration target
+Issues: #47, #146
 
 ## Purpose
 
@@ -25,6 +25,7 @@ Example:
       "kind": "vault",
       "displayName": "Vault prod",
       "enabled": true,
+      "enableMigrationTarget": true,
       "critical": false,
       "priority": 50,
       "namespaces": ["prod/*"],
@@ -52,14 +53,20 @@ OpenBao uses the same API shape for this MVP:
 Vault/OpenBao capability/status output follows the shared adapter contract in `docs/external-adapter-contract.md`:
 
 - `read` and `reveal` are implemented through bounded HTTP reads.
-- Legacy `write/update`, `rotate/reset`, `policy`, `audit`, and `migration`
-  strings describe the adapter contract and planning surface only.
-- Remote write, rotation, policy apply, and migration target apply still require a configured provider operation path before apply is allowed.
+- Migration target apply is validated only for the exact enabled connection when
+  `enableMigrationTarget: true`, address, token/token env, and every ref path and
+  field mapping pass local validation.
+- A disabled or incomplete connection remains planned/unsupported. The
+  provider-family capability is also still planning metadata and never enables
+  apply by itself.
+- General write/update, rotate/reset and policy apply remain unavailable or
+  planned; the executable mutation is limited to verified KV v2 migration.
 - `value-search` is intentionally not advertised for Vault/OpenBao.
 
 Service Admin must use the connection-scoped operation manifest. Vault/OpenBao
-read/reveal are validated, edit/migration/policy previews are dry-run or planned,
-and all current remote apply operations are unavailable or planned.
+read/reveal are validated. Migration apply is validated only on an explicitly
+enabled and fully configured connection; all other remote apply operations are
+unavailable or planned.
 
 ## Auth and backend state mapping
 
@@ -68,41 +75,51 @@ and all current remote apply operations are unavailable or planned.
 - HTTP 401/403 -> `source_auth_required` or `policy_denied`
 - HTTP 404 -> `missing_ref`
 - HTTP 400 -> `invalid_ref`
-- HTTP 429 or explicit rate-limit/degraded response -> `degraded`
+- HTTP 429 -> `rate_limited`
+- KV v2 CAS conflict (HTTP 400/409/412 on write) -> `conflict`
 - sealed response body (`{"sealed":true}` on a non-2xx response) -> `locked`
 - unreachable/5xx without sealed evidence -> `source_unavailable`
 - successful value -> `ready`
 
 `GET /v1/sources/status` reports configured Vault/OpenBao sources without returning tokens. It performs local config/auth-state classification only; it does not poll external clusters on every status request.
 
-## KV response shape
+## KV v2 migration protocol
 
-The MVP supports common KV v2 response shape:
-
-```json
-{
-  "data": {
-    "data": {
-      "api_key": "value"
-    }
-  }
-}
-```
-
-It also accepts a flat `data` object for lightweight OpenBao/Vault-compatible test doubles:
+Reads use the common KV v2 response shape, including metadata version for CAS:
 
 ```json
 {
   "data": {
-    "api_key": "value"
+    "data": { "api_key": "value" },
+    "metadata": { "version": 7 }
   }
 }
 ```
+
+The read-only source adapter also accepts a flat `data` object for lightweight
+compatibility. Migration target apply does not: it requires KV v2 metadata so it
+can write with a compare-and-set version.
+
+Before writing, the executor reads the current target. It preserves sibling
+fields, skips the POST when the mapped field is already equal, and otherwise
+POSTs `{data, options: {cas}}`. A separate bounded GET must return the expected
+field value before the durable operation is marked migrated. Source values are
+not deleted.
+
+The validated matrix for this release is the Vault/OpenBao KV v2 HTTP protocol
+implemented by bounded `httptest` protocol suites for both provider kinds.
+Live-cluster certification for named HashiCorp Vault and OpenBao product
+versions remains tracked by #134; this document does not claim a live version
+that has not been exercised with external credentials.
 
 ## Security notes
 
 - tokens are read from env or explicit source token only
 - tokens are not returned by status/capabilities/source status
+- authenticated requests never follow redirects
+- remote targets require HTTPS; plaintext HTTP is accepted only for loopback testing
+- request/response bodies and timeouts are bounded per mapping and capped by the Broker
+- remote bodies and transport errors are reduced to typed outcomes and never returned
 - resolved secret values are returned only through authenticated `POST /v1/resolve`
 - audit records include ref/source/outcome only
 
@@ -111,6 +128,6 @@ It also accepts a flat `data` object for lightweight OpenBao/Vault-compatible te
 - Vault login methods
 - token renewal/revoke
 - lease handling
-- write-back
+- general provider write-back outside verified migration
 - namespace auto-discovery
 - Service Admin reconnect UX


### PR DESCRIPTION
## Summary

- register a real Vault/OpenBao KV v2 migration executor only when the exact source explicitly sets `enableMigrationTarget: true`
- validate source address, auth and every KV v2 path/field mapping before registration
- use bounded no-redirect authenticated HTTP, require HTTPS outside loopback, preserve sibling fields and write with CAS
- skip an already-equal target, then independently read back and verify before marking migrated
- expose validated migration apply only on the registered connection while family/default capabilities remain planned
- map auth, policy, rate-limit, CAS, unavailable and verification failures to typed metadata-only outcomes

## Safety boundary

Source values cross only the in-process executor seam. Vault/OpenBao tokens, mapped provider paths, raw response bodies and raw transport errors are not returned or added to durable migration state/audit. Source entries remain unchanged and recoverable. AWS, other provider mutations, bulk campaigns and live product-version certification remain in #134.

## Validation

- `go test ./cmd/secretsbroker -run '^TestVaultKVMigration' -count=10`
- `go test ./...`
- `pwsh -NoLogo -NoProfile -File .\scripts\test.ps1`
- `go vet ./...`
- `go build ./cmd/secretsbroker ./cmd/secretsbroker-resolve`
- `go test ./cmd/secretsbroker -run '^TestContractArtefactsAreCurrent$' -count=1`
- `git diff --check`

Optional `go test -race` was unavailable on the Windows host because this Go environment has CGO disabled; the required suites above pass.

Closes #146
Parent: #134