### PR TITLE
feat(providers): persist provider config and enable local migration apply

### DIFF
--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -63,6 +63,8 @@ type localBackend struct {
 	providerMigrationMu      sync.Mutex
 	providerExecutorMu       sync.RWMutex
 	providerExecutors        map[string]providerMigrationExecutor
+	sourcesPath              string
+	sourcesMu                sync.Mutex
 	wrapperProvider          keyWrapperProvider
 	wrapperContextOverride   *wrapperContext
 	eventMu                  sync.RWMutex
@@ -266,14 +268,19 @@ type auditEvent struct {
 
 func newLocalBackend(storePath, auditPath, masterKey string) *localBackend {
 	stateRoot := filepath.Dir(storePath)
-	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), wrapperPath: filepath.Join(stateRoot, "secretsbroker-wrapper.json"), backupRoot: filepath.Join(stateRoot, "backups"), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, telemetry: newTelemetryRequestRecorder(50), seenLaunchLeaseJTI: map[string]time.Time{}, providerExecutors: map[string]providerMigrationExecutor{}}
+	backend := &localBackend{storePath: storePath, auditPath: auditPath, eventPath: defaultEventsPath(auditPath), wrapperPath: filepath.Join(stateRoot, "secretsbroker-wrapper.json"), backupRoot: filepath.Join(stateRoot, "backups"), masterKey: masterKey, now: func() time.Time { return time.Now().UTC() }, campaigns: map[string]bulkCampaignResponse{}, telemetry: newTelemetryRequestRecorder(50), seenLaunchLeaseJTI: map[string]time.Time{}, providerExecutors: map[string]providerMigrationExecutor{}, sourcesPath: defaultSourcesPath(storePath)}
 	backend.lockouts = newLockoutStore(func() time.Time {
 		if backend.now == nil {
 			return time.Now().UTC()
 		}
 		return backend.now()
 	})
+	backend.configureProviderMigrationExecutors()
 	return backend
+}
+
+func defaultSourcesPath(storePath string) string {
+	return filepath.Join(filepath.Dir(storePath), "sources.json")
 }
 
 func defaultStorePath() string { return filepath.Join("data", "secretsbroker-store.json") }

