### PR TITLE
feat(providers): execute verified AWS migrations

### DIFF
--- a/cmd/secretsbroker/aws_secrets_manager_executor.go
+++ b/cmd/secretsbroker/aws_secrets_manager_executor.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAWSSecretsManagerMigrationTimeout  = 3 * time.Second
+	maximumAWSSecretsManagerMigrationTimeout  = 30 * time.Second
+	defaultAWSSecretsManagerMigrationMaxBytes = 64 * 1024
+	maximumAWSSecretsManagerMigrationMaxBytes = 1024 * 1024
+)
+
+var awsEnvironmentNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type awsSecretsManagerMigrationExecutor struct {
+	source   sourceConfig
+	endpoint url.URL
+	client   *http.Client
+	now      func() time.Time
+}
+
+type awsSecretsManagerCredentials struct {
+	accessKeyID     string
+	secretAccessKey string
+	sessionToken    string
+}
+
+type awsSecretsManagerMigrationReadResult struct {
+	secretString string
+	outcome      string
+}
+
+type awsSecretsManagerPutSecretValueRequest struct {
+	ClientRequestToken string `json:"ClientRequestToken"`
+	SecretID           string `json:"SecretId"`
+	SecretString       string `json:"SecretString"`
+}
+
+func newAWSSecretsManagerMigrationExecutor(source sourceConfig) (*awsSecretsManagerMigrationExecutor, error) {
+	if !source.Enabled || !source.EnableMigrationTarget || !strings.EqualFold(strings.TrimSpace(source.Kind), "aws-secrets-manager") {
+		return nil, errors.New("AWS Secrets Manager migration target is not explicitly enabled")
+	}
+	if !validAWSSecretsManagerRegion(source.Region) {
+		return nil, errors.New("AWS Secrets Manager migration target region is invalid")
+	}
+	endpoint, err := validatedAWSSecretsManagerEndpoint(source)
+	if err != nil {
+		return nil, err
+	}
+	if !awsSecretsManagerCredentialHandlesConfigured(source) || !awsSecretsManagerCredentialsAvailable(source) {
+		return nil, errors.New("AWS Secrets Manager migration target authentication is missing")
+	}
+	if len(source.Refs) == 0 {
+		return nil, errors.New("AWS Secrets Manager migration target has no ref mappings")
+	}
+	for ref, mapping := range source.Refs {
+		if !validSecretRef(ref) || !validAWSSecretsManagerMigrationMapping(mapping) {
+			return nil, errors.New("AWS Secrets Manager migration target mapping is invalid")
+		}
+	}
+	return &awsSecretsManagerMigrationExecutor{
+		source:   source,
+		endpoint: endpoint,
+		client: &http.Client{
+			Timeout: maximumAWSSecretsManagerMigrationTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		now: func() time.Time { return time.Now().UTC() },
+	}, nil
+}
+
+func awsSecretsManagerCredentialHandlesConfigured(source sourceConfig) bool {
+	return awsEnvironmentNamePattern.MatchString(strings.TrimSpace(source.AccessKeyIDEnv)) &&
+		awsEnvironmentNamePattern.MatchString(strings.TrimSpace(source.SecretAccessKeyEnv)) &&
+		(strings.TrimSpace(source.SessionTokenEnv) == "" || awsEnvironmentNamePattern.MatchString(strings.TrimSpace(source.SessionTokenEnv)))
+}
+
+func awsSecretsManagerCredentialsAvailable(source sourceConfig) bool {
+	credentials := awsSecretsManagerCredentialsFromEnvironment(source)
+	return credentials.accessKeyID != "" && credentials.secretAccessKey != ""
+}
+
+func awsSecretsManagerCredentialsFromEnvironment(source sourceConfig) awsSecretsManagerCredentials {
+	return awsSecretsManagerCredentials{
+		accessKeyID:     strings.TrimSpace(os.Getenv(strings.TrimSpace(source.AccessKeyIDEnv))),
+		secretAccessKey: strings.TrimSpace(os.Getenv(strings.TrimSpace(source.SecretAccessKeyEnv))),
+		sessionToken:    strings.TrimSpace(os.Getenv(strings.TrimSpace(source.SessionTokenEnv))),
+	}
+}
+
+func validAWSSecretsManagerRegion(region string) bool {
+	region = strings.TrimSpace(region)
+	if len(region) < 3 || len(region) > 64 {
+		return false
+	}
+	for _, char := range region {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' {
+			return false
+		}
+	}
+	return !strings.HasPrefix(region, "-") && !strings.HasSuffix(region, "-")
+}
+
+func validatedAWSSecretsManagerEndpoint(source sourceConfig) (url.URL, error) {
+	address := strings.TrimSpace(source.Address)
+	if address == "" {
+		address = "https://secretsmanager." + strings.TrimSpace(source.Region) + ".amazonaws.com"
+	}
+	parsed, err := url.Parse(address)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return url.URL{}, errors.New("AWS Secrets Manager migration target address is invalid")
+	}
+	if parsed.Scheme == "http" && !awsSecretsManagerLoopbackHost(parsed.Hostname()) {
+		return url.URL{}, errors.New("AWS Secrets Manager migration target requires HTTPS outside loopback")
+	}
+	return url.URL{Scheme: parsed.Scheme, Host: parsed.Host, Path: "/"}, nil
+}
+
+func awsSecretsManagerLoopbackHost(host string) bool {
+	if strings.EqualFold(strings.TrimSpace(host), "localhost") {
+		return true
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsLoopback()
+}
+
+func validAWSSecretsManagerMigrationMapping(mapping sourceRefConfig) bool {
+	path := strings.TrimSpace(mapping.Path)
+	field := strings.TrimSpace(mapping.Field)
+	if path == "" || len(path) > 2048 || len(field) > 256 || strings.TrimSpace(mapping.VersionID) != "" {
+		return false
+	}
+	if stage := strings.TrimSpace(mapping.VersionStage); stage != "" && stage != "AWSCURRENT" {
+		return false
+	}
+	for _, value := range []string{path, field} {
+		for _, char := range value {
+			if char < 0x20 || char == 0x7f {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (e *awsSecretsManagerMigrationExecutor) Write(req providerMigrationWriteRequest) providerMigrationExecutorResult {
+	mapping, ok := e.source.Refs[req.Ref]
+	if !ok || !validAWSSecretsManagerMigrationMapping(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	current := e.read(mapping)
+	if current.outcome != "ready" {
+		if current.outcome == "missing_ref" {
+			return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+		}
+		return providerMigrationExecutorResult{Outcome: current.outcome}
+	}
+	secretString, alreadyEqual, outcome := awsSecretsManagerUpdatedSecretString(current.secretString, mapping.Field, req.Value)
+	if outcome != "ready" {
+		return providerMigrationExecutorResult{Outcome: outcome}
+	}
+	if alreadyEqual {
+		return providerMigrationExecutorResult{Outcome: "applied"}
+	}
+	payload, err := json.Marshal(awsSecretsManagerPutSecretValueRequest{
+		ClientRequestToken: awsSecretsManagerClientRequestToken(req),
+		SecretID:           strings.TrimSpace(mapping.Path),
+		SecretString:       secretString,
+	})
+	if err != nil || len(payload) > awsSecretsManagerMigrationMaxBytes(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	status, body, requestOutcome := e.request("secretsmanager.PutSecretValue", payload, mapping)
+	if requestOutcome != "ready" {
+		return providerMigrationExecutorResult{Outcome: requestOutcome}
+	}
+	if status < 200 || status >= 300 {
+		return providerMigrationExecutorResult{Outcome: awsSecretsManagerMigrationStatusOutcome(status, body, true)}
+	}
+	var response struct {
+		VersionID string `json:"VersionId"`
+	}
+	if len(body) == 0 || json.Unmarshal(body, &response) != nil || strings.TrimSpace(response.VersionID) == "" {
+		return providerMigrationExecutorResult{Outcome: "source_unavailable"}
+	}
+	return providerMigrationExecutorResult{Outcome: "applied"}
+}
+
+func (e *awsSecretsManagerMigrationExecutor) Verify(req providerMigrationVerifyRequest) providerMigrationExecutorResult {
+	mapping, ok := e.source.Refs[req.Ref]
+	if !ok || !validAWSSecretsManagerMigrationMapping(mapping) {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	current := e.read(mapping)
+	if current.outcome != "ready" {
+		if current.outcome == "missing_ref" || current.outcome == "invalid_ref" {
+			return providerMigrationExecutorResult{Outcome: "verification_failed"}
+		}
+		return providerMigrationExecutorResult{Outcome: current.outcome}
+	}
+	value, ok := awsSecretsManagerMigrationField(current.secretString, mapping.Field)
+	if !ok || value != req.ExpectedValue {
+		return providerMigrationExecutorResult{Outcome: "verification_failed"}
+	}
+	return providerMigrationExecutorResult{Outcome: "verified"}
+}
+
+func (e *awsSecretsManagerMigrationExecutor) read(mapping sourceRefConfig) awsSecretsManagerMigrationReadResult {
+	payload, err := json.Marshal(awsSecretsManagerGetSecretValueRequest{SecretID: strings.TrimSpace(mapping.Path), VersionStage: firstNonEmpty(strings.TrimSpace(mapping.VersionStage), "AWSCURRENT")})
+	if err != nil || len(payload) > awsSecretsManagerMigrationMaxBytes(mapping) {
+		return awsSecretsManagerMigrationReadResult{outcome: "invalid_ref"}
+	}
+	status, body, requestOutcome := e.request("secretsmanager.GetSecretValue", payload, mapping)
+	if requestOutcome != "ready" {
+		return awsSecretsManagerMigrationReadResult{outcome: requestOutcome}
+	}
+	if status < 200 || status >= 300 {
+		return awsSecretsManagerMigrationReadResult{outcome: awsSecretsManagerMigrationStatusOutcome(status, body, false)}
+	}
+	var response struct {
+		SecretString *string `json:"SecretString"`
+		VersionID    string  `json:"VersionId"`
+	}
+	if len(body) == 0 || json.Unmarshal(body, &response) != nil || response.SecretString == nil || strings.TrimSpace(response.VersionID) == "" {
+		return awsSecretsManagerMigrationReadResult{outcome: "source_unavailable"}
+	}
+	return awsSecretsManagerMigrationReadResult{secretString: *response.SecretString, outcome: "ready"}
+}
+
+func awsSecretsManagerUpdatedSecretString(current, field, value string) (string, bool, string) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return value, current == value, "ready"
+	}
+	data := map[string]any{}
+	if json.Unmarshal([]byte(current), &data) != nil || data == nil {
+		return "", false, "invalid_ref"
+	}
+	if existing, ok := data[field].(string); ok && existing == value {
+		return current, true, "ready"
+	}
+	data[field] = value
+	updated, err := json.Marshal(data)
+	if err != nil {
+		return "", false, "invalid_ref"
+	}
+	return string(updated), false, "ready"
+}
+
+func awsSecretsManagerMigrationField(secretString, field string) (string, bool) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return secretString, true
+	}
+	data := map[string]any{}
+	if json.Unmarshal([]byte(secretString), &data) != nil {
+		return "", false
+	}
+	value, ok := data[field].(string)
+	return value, ok
+}
+
+func awsSecretsManagerClientRequestToken(req providerMigrationWriteRequest) string {
+	material := strings.TrimSpace(req.IdempotencyKey)
+	if material == "" {
+		material = strings.Join([]string{req.OperationID, req.TargetProviderID, req.Ref}, "\n")
+	}
+	sum := sha256.Sum256([]byte(material))
+	return hex.EncodeToString(sum[:])
+}
+
+func (e *awsSecretsManagerMigrationExecutor) request(target string, body []byte, mapping sourceRefConfig) (int, []byte, string) {
+	credentials := awsSecretsManagerCredentialsFromEnvironment(e.source)
+	if credentials.accessKeyID == "" || credentials.secretAccessKey == "" {
+		return 0, nil, "source_auth_required"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), awsSecretsManagerMigrationTimeout(mapping))
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, "invalid_ref"
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", target)
+	awsSignSecretsManagerRequest(req, body, strings.TrimSpace(e.source.Region), credentials, e.now().UTC())
+	res, err := e.client.Do(req)
+	if err != nil {
+		return 0, nil, "source_unavailable"
+	}
+	defer res.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(res.Body, int64(awsSecretsManagerMigrationMaxBytes(mapping))+1))
+	if err != nil || len(responseBody) > awsSecretsManagerMigrationMaxBytes(mapping) {
+		return res.StatusCode, nil, "source_unavailable"
+	}
+	if res.StatusCode >= 300 && res.StatusCode < 400 {
+		return res.StatusCode, nil, "source_unavailable"
+	}
+	return res.StatusCode, responseBody, "ready"
+}
+
+func awsSignSecretsManagerRequest(req *http.Request, body []byte, region string, credentials awsSecretsManagerCredentials, now time.Time) {
+	amzDate := now.Format("20060102T150405Z")
+	date := now.Format("20060102")
+	payloadHash := sha256Hex(body)
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if credentials.sessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", credentials.sessionToken)
+	}
+	headers := map[string]string{
+		"content-type":         canonicalAWSHeaderValue(req.Header.Get("Content-Type")),
+		"host":                 strings.ToLower(req.URL.Host),
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date":           amzDate,
+		"x-amz-target":         canonicalAWSHeaderValue(req.Header.Get("X-Amz-Target")),
+	}
+	if credentials.sessionToken != "" {
+		headers["x-amz-security-token"] = canonicalAWSHeaderValue(credentials.sessionToken)
+	}
+	headerNames := make([]string, 0, len(headers))
+	for name := range headers {
+		headerNames = append(headerNames, name)
+	}
+	sort.Strings(headerNames)
+	var canonicalHeaders strings.Builder
+	for _, name := range headerNames {
+		canonicalHeaders.WriteString(name)
+		canonicalHeaders.WriteByte(':')
+		canonicalHeaders.WriteString(headers[name])
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(headerNames, ";")
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	canonicalRequest := strings.Join([]string{req.Method, canonicalURI, req.URL.Query().Encode(), canonicalHeaders.String(), signedHeaders, payloadHash}, "\n")
+	scope := strings.Join([]string{date, region, "secretsmanager", "aws4_request"}, "/")
+	stringToSign := strings.Join([]string{"AWS4-HMAC-SHA256", amzDate, scope, sha256Hex([]byte(canonicalRequest))}, "\n")
+	dateKey := awsHMAC([]byte("AWS4"+credentials.secretAccessKey), date)
+	regionKey := awsHMAC(dateKey, region)
+	serviceKey := awsHMAC(regionKey, "secretsmanager")
+	signingKey := awsHMAC(serviceKey, "aws4_request")
+	signature := hex.EncodeToString(awsHMAC(signingKey, stringToSign))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+credentials.accessKeyID+"/"+scope+", SignedHeaders="+signedHeaders+", Signature="+signature)
+}
+
+func canonicalAWSHeaderValue(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func sha256Hex(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+func awsHMAC(key []byte, value string) []byte {
+	hash := hmac.New(sha256.New, key)
+	_, _ = hash.Write([]byte(value))
+	return hash.Sum(nil)
+}
+
+func awsSecretsManagerMigrationStatusOutcome(status int, body []byte, write bool) string {
+	var payload struct {
+		Type string `json:"__type"`
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	errorType := strings.ToLower(firstNonEmpty(payload.Type, payload.Code))
+	switch {
+	case strings.Contains(errorType, "expiredtoken"), strings.Contains(errorType, "unrecognizedclient"), strings.Contains(errorType, "invalidclienttoken"), strings.Contains(errorType, "missingauthentication"):
+		return "source_auth_required"
+	case strings.Contains(errorType, "accessdenied"), strings.Contains(errorType, "notauthorized"):
+		return "policy_denied"
+	case strings.Contains(errorType, "throttl"), strings.Contains(errorType, "limitexceeded"):
+		return "rate_limited"
+	case strings.Contains(errorType, "resourceexists"), strings.Contains(errorType, "conflict"):
+		return "conflict"
+	case strings.Contains(errorType, "resourcenotfound"):
+		if write {
+			return "invalid_ref"
+		}
+		return "missing_ref"
+	case strings.Contains(errorType, "invalidrequest"), strings.Contains(errorType, "invalidparameter"):
+		return "invalid_ref"
+	case strings.Contains(errorType, "internalservice"), strings.Contains(errorType, "serviceunavailable"), strings.Contains(errorType, "decryptionfailure"):
+		return "source_unavailable"
+	}
+	switch status {
+	case http.StatusUnauthorized:
+		return "source_auth_required"
+	case http.StatusForbidden:
+		return "policy_denied"
+	case http.StatusTooManyRequests:
+		return "rate_limited"
+	case http.StatusConflict, http.StatusPreconditionFailed:
+		return "conflict"
+	case http.StatusNotFound:
+		if write {
+			return "invalid_ref"
+		}
+		return "missing_ref"
+	case http.StatusBadRequest:
+		return "invalid_ref"
+	}
+	if status >= 500 || status == http.StatusRequestTimeout || (status >= 300 && status < 400) {
+		return "source_unavailable"
+	}
+	return "invalid_ref"
+}
+
+func awsSecretsManagerMigrationTimeout(mapping sourceRefConfig) time.Duration {
+	timeout := time.Duration(firstPositive(mapping.TimeoutMs, int(defaultAWSSecretsManagerMigrationTimeout/time.Millisecond))) * time.Millisecond
+	if timeout < 100*time.Millisecond {
+		return 100 * time.Millisecond
+	}
+	if timeout > maximumAWSSecretsManagerMigrationTimeout {
+		return maximumAWSSecretsManagerMigrationTimeout
+	}
+	return timeout
+}
+
+func awsSecretsManagerMigrationMaxBytes(mapping sourceRefConfig) int {
+	limit := firstPositive(mapping.MaxBytes, firstPositive(mapping.MaxStdoutBytes, defaultAWSSecretsManagerMigrationMaxBytes))
+	if limit > maximumAWSSecretsManagerMigrationMaxBytes {
+		return maximumAWSSecretsManagerMigrationMaxBytes
+	}
+	return limit
+}

--- a/cmd/secretsbroker/aws_secrets_manager_executor_test.go
+++ b/cmd/secretsbroker/aws_secrets_manager_executor_test.go
@@ -1,0 +1,452 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	awsMigrationAccessKey   = "AWS_ACCESS_KEY_TEST_ONLY"
+	awsMigrationSecretKey   = "aws-secret-key-sentinel-test-only"
+	awsMigrationSession     = "aws-session-token-sentinel-test-only"
+	awsMigrationSecret      = "aws-migration-secret-sentinel"
+	awsMigrationRemoteBody  = "aws-remote-body-sentinel"
+	awsMigrationMappedField = "session_key"
+)
+
+var awsMigrationFixedTime = time.Date(2026, 8, 12, 10, 30, 0, 0, time.UTC)
+
+type awsSecretsManagerProtocolFixture struct {
+	mu                sync.Mutex
+	secretString      string
+	version           int
+	getCount          int
+	putCount          int
+	forceGetStatus    int
+	forceGetType      string
+	forcePutStatus    int
+	forcePutType      string
+	mismatchRead      bool
+	lastClientToken   string
+	lastSecretID      string
+	lastAmzDate       string
+	signatureFailures []string
+}
+
+func (f *awsSecretsManagerProtocolFixture) handler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	beforeSignatureFailures := len(f.signatureFailures)
+	f.validateSignature(r, body)
+	if len(f.signatureFailures) != beforeSignatureFailures {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"__type":"UnrecognizedClientException","message":"`+awsMigrationRemoteBody+`"}`)
+		return
+	}
+	target := r.Header.Get("X-Amz-Target")
+	switch target {
+	case "secretsmanager.GetSecretValue":
+		f.getCount++
+		if f.forceGetStatus != 0 {
+			w.WriteHeader(f.forceGetStatus)
+			fmt.Fprintf(w, `{"__type":%q,"message":%q}`, f.forceGetType, awsMigrationRemoteBody)
+			return
+		}
+		var request awsSecretsManagerGetSecretValueRequest
+		if json.Unmarshal(body, &request) != nil || request.SecretID != awsMigrationSecretID() || request.VersionStage != "AWSCURRENT" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		secretString := f.secretString
+		if f.mismatchRead {
+			secretString = `{"session_key":"different-remote-value","sibling":"preserve-me"}`
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:test", "Name": "test", "SecretString": secretString, "VersionId": fmt.Sprintf("version-%d", f.version)})
+	case "secretsmanager.PutSecretValue":
+		f.putCount++
+		if f.forcePutStatus != 0 {
+			w.WriteHeader(f.forcePutStatus)
+			fmt.Fprintf(w, `{"__type":%q,"message":%q}`, f.forcePutType, awsMigrationRemoteBody)
+			return
+		}
+		var request awsSecretsManagerPutSecretValueRequest
+		if json.Unmarshal(body, &request) != nil || request.SecretID != awsMigrationSecretID() || len(request.ClientRequestToken) != 64 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.lastClientToken = request.ClientRequestToken
+		f.lastSecretID = request.SecretID
+		f.secretString = request.SecretString
+		f.version++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:test", "Name": "test", "VersionId": fmt.Sprintf("version-%d", f.version)})
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+func (f *awsSecretsManagerProtocolFixture) validateSignature(r *http.Request, body []byte) {
+	if r.Method != http.MethodPost || r.Header.Get("Content-Type") != "application/x-amz-json-1.1" {
+		f.signatureFailures = append(f.signatureFailures, "method_or_content_type")
+		return
+	}
+	expected, err := http.NewRequest(http.MethodPost, "http://"+r.Host+r.URL.RequestURI(), bytes.NewReader(body))
+	if err != nil {
+		f.signatureFailures = append(f.signatureFailures, "request")
+		return
+	}
+	expected.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	expected.Header.Set("X-Amz-Target", r.Header.Get("X-Amz-Target"))
+	amzDate := r.Header.Get("X-Amz-Date")
+	f.lastAmzDate = amzDate
+	signedAt, parseErr := time.Parse("20060102T150405Z", amzDate)
+	if parseErr != nil {
+		f.signatureFailures = append(f.signatureFailures, "X-Amz-Date")
+		return
+	}
+	awsSignSecretsManagerRequest(expected, body, "us-east-1", awsSecretsManagerCredentials{accessKeyID: awsMigrationAccessKey, secretAccessKey: awsMigrationSecretKey, sessionToken: awsMigrationSession}, signedAt)
+	for _, header := range []string{"Authorization", "X-Amz-Date", "X-Amz-Content-Sha256", "X-Amz-Security-Token"} {
+		if r.Header.Get(header) != expected.Header.Get(header) {
+			f.signatureFailures = append(f.signatureFailures, header)
+		}
+	}
+}
+
+func TestAWSSecretsManagerMigrationExecutorUsesSigV4PreservesFieldsAndVerifies(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"sibling":"preserve-me","session_key":"old-value"}`, version: 7}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+	idempotencyKey := "aws-safe-idempotency-key"
+	write := executor.Write(providerMigrationWriteRequest{OperationID: "aws-write", IdempotencyKey: idempotencyKey, TargetProviderID: "aws-migration-target", Ref: awsMigrationRef(), Value: awsMigrationSecret})
+	if write.Outcome != "applied" {
+		t.Fatalf("write=%#v", write)
+	}
+	verified := executor.Verify(providerMigrationVerifyRequest{OperationID: "aws-write", IdempotencyKey: idempotencyKey, TargetProviderID: "aws-migration-target", Ref: awsMigrationRef(), ExpectedValue: awsMigrationSecret})
+	if verified.Outcome != "verified" {
+		t.Fatalf("verify=%#v", verified)
+	}
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	var remote map[string]any
+	if json.Unmarshal([]byte(fixture.secretString), &remote) != nil || remote["sibling"] != "preserve-me" || remote[awsMigrationMappedField] != awsMigrationSecret {
+		t.Fatalf("remote=%#v", remote)
+	}
+	if fixture.getCount != 2 || fixture.putCount != 1 || fixture.lastClientToken != awsSecretsManagerClientRequestToken(providerMigrationWriteRequest{IdempotencyKey: idempotencyKey}) || fixture.lastSecretID != awsMigrationSecretID() || fixture.lastAmzDate != awsMigrationFixedTime.Format("20060102T150405Z") || len(fixture.signatureFailures) != 0 {
+		t.Fatalf("fixture=%#v", fixture)
+	}
+}
+
+func TestAWSSignSecretsManagerRequestMatchesFixedSigV4Vector(t *testing.T) {
+	body := []byte(`{"SecretId":"service-lasso/prod/serviceadmin","VersionStage":"AWSCURRENT"}`)
+	req, err := http.NewRequest(http.MethodPost, "https://secretsmanager.us-east-1.amazonaws.com/", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "secretsmanager.GetSecretValue")
+	awsSignSecretsManagerRequest(req, body, "us-east-1", awsSecretsManagerCredentials{accessKeyID: awsMigrationAccessKey, secretAccessKey: awsMigrationSecretKey, sessionToken: awsMigrationSession}, awsMigrationFixedTime)
+	wantAuthorization := "AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_TEST_ONLY/20260812/us-east-1/secretsmanager/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-target, Signature=47692711d5ccd17779369cc749b412c0a712737e9ed8243caf004c3e5942d65d"
+	if req.Header.Get("Authorization") != wantAuthorization || req.Header.Get("X-Amz-Date") != "20260812T103000Z" || req.Header.Get("X-Amz-Content-Sha256") != "05b121ded35812be1474595b325f9cb14f6ed11dd44957169f8c04d6030d94e5" || req.Header.Get("X-Amz-Security-Token") != awsMigrationSession {
+		t.Fatalf("signed headers=%#v", req.Header)
+	}
+}
+
+func TestAWSSecretsManagerMigrationExecutorAlreadyEqualSkipsWrite(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"sibling":"preserve-me","session_key":"` + awsMigrationSecret + `"}`, version: 3}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+	result := executor.Write(providerMigrationWriteRequest{IdempotencyKey: "safe-key", Ref: awsMigrationRef(), Value: awsMigrationSecret})
+	if result.Outcome != "applied" || fixture.putCount != 0 || fixture.getCount != 1 {
+		t.Fatalf("result=%#v get=%d put=%d", result, fixture.getCount, fixture.putCount)
+	}
+}
+
+func TestAWSSecretsManagerMigrationApplyIsConnectionScopedVerifiedAndRestartSafe(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"sibling":"preserve-me","session_key":"old"}`, version: 1}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	backend := managedTestBackend(t)
+	ref := awsMigrationRef()
+	writeManagedTestSecret(t, backend, ref, awsMigrationSecret)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{awsMigrationSource(server.URL, true)}}
+	backend.configureProviderMigrationExecutors()
+	provider := providerStatusByID(t, backend.providerConfigStatusResponse(), "aws-migration-target")
+	if migrationApplyMaturity(provider.Operations) != OperationMaturityValidated || migrationApplyMaturity(providerCapabilitiesByKind("aws-secrets-manager").Operations) != OperationMaturityPlanned {
+		t.Fatalf("connection operations=%#v family=%#v", provider.Operations, providerCapabilitiesByKind("aws-secrets-manager").Operations)
+	}
+	req := migrationPlanRequest{RequestID: "req-aws-migration", ServiceID: "@serviceadmin", OperationID: "aws-migration-operation", SourceProviderID: "local", TargetProviderID: "aws-migration-target", Refs: []string{ref}, Reason: "approved AWS migration", Confirm: true}
+	applied, err := backend.migrationApply(req)
+	if err != nil || !applied.Applied || applied.Outcome != "applied" || len(applied.Results) != 1 || !applied.Results[0].Verified {
+		t.Fatalf("applied=%#v err=%v", applied, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), awsMigrationSecret, awsMigrationAccessKey, awsMigrationSecretKey, awsMigrationSession, awsMigrationRemoteBody, awsMigrationSecretID())
+	assertAWSMigrationSourceUnchanged(t, backend, ref)
+	fixture.mu.Lock()
+	getCount, putCount := fixture.getCount, fixture.putCount
+	fixture.mu.Unlock()
+
+	restarted := newLocalBackend(backend.storePath, backend.auditPath, backend.masterKey)
+	restarted.sources = backend.sources
+	restarted.configureProviderMigrationExecutors()
+	retried, err := restarted.migrationApply(req)
+	if err != nil || !retried.Applied || retried.Outcome != "applied" {
+		t.Fatalf("retried=%#v err=%v", retried, err)
+	}
+	fixture.mu.Lock()
+	if fixture.getCount != getCount || fixture.putCount != putCount {
+		t.Fatalf("restart retry repeated remote calls: before=%d/%d after=%d/%d", getCount, putCount, fixture.getCount, fixture.putCount)
+	}
+	fixture.mu.Unlock()
+	assertAWSMigrationPersistenceRedacted(t, restarted)
+}
+
+func TestAWSSecretsManagerMigrationApplyRetriesVerificationWithoutDuplicateWrite(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"sibling":"preserve-me","session_key":"old"}`, version: 1, mismatchRead: true}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	backend := managedTestBackend(t)
+	ref := awsMigrationRef()
+	writeManagedTestSecret(t, backend, ref, awsMigrationSecret)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{awsMigrationSource(server.URL, true)}}
+	backend.configureProviderMigrationExecutors()
+	req := migrationPlanRequest{RequestID: "req-aws-verification-retry", ServiceID: "@serviceadmin", OperationID: "aws-verification-retry", SourceProviderID: "local", TargetProviderID: "aws-migration-target", Refs: []string{ref}, Reason: "approved AWS verification retry", Confirm: true}
+	failed, err := backend.migrationApply(req)
+	if err != nil || failed.Outcome != "partial_failure" || failed.Applied || len(failed.Results) != 1 || failed.Results[0].Outcome != "verification_failed" || failed.Results[0].Attempts != 1 {
+		t.Fatalf("failed=%#v err=%v", failed, err)
+	}
+	fixture.mu.Lock()
+	if fixture.putCount != 1 {
+		t.Fatalf("initial writes=%d", fixture.putCount)
+	}
+	fixture.mismatchRead = false
+	fixture.mu.Unlock()
+	retried, err := backend.migrationApply(req)
+	if err != nil || !retried.Applied || retried.Outcome != "applied" || !retried.Results[0].Verified || retried.Results[0].Attempts != 1 {
+		t.Fatalf("retried=%#v err=%v", retried, err)
+	}
+	fixture.mu.Lock()
+	if fixture.putCount != 1 {
+		t.Fatalf("verification retry duplicated write: %d", fixture.putCount)
+	}
+	fixture.mu.Unlock()
+	assertAWSMigrationPersistenceRedacted(t, backend)
+}
+
+func TestAWSSecretsManagerMigrationExecutorRefreshesCredentialsPerOperation(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"session_key":"old"}`, version: 1}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+	t.Setenv("AWS_MIGRATION_SECRET_ACCESS_KEY", "rotated-invalid-key")
+	if result := executor.Write(providerMigrationWriteRequest{Ref: awsMigrationRef(), Value: awsMigrationSecret}); result.Outcome != "source_auth_required" {
+		t.Fatalf("stale credential result=%#v", result)
+	}
+	t.Setenv("AWS_MIGRATION_SECRET_ACCESS_KEY", awsMigrationSecretKey)
+	if result := executor.Write(providerMigrationWriteRequest{Ref: awsMigrationRef(), Value: awsMigrationSecret}); result.Outcome != "applied" {
+		t.Fatalf("refreshed credential result=%#v", result)
+	}
+	t.Setenv("AWS_MIGRATION_ACCESS_KEY_ID", "")
+	if result := executor.Verify(providerMigrationVerifyRequest{Ref: awsMigrationRef(), ExpectedValue: awsMigrationSecret}); result.Outcome != "source_auth_required" {
+		t.Fatalf("missing credential result=%#v", result)
+	}
+}
+
+func TestAWSSecretsManagerMigrationRegistrationFailsClosedUnlessFullyConfigured(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	for _, test := range []struct {
+		name   string
+		mutate func(*sourceConfig)
+		want   string
+	}{
+		{name: "disabled capability", mutate: func(source *sourceConfig) { source.EnableMigrationTarget = false }, want: "source_auth_required"},
+		{name: "missing credential handle", mutate: func(source *sourceConfig) { source.SecretAccessKeyEnv = "" }, want: "source_auth_required"},
+		{name: "missing credential value", mutate: func(source *sourceConfig) { source.SecretAccessKeyEnv = "AWS_MIGRATION_MISSING_SECRET" }, want: "source_auth_required"},
+		{name: "unsafe address", mutate: func(source *sourceConfig) { source.Address = "https://user:password@aws.invalid/path?credential=value" }, want: "invalid_ref"},
+		{name: "remote plaintext HTTP", mutate: func(source *sourceConfig) { source.Address = "http://aws.invalid" }, want: "invalid_ref"},
+		{name: "invalid mapping", mutate: func(source *sourceConfig) {
+			source.Refs[awsMigrationRef()] = sourceRefConfig{Path: "secret", VersionID: "immutable-version"}
+		}, want: "invalid_ref"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := managedTestBackend(t)
+			source := awsMigrationSource("https://aws.invalid", true)
+			test.mutate(&source)
+			backend.sources = sourceConfigFile{Sources: []sourceConfig{source}}
+			backend.configureProviderMigrationExecutors()
+			if _, ok := backend.providerMigrationExecutor(source.SourceID); ok {
+				t.Fatal("invalid or disabled source registered an executor")
+			}
+			registry := defaultSourceRegistry(backend)
+			if len(registry.Sources) != 2 || registry.Sources[1].Outcome != test.want || migrationApplyMaturity(registry.Sources[1].Operations) == OperationMaturityValidated {
+				t.Fatalf("source status=%#v", registry.Sources)
+			}
+		})
+	}
+}
+
+func TestAWSSecretsManagerMigrationExecutorMapsRemoteFailuresWithoutLeakingBodies(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	for _, test := range []struct {
+		name       string
+		status     int
+		errorType  string
+		writeError bool
+		want       string
+	}{
+		{name: "expired auth", status: http.StatusBadRequest, errorType: "ExpiredTokenException", want: "source_auth_required"},
+		{name: "policy", status: http.StatusForbidden, errorType: "AccessDeniedException", want: "policy_denied"},
+		{name: "rate limit", status: http.StatusBadRequest, errorType: "ThrottlingException", want: "rate_limited"},
+		{name: "unavailable", status: http.StatusServiceUnavailable, errorType: "InternalServiceError", want: "source_unavailable"},
+		{name: "version conflict", status: http.StatusBadRequest, errorType: "ResourceExistsException", writeError: true, want: "conflict"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := &awsSecretsManagerProtocolFixture{secretString: `{"session_key":"old"}`, version: 1}
+			if test.writeError {
+				fixture.forcePutStatus, fixture.forcePutType = test.status, test.errorType
+			} else {
+				fixture.forceGetStatus, fixture.forceGetType = test.status, test.errorType
+			}
+			server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+			defer server.Close()
+			executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+			result := executor.Write(providerMigrationWriteRequest{IdempotencyKey: "safe-key", Ref: awsMigrationRef(), Value: awsMigrationSecret})
+			if result.Outcome != test.want {
+				t.Fatalf("result=%#v", result)
+			}
+			assertNoSecretMaterial(t, mustManagedJSON(t, result), awsMigrationSecret, awsMigrationAccessKey, awsMigrationSecretKey, awsMigrationSession, awsMigrationRemoteBody, awsMigrationSecretID())
+		})
+	}
+}
+
+func TestAWSSecretsManagerMigrationExecutorVerificationMismatchIsTyped(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	fixture := &awsSecretsManagerProtocolFixture{secretString: `{"session_key":"old"}`, version: 1, mismatchRead: true}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handler))
+	defer server.Close()
+	executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+	result := executor.Verify(providerMigrationVerifyRequest{Ref: awsMigrationRef(), ExpectedValue: awsMigrationSecret})
+	if result.Outcome != "verification_failed" {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestAWSSecretsManagerMigrationExecutorRejectsRedirectOversizeAndTimeout(t *testing.T) {
+	setAWSMigrationEnvironment(t)
+	t.Run("redirect", func(t *testing.T) {
+		redirected := 0
+		target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { redirected++ }))
+		defer target.Close()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+		}))
+		defer server.Close()
+		executor := mustAWSSecretsManagerMigrationExecutor(t, awsMigrationSource(server.URL, true))
+		result := executor.Write(providerMigrationWriteRequest{Ref: awsMigrationRef(), Value: awsMigrationSecret})
+		if result.Outcome != "source_unavailable" || redirected != 0 {
+			t.Fatalf("result=%#v redirected=%d", result, redirected)
+		}
+	})
+
+	t.Run("oversize", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, strings.Repeat("x", 129)) }))
+		defer server.Close()
+		source := awsMigrationSource(server.URL, true)
+		mapping := source.Refs[awsMigrationRef()]
+		mapping.MaxBytes = 128
+		source.Refs[awsMigrationRef()] = mapping
+		executor := mustAWSSecretsManagerMigrationExecutor(t, source)
+		if result := executor.Write(providerMigrationWriteRequest{Ref: awsMigrationRef(), Value: awsMigrationSecret}); result.Outcome != "source_unavailable" {
+			t.Fatalf("result=%#v", result)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { time.Sleep(250 * time.Millisecond) }))
+		defer server.Close()
+		source := awsMigrationSource(server.URL, true)
+		mapping := source.Refs[awsMigrationRef()]
+		mapping.TimeoutMs = 100
+		source.Refs[awsMigrationRef()] = mapping
+		executor := mustAWSSecretsManagerMigrationExecutor(t, source)
+		started := time.Now()
+		result := executor.Write(providerMigrationWriteRequest{Ref: awsMigrationRef(), Value: awsMigrationSecret})
+		if result.Outcome != "source_unavailable" || time.Since(started) > time.Second {
+			t.Fatalf("result=%#v elapsed=%s", result, time.Since(started))
+		}
+	})
+}
+
+func setAWSMigrationEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_MIGRATION_ACCESS_KEY_ID", awsMigrationAccessKey)
+	t.Setenv("AWS_MIGRATION_SECRET_ACCESS_KEY", awsMigrationSecretKey)
+	t.Setenv("AWS_MIGRATION_SESSION_TOKEN", awsMigrationSession)
+}
+
+func awsMigrationSource(address string, enabled bool) sourceConfig {
+	return sourceConfig{
+		SourceID: "aws-migration-target", Kind: "aws-secrets-manager", DisplayName: "AWS migration target", Enabled: true, EnableMigrationTarget: enabled,
+		Address: address, Region: "us-east-1", AccessKeyIDEnv: "AWS_MIGRATION_ACCESS_KEY_ID", SecretAccessKeyEnv: "AWS_MIGRATION_SECRET_ACCESS_KEY", SessionTokenEnv: "AWS_MIGRATION_SESSION_TOKEN",
+		Refs: map[string]sourceRefConfig{awsMigrationRef(): {Path: awsMigrationSecretID(), Field: awsMigrationMappedField, VersionStage: "AWSCURRENT", TimeoutMs: 1000, MaxBytes: 4096}},
+	}
+}
+
+func awsMigrationRef() string {
+	return "services/@serviceadmin/runtime/AWS_SESSION_KEY"
+}
+
+func awsMigrationSecretID() string {
+	return "service-lasso/prod/serviceadmin"
+}
+
+func mustAWSSecretsManagerMigrationExecutor(t *testing.T, source sourceConfig) *awsSecretsManagerMigrationExecutor {
+	t.Helper()
+	executor, err := newAWSSecretsManagerMigrationExecutor(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executor.now = func() time.Time { return awsMigrationFixedTime }
+	return executor
+}
+
+func assertAWSMigrationSourceUnchanged(t *testing.T, backend *localBackend, ref string) {
+	t.Helper()
+	resolved := backend.resolve(resolveRequest{RequestID: "req-aws-source-proof", ServiceID: "@serviceadmin", Purpose: "source recovery proof", Refs: []string{ref}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Outcome != "ready" || resolved.Results[0].Value != awsMigrationSecret {
+		t.Fatalf("source not recoverable: %#v", resolved.Results)
+	}
+}
+
+func assertAWSMigrationPersistenceRedacted(t *testing.T, backend *localBackend) {
+	t.Helper()
+	store, err := os.ReadFile(backend.storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit, err := os.ReadFile(backend.auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecretMaterial(t, store, awsMigrationSecret, awsMigrationAccessKey, awsMigrationSecretKey, awsMigrationSession, awsMigrationRemoteBody, awsMigrationSecretID())
+	assertNoSecretMaterial(t, audit, awsMigrationSecret, awsMigrationAccessKey, awsMigrationSecretKey, awsMigrationSession, awsMigrationRemoteBody, awsMigrationSecretID())
+}

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -37,6 +37,9 @@ type sourceConfig struct {
 	Address               string                     `json:"address"`
 	Region                string                     `json:"region"`
 	AccountID             string                     `json:"accountId"`
+	AccessKeyIDEnv        string                     `json:"accessKeyIdEnv,omitempty"`
+	SecretAccessKeyEnv    string                     `json:"secretAccessKeyEnv,omitempty"`
+	SessionTokenEnv       string                     `json:"sessionTokenEnv,omitempty"`
 	Token                 string                     `json:"token"`
 	TokenEnv              string                     `json:"tokenEnv"`
 	Refs                  map[string]sourceRefConfig `json:"refs"`

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -158,6 +158,15 @@ func sourceRegistryLifecycle(source sourceConfig) SourceLifecycle {
 		if strings.TrimSpace(source.Address) == "" && strings.TrimSpace(source.Region) == "" {
 			return normalizeSourceLifecycle("invalid_ref")
 		}
+		if source.EnableMigrationTarget {
+			if !awsSecretsManagerCredentialHandlesConfigured(source) || !awsSecretsManagerCredentialsAvailable(source) {
+				return normalizeSourceLifecycle("source_auth_required")
+			}
+			if _, err := newAWSSecretsManagerMigrationExecutor(source); err != nil {
+				return normalizeSourceLifecycle("invalid_ref")
+			}
+			break
+		}
 		if strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv))) == "" {
 			return normalizeSourceLifecycle("source_auth_required")
 		}

--- a/cmd/secretsbroker/vault_kv_executor.go
+++ b/cmd/secretsbroker/vault_kv_executor.go
@@ -41,7 +41,16 @@ func (b *localBackend) configureProviderMigrationExecutors() {
 		if !source.EnableMigrationTarget {
 			continue
 		}
-		executor, err := newVaultKVMigrationExecutor(source)
+		var executor providerMigrationExecutor
+		var err error
+		switch strings.ToLower(strings.TrimSpace(source.Kind)) {
+		case "vault", "openbao":
+			executor, err = newVaultKVMigrationExecutor(source)
+		case "aws-secrets-manager":
+			executor, err = newAWSSecretsManagerMigrationExecutor(source)
+		default:
+			continue
+		}
 		if err != nil {
 			continue
 		}

--- a/docs/aws-secrets-manager-source.md
+++ b/docs/aws-secrets-manager-source.md
@@ -4,8 +4,9 @@
 
 The connection-scoped operation manifest is authoritative for action
 enablement. Read/reveal and metadata-only value search are validated; rotation
-planning is dry-run; remote edit, reset, rotation, policy, migration, and sync
-apply paths are not currently executable.
+planning is dry-run. Migration apply becomes validated only for an exact source
+that explicitly enables and fully configures the production migration executor.
+Remote edit, reset, rotation, policy, and sync apply remain non-executable.
 
 ## Source config
 
@@ -34,13 +35,62 @@ AWS sources use the same `SECRETSBROKER_SOURCES_PATH` config as other external a
 
 `address` may be set for tests or local AWS-compatible mocks. If `address` is omitted, `region` is used to derive the Secrets Manager endpoint. Tests use fake tokens and fake secret strings only.
 
+The read-adapter fixture above is retained for compatibility. A production
+migration target must instead add explicit signing credential handles and opt in:
+
+```json
+{
+  "sourceId": "aws-prod",
+  "kind": "aws-secrets-manager",
+  "enabled": true,
+  "enableMigrationTarget": true,
+  "region": "us-east-1",
+  "accessKeyIdEnv": "AWS_ACCESS_KEY_ID",
+  "secretAccessKeyEnv": "AWS_SECRET_ACCESS_KEY",
+  "sessionTokenEnv": "AWS_SESSION_TOKEN",
+  "refs": {
+    "prod/openclaw/api_key": {
+      "path": "service-lasso/prod/api",
+      "field": "api_key",
+      "versionStage": "AWSCURRENT"
+    }
+  }
+}
+```
+
+These fields are environment-variable names, not credential values. The Broker
+resolves the access key, secret access key, and optional session token for every
+provider operation so rotated session credentials take effect without
+persisting them. Missing handles or values fail closed and migration apply stays
+planned. Custom non-loopback endpoints require HTTPS; redirects are never
+followed.
+
+## Validated migration operation matrix
+
+| Provider protocol | Operation | Local evidence | Release status |
+| --- | --- | --- | --- |
+| AWS Secrets Manager JSON 1.1, SigV4 service `secretsmanager` | `PutSecretValue` with deterministic `ClientRequestToken` | fixed-clock signed `httptest` protocol fixture | validated for a fully configured connection |
+| AWS Secrets Manager JSON 1.1, SigV4 service `secretsmanager` | independent `GetSecretValue` at `AWSCURRENT` | signed readback, value comparison, retry/restart tests | validated for a fully configured connection |
+
+The executor migrates into an existing Secrets Manager secret; it does not call
+`CreateSecret`. A field mapping requires the current `SecretString` to be a JSON
+object and preserves sibling fields. An empty field mapping replaces the entire
+`SecretString`. The write uses a stable 64-character request token derived from
+the Broker's durable per-ref idempotency key, and an independently authenticated
+readback must match before the ref is reported migrated. Source data remains
+unchanged and recoverable throughout.
+
+This matrix is deterministic local protocol evidence only. It does not claim
+live AWS account, IAM-policy, endpoint-version, or cloud certification proof.
+
 ## Failure mapping
 
 - missing token or auth identity -> `source_auth_required`
-- expired identity -> `identity_expired`
+- expired identity -> `identity_expired` for read; `source_auth_required` for migration retry
 - access denied -> `policy_denied`
 - missing secret id or field -> `missing_ref`
-- throttling or rate limits -> `degraded`
+- throttling or rate limits during migration -> `rate_limited`
+- duplicate request-token/version conflicts -> `conflict`
 - invalid request or mapping -> `invalid_ref`
 - timeout, unavailable endpoint, oversized response, or malformed payload -> `source_unavailable`
 

--- a/docs/operation-capability-manifest.md
+++ b/docs/operation-capability-manifest.md
@@ -85,7 +85,7 @@ machine-readable authority.
 | Policy preview | dry-run | dry-run | dry-run | unavailable |
 | Policy apply | planned | planned | planned | unavailable |
 | Migration dry-run | dry-run | dry-run | dry-run | dry-run |
-| Migration apply | planned | validated* | planned | planned |
+| Migration apply | planned | validated* | validated** | planned |
 | Secrets Sync dry-run | dry-run | dry-run | dry-run | dry-run |
 
 `validated*` applies only to a Vault/OpenBao connection whose source config
@@ -93,9 +93,15 @@ explicitly sets `enableMigrationTarget: true` and passes address, auth and KV v2
 mapping validation. The family capability and every disabled/incomplete
 connection remain `planned`.
 
+`validated**` applies only to an AWS Secrets Manager connection whose source
+config explicitly sets `enableMigrationTarget: true` and passes region,
+endpoint, SigV4 credential-handle, credential-availability, and ref mapping
+validation. The family capability and every disabled/incomplete connection
+remain `planned`.
+
 The current provider configuration apply handler validates and reports an apply
-result but does not persist a connection. AWS and bulk campaign apply do not yet
-mutate provider values. Provider-family upper bounds never authorize apply.
+result but does not persist a connection. Bulk campaign apply does not yet use
+the provider executor layer. Provider-family upper bounds never authorize apply.
 
 ## Drift and conformance gates
 

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -145,12 +145,12 @@ inventory, provider readiness, and exact target capability. It then requires an
 explicit in-process executor registration for the selected provider id. Without
 that registration every target fails closed with `outcome: "unsupported"`,
 `applied: false`, and `nextAction: "implement_provider_operation_executor"`.
-Vault/OpenBao KV v2 sources can register the production executor only when the
-exact source sets `enableMigrationTarget: true` and its address, token/token env,
-and every ref path/field mapping pass validation. That connection reports
-validated migration apply. Disabled or incomplete Vault/OpenBao sources, AWS,
-and all provider-family upper bounds remain `planned`; Service Admin must not
-enable apply from those records.
+Vault/OpenBao KV v2 and AWS Secrets Manager sources can register a production
+executor only when the exact source sets `enableMigrationTarget: true` and its
+provider-specific endpoint, authentication handles, and every ref mapping pass
+validation. That connection reports validated migration apply. Disabled or
+incomplete sources and all provider-family upper bounds remain `planned`;
+Service Admin must not enable apply from those records.
 
 The executor seam receives an operation-scoped idempotency key and source value
 inside the Broker process. A ref is reported `migrated` only after a separate
@@ -166,6 +166,18 @@ match before the operation is verified. HTTP 401/403/429, CAS conflicts,
 unavailable endpoints and readback mismatch become typed metadata-only results;
 the provider body, token, mapped provider path and transport error are not
 returned or persisted.
+
+The AWS executor uses the AWS Secrets Manager JSON 1.1 protocol with SigV4
+authentication resolved from configured environment-variable handles for every
+operation. It performs a signed `GetSecretValue`, preserves JSON sibling fields
+when a field is mapped, then calls `PutSecretValue` with a deterministic
+`ClientRequestToken`. A separate signed `GetSecretValue` at `AWSCURRENT` must
+match before verification succeeds. The client rejects redirects, requires
+HTTPS outside loopback, and bounds time and bodies. Missing/expired auth, policy
+denial, throttling, service unavailability, request-token conflict, invalid
+mapping, and readback mismatch become typed metadata-only outcomes. The locally
+validated matrix is documented in `aws-secrets-manager-source.md`; no live AWS
+account or IAM certification is claimed.
 
 An exact retry skips already verified refs. A retry after `partial_failure`
 resumes failed refs; a ref whose write succeeded but verification failed retries


### PR DESCRIPTION
## Summary

- register AWS Secrets Manager migration apply only for an exact source with `enableMigrationTarget: true`, valid endpoint/region/ref mappings, and available credential environment handles
- execute genuine AWS JSON 1.1 `PutSecretValue` requests signed with SigV4, using a deterministic 64-character `ClientRequestToken`
- perform a separate signed `GetSecretValue` verification before durable migration state becomes verified
- preserve mapped JSON sibling fields, converge without a duplicate write when the target already matches, and reuse the merged durable retry/restart seam
- fail closed with typed metadata-only auth, policy, rate-limit, conflict, unavailable, invalid-ref, and verification outcomes
- document the exact locally validated AWS operation matrix and the remaining live-cloud/bulk boundary

## Safety

- credentials are configured by environment-variable names and resolved per operation
- missing/rotated credentials fail closed; disabled/incomplete connections remain planned
- non-loopback HTTP and redirects are rejected; request time and bodies are bounded
- values, access keys, secret keys, session tokens, mapped provider paths, raw response bodies, and transport errors are not returned or persisted
- source entries remain unchanged until and after independent target verification

## Evidence

- fixed SigV4 vector validates payload hash, credential scope, signed headers, and exact signature
- `httptest` AWS JSON protocol fixture validates `GetSecretValue`, `PutSecretValue`, session-token signing, deterministic request token, field preservation, and readback
- exact restart retry makes no additional remote call
- verification retry makes no duplicate write
- missing/expired auth, policy denial, throttling, unavailable service, request-token conflict, readback mismatch, redirect, timeout, and oversized body are covered
- source recovery and metadata-only store/audit/API responses are asserted

## Validation

- `go test ./cmd/secretsbroker -run 'TestAWSSecretsManagerMigration|TestAWSSignSecretsManagerRequest' -count=10`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./cmd/secretsbroker -run 'Contract|OpenAPI|OperationManifest' -count=1`
- `./scripts/test.ps1`
- `git diff --check`

This is deterministic local protocol evidence only. It does not claim live AWS account, IAM-policy, endpoint-version, or cloud certification proof. Bulk campaign integration remains open, so parent #134 stays open.

Closes #148
Parent: #134