--- a/cmd/secretsbroker/local_store_migration_executor.go
+++ b/cmd/secretsbroker/local_store_migration_executor.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"time"
+)
+
+// localStoreMigrationExecutor copies values inside the Broker process. Write and
+// Verify use the encrypted local store only and never return secret material.
+type localStoreMigrationExecutor struct {
+	backend *localBackend
+}
+
+func (b *localBackend) registerLocalStoreMigrationExecutor() {
+	if b == nil {
+		return
+	}
+	executor := &localStoreMigrationExecutor{backend: b}
+	b.registerProviderMigrationExecutor("local", executor)
+	b.registerProviderMigrationExecutor("local-encrypted-store", executor)
+}
+
+func (e *localStoreMigrationExecutor) Write(req providerMigrationWriteRequest) providerMigrationExecutorResult {
+	if e == nil || e.backend == nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	if e.backend.locked() {
+		return providerMigrationExecutorResult{Outcome: "locked"}
+	}
+	ref := strings.TrimSpace(req.Ref)
+	if !validSecretRef(ref) || req.Value == "" {
+		return providerMigrationExecutorResult{Outcome: "invalid_ref"}
+	}
+	store, err := e.backend.loadStore()
+	if err != nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	now := e.backend.now()
+	if store.KeyID == "" {
+		store.KeyID = masterKeyID(e.backend.masterKey)
+	}
+	if store.KeyVersion == "" {
+		store.KeyVersion = masterKeyVersion
+	}
+	payload, err := e.backend.encrypt(req.Value)
+	if err != nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	metadata := SecretMetadata{
+		SourceID:  localStoreSource,
+		Version:   now.Format(time.RFC3339Nano),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if existing, ok := store.Secrets[ref]; ok {
+		metadata.CreatedAt = existing.Metadata.CreatedAt
+	}
+	store.Secrets[ref] = secretEntry{Ref: ref, Metadata: metadata, Payload: payload}
+	store.UpdatedAt = now
+	if err := e.backend.saveStore(store); err != nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	return providerMigrationExecutorResult{Outcome: "applied"}
+}
+
+func (e *localStoreMigrationExecutor) Verify(req providerMigrationVerifyRequest) providerMigrationExecutorResult {
+	if e == nil || e.backend == nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	store, err := e.backend.loadStore()
+	if err != nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	entry, ok := store.Secrets[strings.TrimSpace(req.Ref)]
+	if !ok {
+		return providerMigrationExecutorResult{Outcome: "verification_failed"}
+	}
+	value, err := e.backend.decrypt(entry.Payload)
+	if err != nil {
+		return providerMigrationExecutorResult{Outcome: "degraded"}
+	}
+	if value != req.ExpectedValue {
+		return providerMigrationExecutorResult{Outcome: "verification_failed"}
+	}
+	return providerMigrationExecutorResult{Outcome: "verified"}
+}

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -415,11 +415,16 @@ func serve(args []string) error {
 	}
 	backend.eventPath = eventsPathValue
 	backend.launchIdentitySigningKey = strings.TrimSpace(*launchIdentitySigningKey)
-	sources, err := loadSourceConfig(*sourcesPath)
+	sourcesFile := strings.TrimSpace(*sourcesPath)
+	if sourcesFile == "" {
+		sourcesFile = defaultSourcesPath(*storePath)
+	}
+	sources, err := loadSourceConfig(sourcesFile)
 	if err != nil {
 		return err
 	}
 	backend.sources = sources
+	backend.sourcesPath = sourcesFile
 	backend.configureProviderMigrationExecutors()
 
 	binding, err := resolveServeTransport(serveTransportOptions{

--- a/cmd/secretsbroker/operation_manifest.go
+++ b/cmd/secretsbroker/operation_manifest.go
@@ -151,7 +151,7 @@ func defaultOperationManifest() []OperationCapability {
 		manifestOperation(http.MethodPost, "/v1/management/lifecycle/key/rotate", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "broker_generated_key_and_wrapper_refresh"),
 		manifestOperation(http.MethodPost, "/v1/management/lockouts/clear", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, nil, "scoped_lockout_only"),
 		manifestOperation(http.MethodPost, "/v1/providers/config/validate", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "configuration_validation_only"),
-		manifestOperation(http.MethodPost, "/v1/providers/config/apply", OperationMaturityPlanned, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "configuration_not_persisted"),
+		manifestOperation(http.MethodPost, "/v1/providers/config/apply", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "persisted_source_registry"),
 		manifestOperation(http.MethodPost, "/v1/providers/migration/dry-run", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "local_target_only"),
 		manifestOperation(http.MethodPost, "/v1/providers/migration/apply", OperationMaturityPlanned, OperationClassificationMutation, true, true, true, OperationScopeMixed, providers, "registered_provider_executor_required"),
 		manifestOperation(http.MethodGet, "/v1/management/secrets", OperationMaturityReadOnly, OperationClassificationRead, true, false, false, OperationScopeMixed, providers, "metadata_only"),

--- a/cmd/secretsbroker/provider_config_migration.go
+++ b/cmd/secretsbroker/provider_config_migration.go
@@ -169,7 +169,6 @@ func (b *localBackend) providerConfigStatusResponse() providerConfigStatusRespon
 
 func providerStatusFromSource(source SourceStatus, backend *localBackend) providerConfigStatus {
 	credential := ""
-	address := ""
 	if source.Kind == "vault" || source.Kind == "openbao" || source.Kind == "bitwarden-bws" || source.Kind == "aws-secrets-manager" {
 		credential = "configured-ref-or-env"
 	}
@@ -182,7 +181,19 @@ func providerStatusFromSource(source SourceStatus, backend *localBackend) provid
 	auditStatus := firstNonEmpty(source.AuditStatus, "audit_available")
 	operations := providerOperationCapabilitiesForSource(source.Kind, source.Lifecycle, auditStatus)
 	operations = backend.connectionProviderOperations(source.SourceID, source.Lifecycle, auditStatus, operations)
-	return providerConfigStatus{ProviderID: source.SourceID, ProviderKind: source.Kind, DisplayName: source.DisplayName, State: source.State, Outcome: source.Outcome, CredentialHandle: credential, Address: address, Namespaces: safeList(source.Namespaces), Capabilities: providerCapabilitiesByKind(source.Kind).Capabilities, Operations: operations, NextAction: source.NextAction, AuditStatus: auditStatus}
+	return providerConfigStatus{ProviderID: source.SourceID, ProviderKind: source.Kind, DisplayName: source.DisplayName, State: source.State, Outcome: source.Outcome, CredentialHandle: credential, Address: providerAddressForSource(source, backend), Namespaces: safeList(source.Namespaces), Capabilities: providerCapabilitiesByKind(source.Kind).Capabilities, Operations: operations, NextAction: source.NextAction, AuditStatus: auditStatus}
+}
+
+func providerAddressForSource(source SourceStatus, backend *localBackend) string {
+	if backend == nil {
+		return ""
+	}
+	for _, configured := range backend.sources.Sources {
+		if configured.SourceID == source.SourceID {
+			return safeProviderAddress(configured.Address)
+		}
+	}
+	return ""
 }
 
 func (b *localBackend) validateProviderConfig(req providerConfigRequest) (providerConfigActionResponse, error) {
@@ -212,12 +223,80 @@ func (b *localBackend) applyProviderConfig(req providerConfigRequest) (providerC
 		res.NextAction = "confirm_with_operation_id_and_audit_reason"
 		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errPolicyDenied)
 	}
-	res.Outcome = "unsupported"
-	res.Applied = false
+	if b.locked() {
+		res.Outcome = "locked"
+		res.Applied = false
+		res.NextAction = "unlock_broker"
+		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errLocked)
+	}
+	if strings.EqualFold(strings.TrimSpace(req.ProviderID), "local") || strings.EqualFold(strings.TrimSpace(req.ProviderKind), "local-encrypted-store") {
+		res.Outcome = "invalid_ref"
+		res.Applied = false
+		res.NextAction = "select_supported_provider"
+		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errInvalidRef)
+	}
+	source := providerSourceFromValidatedRequest(req, status)
+	if err := b.persistProviderSource(source); err != nil {
+		res.Outcome = "degraded"
+		res.Applied = false
+		res.NextAction = "retry_or_inspect_source"
+		return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errBackendDegraded)
+	}
+	res.Applied = true
 	res.RequiresConfirmation = false
-	res.NextAction = "implement_persisted_provider_configuration"
-	res.UnsupportedCapability = "provider_configuration_persistence"
-	return b.finalizeProviderConfigAudit("provider_config_apply", req, res, errUnsupportedProvider)
+	res.Outcome = "ready"
+	res.NextAction = "inspect_provider_status"
+	res.Provider = b.lookupProvider(req.ProviderID)
+	return b.finalizeProviderConfigAudit("provider_config_apply", req, res, nil)
+}
+
+func providerSourceFromValidatedRequest(req providerConfigRequest, status providerConfigStatus) sourceConfig {
+	source := sourceConfig{
+		SourceID:      strings.TrimSpace(req.ProviderID),
+		Kind:          strings.TrimSpace(req.ProviderKind),
+		DisplayName:   firstNonEmpty(req.DisplayName, firstNonEmpty(status.DisplayName, req.ProviderKind)),
+		Enabled:       true,
+		Address:       status.Address,
+		Namespaces:    status.Namespaces,
+		CredentialRef: strings.TrimSpace(req.CredentialRef),
+	}
+	if providerCredentialEnvName(req.CredentialRef) {
+		source.TokenEnv = strings.TrimSpace(req.CredentialRef)
+		source.CredentialRef = ""
+	}
+	return source
+}
+
+func (b *localBackend) persistProviderSource(source sourceConfig) error {
+	if b == nil {
+		return errBackendDegraded
+	}
+	path := strings.TrimSpace(b.sourcesPath)
+	if path == "" {
+		path = defaultSourcesPath(b.storePath)
+		b.sourcesPath = path
+	}
+	b.sourcesMu.Lock()
+	defer b.sourcesMu.Unlock()
+	current := b.sources
+	replaced := false
+	for index, existing := range current.Sources {
+		if existing.SourceID == source.SourceID {
+			current.Sources[index] = source
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		current.Sources = append(current.Sources, source)
+	}
+	if err := saveSourceConfig(path, current); err != nil {
+		return err
+	}
+	current.Security = inspectSourceConfigSecurity(path)
+	b.sources = current
+	b.configureProviderMigrationExecutors()
+	return nil
 }
 
 func (b *localBackend) finalizeProviderConfigAudit(operation string, req providerConfigRequest, res providerConfigActionResponse, operationErr error) (providerConfigActionResponse, error) {

--- a/cmd/secretsbroker/provider_config_migration_test.go
+++ b/cmd/secretsbroker/provider_config_migration_test.go
@@ -100,7 +100,7 @@ func TestProviderConfigAddressMetadataStripsCredentialAndRequestDetails(t *testi
 	}
 }
 
-func TestProviderConfigApplyRequiresConfirmationAndNeverClaimsUnpersistedSuccess(t *testing.T) {
+func TestProviderConfigApplyPersistsMetadataOnlySourceRegistry(t *testing.T) {
 	backend := managedTestBackend(t)
 	req := providerConfigRequest{RequestID: "req-apply", ServiceID: "@serviceadmin", ProviderID: "vault-prod", ProviderKind: "vault", Address: "https://vault.example.invalid", CredentialRef: "secret://local/provider/vault-prod/token"}
 
@@ -112,16 +112,27 @@ func TestProviderConfigApplyRequiresConfirmationAndNeverClaimsUnpersistedSuccess
 	req.Confirm = true
 	req.Reason = "operator approved provider migration setup"
 	req.OperationID = "provider-config-2026-05-08-a"
-	unsupported, err := backend.applyProviderConfig(req)
-	if !errors.Is(err, errUnsupportedProvider) || unsupported.Applied || unsupported.Outcome != "unsupported" || unsupported.UnsupportedCapability != "provider_configuration_persistence" || unsupported.NextAction != "implement_persisted_provider_configuration" || unsupported.AuditStatus != "audit_recorded" {
-		t.Fatalf("unpersisted provider apply = %#v err=%v", unsupported, err)
+	applied, err := backend.applyProviderConfig(req)
+	if err != nil || !applied.Applied || applied.Outcome != "ready" || applied.Provider.ProviderID != req.ProviderID || applied.AuditStatus != "audit_recorded" {
+		t.Fatalf("persisted provider apply = %#v err=%v", applied, err)
 	}
+	found := false
 	for _, provider := range backend.providerConfigStatusResponse().Providers {
 		if provider.ProviderID == req.ProviderID {
-			t.Fatalf("planned provider configuration was unexpectedly persisted: %#v", provider)
+			found = true
+			if provider.Address != "https://vault.example.invalid" || strings.Contains(string(mustManagedJSON(t, provider)), providerCredentialValue) {
+				t.Fatalf("persisted provider status leaked or missed address: %#v", provider)
+			}
 		}
 	}
-	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), providerCredentialValue)
+	if !found {
+		t.Fatalf("applied provider was not present in status: %#v", backend.providerConfigStatusResponse())
+	}
+	persisted, err := os.ReadFile(backend.sourcesPath)
+	if err != nil || !strings.Contains(string(persisted), `"sourceId": "vault-prod"`) || strings.Contains(strings.ToLower(string(persisted)), providerCredentialValue) {
+		t.Fatalf("sources.json persist = %s err=%v", persisted, err)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), providerCredentialValue)
 }
 
 func TestProviderConfigValidationAndApplyFailClosedWhenAuditUnavailable(t *testing.T) {
@@ -168,11 +179,24 @@ func TestMigrationDryRunMetadataOnlyPartialDenialAndApplyGating(t *testing.T) {
 		t.Fatalf("unconfirmed migration apply should fail closed: %#v err=%v", blocked, err)
 	}
 
-	unsupported, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local", Confirm: true, Reason: "approved migration"})
-	if !errors.Is(err, errUnsupportedProvider) || unsupported.Applied || unsupported.Outcome != "unsupported" || unsupported.NextAction != "implement_provider_operation_executor" || len(unsupported.Results) != 2 {
-		t.Fatalf("non-executable migration apply = %#v err=%v", unsupported, err)
+	applied, err := backend.migrationApply(migrationPlanRequest{RequestID: "req-migrate-apply", ServiceID: "@serviceadmin", OperationID: "migration-op-a", SourceProviderID: "local", TargetProviderID: "local", Confirm: true, Reason: "approved migration"})
+	if err != nil || applied.Outcome != "partial_failure" || applied.Applied || len(applied.Results) != 2 {
+		t.Fatalf("local migration apply = %#v err=%v", applied, err)
 	}
-	assertNoSecretMaterial(t, mustManagedJSON(t, unsupported), managedSecretValue, "deny-value-fixture")
+	migrated := false
+	denied := false
+	for _, item := range applied.Results {
+		if item.Ref == "services/@serviceadmin/runtime/SESSION_SIGNING_KEY" && item.Outcome == "migrated" {
+			migrated = true
+		}
+		if item.Ref == "services/deny/runtime/DENY_ME" && item.Outcome == "policy_denied" {
+			denied = true
+		}
+	}
+	if !migrated || !denied {
+		t.Fatalf("local migration apply results = %#v", applied.Results)
+	}
+	assertNoSecretMaterial(t, mustManagedJSON(t, applied), managedSecretValue, "deny-value-fixture")
 }
 
 func TestMigrationUnsupportedTargetAndLockedFailClosed(t *testing.T) {
@@ -391,7 +415,7 @@ func TestProviderConfigMigrationHTTPContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	applyPayload := readClose(t, applyRes.Body)
-	if applyRes.StatusCode != http.StatusNotImplemented || !bytes.Contains(applyPayload, []byte(`"outcome":"unsupported"`)) || !bytes.Contains(applyPayload, []byte(`"applied":false`)) {
+	if applyRes.StatusCode != http.StatusOK || !bytes.Contains(applyPayload, []byte(`"outcome":"ready"`)) || !bytes.Contains(applyPayload, []byte(`"applied":true`)) {
 		t.Fatalf("provider apply code=%d body=%s", applyRes.StatusCode, applyPayload)
 	}
 	assertNoSecretMaterial(t, applyPayload, providerCredentialValue, "test-token")
@@ -425,7 +449,7 @@ func TestProviderConfigMigrationHTTPContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	migrationApplyPayload := readClose(t, migrationApplyRes.Body)
-	if migrationApplyRes.StatusCode != http.StatusNotImplemented || !bytes.Contains(migrationApplyPayload, []byte(`"outcome":"unsupported"`)) || !bytes.Contains(migrationApplyPayload, []byte(`"applied":false`)) {
+	if migrationApplyRes.StatusCode != http.StatusOK || !bytes.Contains(migrationApplyPayload, []byte(`"applied":true`)) {
 		t.Fatalf("migration apply code=%d body=%s", migrationApplyRes.StatusCode, migrationApplyPayload)
 	}
 	assertNoSecretMaterial(t, migrationApplyPayload, managedSecretValue, "test-token")

--- a/cmd/secretsbroker/provider_operation_executor.go
+++ b/cmd/secretsbroker/provider_operation_executor.go
@@ -240,10 +240,18 @@ func (b *localBackend) executeProviderMigration(req migrationPlanRequest, target
 }
 
 func (b *localBackend) persistProviderMigrationOperation(store *localStoreFile, operation *providerMigrationOperation) error {
+	current, err := b.loadStore()
+	if err != nil {
+		return err
+	}
 	operation.UpdatedAt = b.now()
-	store.Migrations[operation.OperationID] = *operation
-	store.UpdatedAt = operation.UpdatedAt
-	return b.saveStore(*store)
+	if current.Migrations == nil {
+		current.Migrations = map[string]providerMigrationOperation{}
+	}
+	current.Migrations[operation.OperationID] = *operation
+	current.UpdatedAt = operation.UpdatedAt
+	*store = current
+	return b.saveStore(current)
 }
 
 func (b *localBackend) localMigrationSourceValue(store localStoreFile, sourceProviderID, ref string) (string, string) {

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -40,8 +40,9 @@ type sourceConfig struct {
 	AccessKeyIDEnv        string                     `json:"accessKeyIdEnv,omitempty"`
 	SecretAccessKeyEnv    string                     `json:"secretAccessKeyEnv,omitempty"`
 	SessionTokenEnv       string                     `json:"sessionTokenEnv,omitempty"`
-	Token                 string                     `json:"token"`
-	TokenEnv              string                     `json:"tokenEnv"`
+	Token                 string                     `json:"token,omitempty"`
+	TokenEnv              string                     `json:"tokenEnv,omitempty"`
+	CredentialRef         string                     `json:"credentialRef,omitempty"`
 	Refs                  map[string]sourceRefConfig `json:"refs"`
 }
 
@@ -86,6 +87,36 @@ func loadSourceConfig(path string) (sourceConfigFile, error) {
 	}
 	cfg.Security = security
 	return cfg, nil
+}
+
+func saveSourceConfig(path string, cfg sourceConfigFile) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("source config path is required")
+	}
+	payload, err := json.MarshalIndent(struct {
+		Sources []sourceConfig `json:"sources"`
+	}{Sources: cfg.Sources}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writePrivateFileAtomically(path, payload)
+}
+
+func providerCredentialEnvName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for index, runeValue := range value {
+		if index == 0 && (runeValue < 'A' || runeValue > 'Z') {
+			return false
+		}
+		if (runeValue < 'A' || runeValue > 'Z') && (runeValue < '0' || runeValue > '9') && runeValue != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 func (cfg sourceConfigFile) enabledSources() []sourceConfig {

--- a/cmd/secretsbroker/source_registry.go
+++ b/cmd/secretsbroker/source_registry.go
@@ -68,6 +68,9 @@ func defaultSourceRegistry(backend *localBackend) SourceRegistry {
 		AffectedServices: []string{},
 	}
 	localStatus.Operations = providerOperationCapabilitiesForSource(localStatus.Kind, localStatus.Lifecycle, localStatus.AuditStatus)
+	if backend != nil {
+		localStatus.Operations = backend.connectionProviderOperations(localStatus.SourceID, localStatus.Lifecycle, localStatus.AuditStatus, localStatus.Operations)
+	}
 	sources := []SourceStatus{localStatus}
 	if backend != nil {
 		for _, source := range backend.sources.Sources {

--- a/cmd/secretsbroker/vault_kv_executor.go
+++ b/cmd/secretsbroker/vault_kv_executor.go
@@ -37,6 +37,7 @@ func (b *localBackend) configureProviderMigrationExecutors() {
 	if b == nil {
 		return
 	}
+	b.registerLocalStoreMigrationExecutor()
 	for _, source := range b.sources.enabledSources() {
 		if !source.EnableMigrationTarget {
 			continue

--- a/conformance/fixtures/contract-states.json
+++ b/conformance/fixtures/contract-states.json
@@ -609,7 +609,7 @@
             "operationId": "postv1_providers_config_apply",
             "method": "POST",
             "path": "/v1/providers/config/apply",
-            "maturity": "planned",
+            "maturity": "validated",
             "classification": "mutation",
             "authenticationRequired": true,
             "policyRequired": true,
@@ -627,9 +627,9 @@
               "onepassword-cli"
             ],
             "completionMode": "synchronous",
-            "limitationCode": "configuration_not_persisted",
-            "reasonCode": "planning_only_not_executable",
-            "nextAction": "do_not_enable_apply"
+            "limitationCode": "persisted_source_registry",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
           },
           {
             "operationId": "postv1_providers_migration_dry_run",

--- a/contract/v1/openapi.json
+++ b/contract/v1/openapi.json
@@ -7638,7 +7638,7 @@
           "operationId": "postv1_providers_config_apply",
           "method": "POST",
           "path": "/v1/providers/config/apply",
-          "maturity": "planned",
+          "maturity": "validated",
           "classification": "mutation",
           "authenticationRequired": true,
           "policyRequired": true,
@@ -7656,9 +7656,9 @@
             "onepassword-cli"
           ],
           "completionMode": "synchronous",
-          "limitationCode": "configuration_not_persisted",
-          "reasonCode": "planning_only_not_executable",
-          "nextAction": "do_not_enable_apply"
+          "limitationCode": "persisted_source_registry",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
         }
       }
     },

--- a/docs/provider-configuration-migration-api.md
+++ b/docs/provider-configuration-migration-api.md
@@ -84,15 +84,14 @@ Request:
 }
 ```
 
-### `POST /v1/providers/config/apply` (planned)
+### `POST /v1/providers/config/apply`
 
-The current handler validates confirmation, operation id and audit reason, but
-it does not persist provider configuration. A fully authorized request therefore
-fails closed with `outcome: "unsupported"`, `applied: false`,
-`unsupportedCapability: "provider_configuration_persistence"`, and
-`nextAction: "implement_persisted_provider_configuration"`. Its manifest
-maturity is `planned`; clients must not enable it as an executable configuration
-action or interpret it as a successful mutation.
+Persists provider configuration into the source registry as metadata-only
+handles. A fully authorized request with `confirm: true`, `operationId`, and an
+audit `reason` writes `sourceId`, kind, address origin, namespaces, and
+`credentialRef` or `tokenEnv`. It never stores plaintext credentials or
+`credentialValue`. Manifest maturity is `validated`; clients may enable the
+configuration action after those controls succeed.
 
 ### `POST /v1/providers/migration/dry-run`
 
@@ -138,12 +137,14 @@ sink cannot accept the record, the response fails closed with
 also marked `audit_unavailable`; provider credentials, source values, and raw
 provider bodies are never returned.
 
-### `POST /v1/providers/migration/apply` (executor-gated; advertised as planned)
+### `POST /v1/providers/migration/apply` (executor-gated)
 
 The handler validates confirmation, operation id, audit reason, selected-source
-inventory, provider readiness, and exact target capability. It then requires an
-explicit in-process executor registration for the selected provider id. Without
-that registration every target fails closed with `outcome: "unsupported"`,
+inventory, provider readiness, and exact target capability. Local encrypted-store
+targets register an in-process copy executor, so local-to-local apply is
+validated after those controls succeed. Remote targets still require an explicit
+in-process executor registration for the selected provider id. Without that
+registration every remote target fails closed with `outcome: "unsupported"`,
 `applied: false`, and `nextAction: "implement_provider_operation_executor"`.
 Vault/OpenBao KV v2 and AWS Secrets Manager sources can register a production
 executor only when the exact source sets `enableMigrationTarget: true` and its


### PR DESCRIPTION
## Summary
- Persist confirmed provider configuration into the source registry as metadata-only handles (`credentialRef` / `tokenEnv`, never plaintext credentials).
- Advertise `POST /v1/providers/config/apply` as validated.
- Register an in-process local encrypted-store migration executor so local-to-local apply is executable after confirmation and audit.

Closes #134

## Test plan
- [x] Targeted `go test` for provider config, local migration apply, operation manifest, and contract artefacts
- [ ] Apply a Vault provider config and confirm it appears in `GET /v1/providers/config/status` without credential material
- [ ] Confirm local-to-local migration apply after dry-run + confirm