### PR TITLE
feat(kv): OpenBao-compatible KV v2 facade

### DIFF
--- a/cmd/secretsbroker/contract_artifacts_test.go
+++ b/cmd/secretsbroker/contract_artifacts_test.go
@@ -62,6 +62,12 @@ func contractRoutes() []contractRoute {
 		{Method: http.MethodPost, Path: "/v1/secrets", Summary: "Write a local secret", Auth: true, Request: writeSecretRequest{}, Response: writeSecretResponse{}},
 		{Method: http.MethodPost, Path: "/v1/writeback", Summary: "Capture a generated secret", Auth: true, Request: generatedSecretCaptureRequest{}, Response: generatedSecretCaptureResponse{}},
 		{Method: http.MethodPost, Path: "/v1/resolve", Summary: "Resolve a batch of secret references", Auth: true, Request: resolveRequest{}, Response: resolveResponse{}},
+		{Method: http.MethodGet, Path: "/v1/kv/data/{path}", Summary: "Read OpenBao-compatible KV v2 secret data", Auth: true, Response: kvDataResponse{}, Query: kvContractQueryParameters(true, false)},
+		{Method: http.MethodPost, Path: "/v1/kv/data/{path}", Summary: "Write OpenBao-compatible KV v2 secret data", Auth: true, Request: kvWriteEnvelope{}, Response: kvWriteResponse{}, Query: kvContractQueryParameters(false, false)},
+		{Method: http.MethodPatch, Path: "/v1/kv/data/{path}", Summary: "Patch OpenBao-compatible KV v2 secret data", Auth: true, Request: kvWriteEnvelope{}, Response: kvWriteResponse{}, Query: kvContractQueryParameters(false, false)},
+		{Method: http.MethodGet, Path: "/v1/kv/metadata/{path}", Summary: "Read or list OpenBao-compatible KV v2 metadata", Auth: true, Response: kvMetadataResponse{}, Query: kvContractQueryParameters(false, true)},
+		{Method: http.MethodPost, Path: "/v1/kv/delete/{path}", Summary: "Soft-delete OpenBao-compatible KV v2 versions", Auth: true, Request: kvVersionSelectRequest{}, Response: kvNoContentResponse{}, Query: kvContractQueryParameters(false, false)},
+		{Method: http.MethodPost, Path: "/v1/kv/undelete/{path}", Summary: "Undelete OpenBao-compatible KV v2 versions", Auth: true, Request: kvVersionSelectRequest{}, Response: kvNoContentResponse{}, Query: kvContractQueryParameters(false, false)},
 		{Method: http.MethodGet, Path: "/v1/provisioning/status", Summary: "List generated-secret provisioning status", Auth: true, Response: provisioningStatusResponse{}, Query: []contractQueryParameter{{Name: "search", Type: "string"}, {Name: "ref", Type: "string"}}},
 		{Method: http.MethodPost, Path: "/v1/provisioning/operations/plan", Summary: "Plan a provisioning operation", Auth: true, Request: provisioningOperationRequest{}, Response: provisioningOperationResponse{}},
 		{Method: http.MethodPost, Path: "/v1/provisioning/operations/apply", Summary: "Apply a provisioning operation", Auth: true, Request: provisioningOperationRequest{}, Response: provisioningOperationResponse{}},
@@ -111,6 +117,20 @@ func contractRoutes() []contractRoute {
 		managedAction("/v1/management/secrets/policy/preview", "Preview a managed secret policy change"),
 		managedAction("/v1/management/secrets/policy/apply", "Apply a managed secret policy change"),
 	}
+}
+
+func kvContractQueryParameters(includeVersion, includeList bool) []contractQueryParameter {
+	params := []contractQueryParameter{
+		{Name: "source", Type: "string"},
+		{Name: "mount", Type: "string"},
+	}
+	if includeVersion {
+		params = append(params, contractQueryParameter{Name: "version", Type: "integer"})
+	}
+	if includeList {
+		params = append(params, contractQueryParameter{Name: "list", Type: "string"})
+	}
+	return params
 }
 
 func eventContractQueryParameters() []contractQueryParameter {

--- a/cmd/secretsbroker/kv_v2.go
+++ b/cmd/secretsbroker/kv_v2.go
@@ -1,0 +1,844 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	kvV2MaxVersions     = 10
+	kvV2DefaultMount    = "secret"
+	kvV2MaxPathBytes    = 2048
+	kvV2MaxRequestBytes = 64 * 1024
+	kvV2ProxyTimeout    = 8 * time.Second
+)
+
+var (
+	errKVConflict = errors.New("kv check-and-set parameter did not match the current version")
+	errKVDeleted  = errors.New("kv version is deleted")
+	errKVNotFound = errors.New("kv path was not found")
+)
+
+type kvSecretState struct {
+	Current  int               `json:"current"`
+	Versions []kvVersionRecord `json:"versions"`
+}
+
+type kvVersionRecord struct {
+	Version      int           `json:"version"`
+	CreatedTime  time.Time     `json:"createdTime"`
+	DeletionTime string        `json:"deletionTime,omitempty"`
+	Destroyed    bool          `json:"destroyed"`
+	Payload      secretPayload `json:"payload"`
+}
+
+type kvWriteEnvelope struct {
+	Data    map[string]any  `json:"data"`
+	Options *kvWriteOptions `json:"options"`
+}
+
+type kvWriteOptions struct {
+	CAS *int `json:"cas"`
+}
+
+type kvVersionSelectRequest struct {
+	Versions []int `json:"versions"`
+}
+
+type kvDataResponse struct {
+	Data kvDataBody `json:"data"`
+}
+
+type kvDataBody struct {
+	Data     map[string]string `json:"data"`
+	Metadata kvVersionMetadata `json:"metadata"`
+}
+
+type kvVersionMetadata struct {
+	CreatedTime    string `json:"created_time"`
+	DeletionTime   string `json:"deletion_time"`
+	Destroyed      bool   `json:"destroyed"`
+	Version        int    `json:"version"`
+	CustomMetadata any    `json:"custom_metadata"`
+}
+
+type kvWriteResponse struct {
+	Data kvVersionMetadata `json:"data"`
+}
+
+type kvMetadataResponse struct {
+	Data kvMetadataBody `json:"data"`
+}
+
+type kvMetadataBody struct {
+	CASRequired        bool                       `json:"cas_required"`
+	CreatedTime        string                     `json:"created_time"`
+	CurrentVersion     int                        `json:"current_version"`
+	DeleteVersionAfter string                     `json:"delete_version_after"`
+	MaxVersions        int                        `json:"max_versions"`
+	OldestVersion      int                        `json:"oldest_version"`
+	UpdatedTime        string                     `json:"updated_time"`
+	CustomMetadata     any                        `json:"custom_metadata"`
+	Versions           map[string]kvListedVersion `json:"versions"`
+}
+
+type kvListedVersion struct {
+	CreatedTime  string `json:"created_time"`
+	DeletionTime string `json:"deletion_time"`
+	Destroyed    bool   `json:"destroyed"`
+}
+
+type kvListResponse struct {
+	Data kvListBody `json:"data"`
+}
+
+type kvListBody struct {
+	Keys []string `json:"keys"`
+}
+
+type kvErrorResponse struct {
+	Errors []string `json:"errors"`
+}
+
+type kvNoContentResponse struct{}
+
+func registerKVHandlers(mux *http.ServeMux, backend *localBackend, security localAPISecurity) {
+	mux.HandleFunc("/v1/kv/data/", func(w http.ResponseWriter, r *http.Request) {
+		backend.serveKVData(w, r, security)
+	})
+	mux.HandleFunc("/v1/kv/metadata/", func(w http.ResponseWriter, r *http.Request) {
+		backend.serveKVMetadata(w, r, security)
+	})
+	mux.HandleFunc("/v1/kv/metadata", func(w http.ResponseWriter, r *http.Request) {
+		backend.serveKVMetadata(w, r, security)
+	})
+	mux.HandleFunc("/v1/kv/delete/", func(w http.ResponseWriter, r *http.Request) {
+		backend.serveKVDelete(w, r, security, false)
+	})
+	mux.HandleFunc("/v1/kv/undelete/", func(w http.ResponseWriter, r *http.Request) {
+		backend.serveKVDelete(w, r, security, true)
+	})
+}
+
+func (b *localBackend) serveKVData(w http.ResponseWriter, r *http.Request, security localAPISecurity) {
+	switch r.Method {
+	case http.MethodGet, http.MethodPost, http.MethodPatch:
+	default:
+		writeKVErrors(w, http.StatusMethodNotAllowed, "Use GET, POST, or PATCH /v1/kv/data/{path}.")
+		return
+	}
+	if !security.require(w, r) {
+		return
+	}
+	path, sourceID, mount, err := parseKVRequest(r, "/v1/kv/data/")
+	if err != nil {
+		writeKVErrors(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if path == "" {
+		writeKVErrors(w, http.StatusBadRequest, "kv data path is required")
+		return
+	}
+	if handled := b.proxyRemoteKV(w, r, sourceID, mount, "data", path); handled {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		version := kvQueryVersion(r)
+		body, err := b.readLocalKVData(path, version)
+		if err != nil {
+			writeKVStoreError(w, err)
+			return
+		}
+		_ = b.audit("kv-read", path, "ready", "", "")
+		writeJSON(w, http.StatusOK, body)
+	case http.MethodPost, http.MethodPatch:
+		var req kvWriteEnvelope
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		if req.Data == nil {
+			writeKVErrors(w, http.StatusBadRequest, "missing data")
+			return
+		}
+		fields := kvStringMap(req.Data)
+		var cas *int
+		if req.Options != nil {
+			cas = req.Options.CAS
+		}
+		meta, err := b.writeLocalKVData(path, fields, cas, r.Method == http.MethodPatch)
+		if err != nil {
+			writeKVStoreError(w, err)
+			return
+		}
+		operation := "kv-write"
+		if r.Method == http.MethodPatch {
+			operation = "kv-patch"
+		}
+		_ = b.audit(operation, path, "ready", "", "")
+		writeJSON(w, http.StatusOK, kvWriteResponse{Data: meta})
+	}
+}
+
+func (b *localBackend) serveKVMetadata(w http.ResponseWriter, r *http.Request, security localAPISecurity) {
+	if r.Method != http.MethodGet && !strings.EqualFold(r.Method, "LIST") {
+		writeKVErrors(w, http.StatusMethodNotAllowed, "Use GET or LIST /v1/kv/metadata/{path}.")
+		return
+	}
+	if !security.require(w, r) {
+		return
+	}
+	path, sourceID, mount, err := parseKVRequest(r, "/v1/kv/metadata/")
+	if err != nil {
+		writeKVErrors(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if handled := b.proxyRemoteKV(w, r, sourceID, mount, "metadata", path); handled {
+		return
+	}
+	if kvWantsList(r) {
+		keys, err := b.listLocalKVKeys(path)
+		if err != nil {
+			writeKVStoreError(w, err)
+			return
+		}
+		if len(keys) == 0 {
+			writeKVErrors(w, http.StatusNotFound, "no keys found")
+			return
+		}
+		_ = b.audit("kv-list", path, "ready", "", "")
+		writeJSON(w, http.StatusOK, kvListResponse{Data: kvListBody{Keys: keys}})
+		return
+	}
+	if path == "" {
+		writeKVErrors(w, http.StatusBadRequest, "kv metadata path is required")
+		return
+	}
+	body, err := b.readLocalKVMetadata(path)
+	if err != nil {
+		writeKVStoreError(w, err)
+		return
+	}
+	_ = b.audit("kv-metadata", path, "ready", "", "")
+	writeJSON(w, http.StatusOK, body)
+}
+
+func (b *localBackend) serveKVDelete(w http.ResponseWriter, r *http.Request, security localAPISecurity, undelete bool) {
+	if r.Method != http.MethodPost {
+		action := "/v1/kv/delete/{path}"
+		if undelete {
+			action = "/v1/kv/undelete/{path}"
+		}
+		writeKVErrors(w, http.StatusMethodNotAllowed, "Use POST "+action+".")
+		return
+	}
+	if !security.require(w, r) {
+		return
+	}
+	prefix := "/v1/kv/delete/"
+	op := "delete"
+	auditName := "kv-delete"
+	if undelete {
+		prefix = "/v1/kv/undelete/"
+		op = "undelete"
+		auditName = "kv-undelete"
+	}
+	path, sourceID, mount, err := parseKVRequest(r, prefix)
+	if err != nil {
+		writeKVErrors(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if path == "" {
+		writeKVErrors(w, http.StatusBadRequest, "kv path is required")
+		return
+	}
+	if handled := b.proxyRemoteKV(w, r, sourceID, mount, op, path); handled {
+		return
+	}
+	var req kvVersionSelectRequest
+	if r.Body != nil && r.ContentLength > 0 {
+		if err := decodeSecretBearingJSON(w, r, &req); err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+	}
+	if err := b.mutateLocalKVVersions(path, req.Versions, undelete); err != nil {
+		writeKVStoreError(w, err)
+		return
+	}
+	_ = b.audit(auditName, path, "ready", "", "")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (b *localBackend) proxyRemoteKV(w http.ResponseWriter, r *http.Request, sourceID, mount, op, path string) bool {
+	if sourceID == "local" {
+		return false
+	}
+	source, ok := b.kvRemoteSource(sourceID)
+	if !ok {
+		writeKVErrors(w, http.StatusBadRequest, "unknown kv source")
+		return true
+	}
+	kind := strings.ToLower(strings.TrimSpace(source.Kind))
+	if kind != "vault" && kind != "openbao" {
+		writeKVErrors(w, http.StatusBadRequest, "kv source is not Vault or OpenBao")
+		return true
+	}
+	if !source.Enabled {
+		writeKVErrors(w, http.StatusBadRequest, "kv source is disabled")
+		return true
+	}
+	status, body, err := b.forwardOpenBaoKV(source, r.Method, mount, op, path, r)
+	if err != nil {
+		writeKVStoreError(w, err)
+		return true
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	return true
+}
+
+func (b *localBackend) kvRemoteSource(sourceID string) (sourceConfig, bool) {
+	for _, source := range b.sources.Sources {
+		if source.SourceID == sourceID {
+			return source, true
+		}
+	}
+	return sourceConfig{}, false
+}
+
+func (b *localBackend) forwardOpenBaoKV(source sourceConfig, method, mount, op, path string, incoming *http.Request) (int, []byte, error) {
+	baseURL, err := validatedVaultKVBaseURL(source.Address)
+	if err != nil {
+		return 0, nil, errInvalidRef
+	}
+	token := strings.TrimSpace(firstNonEmpty(source.Token, os.Getenv(source.TokenEnv)))
+	if token == "" {
+		return 0, nil, errSourceAuthRequired
+	}
+	if strings.TrimSpace(source.Mount) != "" && mount == kvV2DefaultMount {
+		mount = strings.TrimSpace(source.Mount)
+	}
+	if !validKVMount(mount) {
+		return 0, nil, errInvalidRef
+	}
+	endpoint := baseURL
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "LIST" {
+		method = http.MethodGet
+	}
+	trimmedPath := strings.Trim(path, "/")
+	if trimmedPath == "" {
+		endpoint.Path = "/v1/" + mount + "/" + op
+	} else {
+		endpoint.Path = "/v1/" + mount + "/" + op + "/" + trimmedPath
+	}
+	query := endpoint.Query()
+	if incoming != nil {
+		if version := strings.TrimSpace(incoming.URL.Query().Get("version")); version != "" {
+			query.Set("version", version)
+		}
+		if kvWantsList(incoming) {
+			query.Set("list", "true")
+		}
+	}
+	endpoint.RawQuery = query.Encode()
+	var bodyReader io.Reader
+	if incoming != nil && incoming.Body != nil && (method == http.MethodPost || method == http.MethodPatch || method == http.MethodPut) {
+		limited, err := io.ReadAll(io.LimitReader(incoming.Body, kvV2MaxRequestBytes+1))
+		if err != nil {
+			return 0, nil, errInvalidRef
+		}
+		if len(limited) > kvV2MaxRequestBytes {
+			return 0, nil, errInvalidRef
+		}
+		bodyReader = bytes.NewReader(limited)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kvV2ProxyTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bodyReader)
+	if err != nil {
+		return 0, nil, errInvalidRef
+	}
+	req.Header.Set("X-Vault-Token", token)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{
+		Timeout: kvV2ProxyTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, errBackendDegraded
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(res.Body, kvV2MaxRequestBytes+1))
+	if err != nil || len(body) > kvV2MaxRequestBytes {
+		return 0, nil, errBackendDegraded
+	}
+	if len(body) == 0 {
+		body = []byte("{}")
+	}
+	return res.StatusCode, body, nil
+}
+
+func (b *localBackend) readLocalKVData(path string, version int) (kvDataResponse, error) {
+	if b.locked() {
+		return kvDataResponse{}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return kvDataResponse{}, err
+	}
+	entry, ok := store.Secrets[path]
+	if !ok {
+		return kvDataResponse{}, errKVNotFound
+	}
+	record, data, err := b.localKVVersion(entry, version)
+	if err != nil {
+		return kvDataResponse{}, err
+	}
+	if strings.TrimSpace(record.DeletionTime) != "" || record.Destroyed {
+		return kvDataResponse{}, errKVDeleted
+	}
+	return kvDataResponse{Data: kvDataBody{Data: data, Metadata: kvMetadataFromRecord(record)}}, nil
+}
+
+func (b *localBackend) readLocalKVMetadata(path string) (kvMetadataResponse, error) {
+	if b.locked() {
+		return kvMetadataResponse{}, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return kvMetadataResponse{}, err
+	}
+	entry, ok := store.Secrets[path]
+	if !ok {
+		return kvMetadataResponse{}, errKVNotFound
+	}
+	state := localKVState(entry)
+	versions := map[string]kvListedVersion{}
+	oldest := 0
+	for _, record := range state.Versions {
+		if oldest == 0 || record.Version < oldest {
+			oldest = record.Version
+		}
+		versions[strconv.Itoa(record.Version)] = kvListedVersion{
+			CreatedTime:  record.CreatedTime.UTC().Format(time.RFC3339Nano),
+			DeletionTime: record.DeletionTime,
+			Destroyed:    record.Destroyed,
+		}
+	}
+	return kvMetadataResponse{Data: kvMetadataBody{
+		CreatedTime:        entry.Metadata.CreatedAt.UTC().Format(time.RFC3339Nano),
+		CurrentVersion:     state.Current,
+		DeleteVersionAfter: "0s",
+		MaxVersions:        kvV2MaxVersions,
+		OldestVersion:      oldest,
+		UpdatedTime:        entry.Metadata.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		Versions:           versions,
+	}}, nil
+}
+
+func (b *localBackend) listLocalKVKeys(prefix string) ([]string, error) {
+	if b.locked() {
+		return nil, errLocked
+	}
+	store, err := b.loadStore()
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]string, 0, len(store.Secrets))
+	for ref := range store.Secrets {
+		refs = append(refs, ref)
+	}
+	return kvChildKeys(refs, prefix), nil
+}
+
+func (b *localBackend) writeLocalKVData(path string, data map[string]string, cas *int, patch bool) (kvVersionMetadata, error) {
+	if b.locked() {
+		return kvVersionMetadata{}, errLocked
+	}
+	if !validSecretRef(path) {
+		return kvVersionMetadata{}, errInvalidRef
+	}
+	b.storeMutationMu.Lock()
+	defer b.storeMutationMu.Unlock()
+	store, err := b.loadStore()
+	if err != nil {
+		return kvVersionMetadata{}, err
+	}
+	now := b.now()
+	existing, exists := store.Secrets[path]
+	fields := data
+	if patch {
+		if !exists {
+			return kvVersionMetadata{}, errKVNotFound
+		}
+		current, currentData, err := b.localKVVersion(existing, 0)
+		if err != nil {
+			return kvVersionMetadata{}, err
+		}
+		if strings.TrimSpace(current.DeletionTime) != "" || current.Destroyed {
+			return kvVersionMetadata{}, errKVDeleted
+		}
+		merged := map[string]string{}
+		for key, value := range currentData {
+			merged[key] = value
+		}
+		for key, value := range data {
+			merged[key] = value
+		}
+		fields = merged
+	}
+	plaintext, err := kvPayloadPlaintext(fields)
+	if err != nil {
+		return kvVersionMetadata{}, errInvalidRef
+	}
+	payload, err := b.encrypt(plaintext)
+	if err != nil {
+		return kvVersionMetadata{}, err
+	}
+	kv, err := b.appendLocalKVVersion(existing, fields, payload, now, cas)
+	if err != nil {
+		return kvVersionMetadata{}, err
+	}
+	metadata := SecretMetadata{SourceID: localStoreSource, Version: now.Format(time.RFC3339Nano), CreatedAt: now, UpdatedAt: now}
+	if exists {
+		metadata.CreatedAt = existing.Metadata.CreatedAt
+	}
+	store.Secrets[path] = secretEntry{Ref: path, Metadata: metadata, Payload: payload, KV: kv}
+	store.UpdatedAt = now
+	if err := b.saveStore(store); err != nil {
+		return kvVersionMetadata{}, err
+	}
+	return kvMetadataFromRecord(kv.Versions[len(kv.Versions)-1]), nil
+}
+
+func (b *localBackend) mutateLocalKVVersions(path string, versions []int, undelete bool) error {
+	if b.locked() {
+		return errLocked
+	}
+	if !validSecretRef(path) {
+		return errInvalidRef
+	}
+	b.storeMutationMu.Lock()
+	defer b.storeMutationMu.Unlock()
+	store, err := b.loadStore()
+	if err != nil {
+		return err
+	}
+	entry, ok := store.Secrets[path]
+	if !ok {
+		return errKVNotFound
+	}
+	state := localKVState(entry)
+	if len(versions) == 0 {
+		versions = []int{state.Current}
+	}
+	now := b.now()
+	selected := map[int]bool{}
+	for _, version := range versions {
+		selected[version] = true
+	}
+	found := 0
+	for index, record := range state.Versions {
+		if !selected[record.Version] {
+			continue
+		}
+		found++
+		if undelete {
+			state.Versions[index].DeletionTime = ""
+			continue
+		}
+		if strings.TrimSpace(record.DeletionTime) == "" {
+			state.Versions[index].DeletionTime = now.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	if found == 0 {
+		return errKVNotFound
+	}
+	entry.KV = &state
+	entry.Metadata.UpdatedAt = now
+	store.Secrets[path] = entry
+	store.UpdatedAt = now
+	return b.saveStore(store)
+}
+
+func (b *localBackend) appendLocalKVVersion(existing secretEntry, _ map[string]string, payload secretPayload, now time.Time, cas *int) (*kvSecretState, error) {
+	state := localKVState(existing)
+	if existing.Ref == "" && existing.Payload.Ciphertext == "" && state.Current == 0 {
+		if cas != nil && *cas != 0 {
+			return nil, errKVConflict
+		}
+		record := kvVersionRecord{Version: 1, CreatedTime: now, Payload: payload}
+		return &kvSecretState{Current: 1, Versions: []kvVersionRecord{record}}, nil
+	}
+	if cas != nil && *cas != state.Current {
+		return nil, errKVConflict
+	}
+	next := state.Current + 1
+	if next == 1 && existing.Payload.Ciphertext != "" && len(state.Versions) == 0 {
+		state.Versions = []kvVersionRecord{{
+			Version:     1,
+			CreatedTime: existing.Metadata.CreatedAt,
+			Payload:     existing.Payload,
+		}}
+		state.Current = 1
+		next = 2
+		if cas != nil && *cas != 1 && *cas != 0 {
+			return nil, errKVConflict
+		}
+		if cas != nil && *cas == 0 {
+			return nil, errKVConflict
+		}
+	}
+	state.Current = next
+	state.Versions = append(state.Versions, kvVersionRecord{Version: next, CreatedTime: now, Payload: payload})
+	if len(state.Versions) > kvV2MaxVersions {
+		state.Versions = state.Versions[len(state.Versions)-kvV2MaxVersions:]
+	}
+	return &state, nil
+}
+
+func (b *localBackend) localKVVersion(entry secretEntry, version int) (kvVersionRecord, map[string]string, error) {
+	state := localKVState(entry)
+	if version <= 0 {
+		version = state.Current
+	}
+	for _, record := range state.Versions {
+		if record.Version != version {
+			continue
+		}
+		plaintext, err := b.decrypt(record.Payload)
+		if err != nil {
+			return kvVersionRecord{}, nil, err
+		}
+		return record, kvDataFromPlaintext(plaintext), nil
+	}
+	if version == 1 || (version == 0 && state.Current <= 1) {
+		plaintext, err := b.decrypt(entry.Payload)
+		if err != nil {
+			return kvVersionRecord{}, nil, err
+		}
+		record := kvVersionRecord{Version: 1, CreatedTime: entry.Metadata.CreatedAt, Payload: entry.Payload}
+		return record, kvDataFromPlaintext(plaintext), nil
+	}
+	return kvVersionRecord{}, nil, errKVNotFound
+}
+
+func localKVState(entry secretEntry) kvSecretState {
+	if entry.KV != nil && len(entry.KV.Versions) > 0 {
+		return *entry.KV
+	}
+	if entry.Payload.Ciphertext == "" {
+		return kvSecretState{}
+	}
+	version := 1
+	return kvSecretState{
+		Current: version,
+		Versions: []kvVersionRecord{{
+			Version:     version,
+			CreatedTime: entry.Metadata.CreatedAt,
+			Payload:     entry.Payload,
+		}},
+	}
+}
+
+func kvMetadataFromRecord(record kvVersionRecord) kvVersionMetadata {
+	return kvVersionMetadata{
+		CreatedTime:  record.CreatedTime.UTC().Format(time.RFC3339Nano),
+		DeletionTime: record.DeletionTime,
+		Destroyed:    record.Destroyed,
+		Version:      record.Version,
+	}
+}
+
+func parseKVRequest(r *http.Request, prefix string) (path, sourceID, mount string, err error) {
+	raw := strings.TrimPrefix(r.URL.Path, strings.TrimSuffix(prefix, "/"))
+	path = strings.Trim(raw, "/")
+	if strings.Contains(path, "{path}") {
+		path = strings.Trim(strings.ReplaceAll(path, "{path}", ""), "/")
+	}
+	if len(path) > kvV2MaxPathBytes {
+		return "", "", "", errInvalidRef
+	}
+	if path != "" && !validSecretRef(path) && !kvWantsList(r) {
+		return "", "", "", errInvalidRef
+	}
+	if path != "" && kvWantsList(r) {
+		trimmed := strings.Trim(path, "/")
+		if trimmed != "" && !validSecretRef(trimmed) {
+			return "", "", "", errInvalidRef
+		}
+		path = trimmed
+	}
+	sourceID = strings.TrimSpace(r.URL.Query().Get("source"))
+	switch sourceID {
+	case "", "local", "local-encrypted-store":
+		sourceID = "local"
+	}
+	mount = strings.TrimSpace(r.URL.Query().Get("mount"))
+	if mount == "" {
+		mount = kvV2DefaultMount
+	}
+	if !validKVMount(mount) {
+		return "", "", "", errInvalidRef
+	}
+	return path, sourceID, mount, nil
+}
+
+func kvWantsList(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if strings.EqualFold(r.Method, "LIST") {
+		return true
+	}
+	value := strings.TrimSpace(r.URL.Query().Get("list"))
+	return value == "true" || value == "1"
+}
+
+func kvQueryVersion(r *http.Request) int {
+	raw := strings.TrimSpace(r.URL.Query().Get("version"))
+	if raw == "" {
+		return 0
+	}
+	version, err := strconv.Atoi(raw)
+	if err != nil || version < 0 {
+		return 0
+	}
+	return version
+}
+
+func validKVMount(mount string) bool {
+	mount = strings.TrimSpace(mount)
+	if mount == "" || len(mount) > 64 || strings.ContainsAny(mount, "/\\?#") {
+		return false
+	}
+	for _, r := range mount {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func kvChildKeys(refs []string, prefix string) []string {
+	normalized := strings.Trim(prefix, "/")
+	if normalized != "" {
+		normalized += "/"
+	}
+	seen := map[string]struct{}{}
+	keys := make([]string, 0)
+	for _, ref := range refs {
+		if normalized != "" && !strings.HasPrefix(ref, normalized) {
+			continue
+		}
+		rest := strings.TrimPrefix(ref, normalized)
+		if rest == "" {
+			continue
+		}
+		name, _, found := strings.Cut(rest, "/")
+		key := name
+		if found {
+			key = name + "/"
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func kvStringMap(data map[string]any) map[string]string {
+	out := map[string]string{}
+	for key, value := range data {
+		out[key] = kvStringify(value)
+	}
+	return out
+}
+
+func kvStringify(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprint(typed)
+		}
+		return string(encoded)
+	}
+}
+
+func kvPayloadPlaintext(data map[string]string) (string, error) {
+	if len(data) == 1 {
+		if value, ok := data["value"]; ok {
+			return value, nil
+		}
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func kvDataFromPlaintext(plaintext string) map[string]string {
+	trimmed := strings.TrimSpace(plaintext)
+	if strings.HasPrefix(trimmed, "{") {
+		var raw map[string]any
+		if json.Unmarshal([]byte(trimmed), &raw) == nil && raw != nil {
+			return kvStringMap(raw)
+		}
+	}
+	return map[string]string{"value": plaintext}
+}
+
+func writeKVErrors(w http.ResponseWriter, status int, messages ...string) {
+	if len(messages) == 0 {
+		messages = []string{"kv request failed"}
+	}
+	writeJSON(w, status, kvErrorResponse{Errors: messages})
+}
+
+func writeKVStoreError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errInvalidRef):
+		writeKVErrors(w, http.StatusBadRequest, "invalid path")
+	case errors.Is(err, errKVConflict):
+		writeKVErrors(w, http.StatusBadRequest, "check-and-set parameter did not match the current version")
+	case errors.Is(err, errKVNotFound), errors.Is(err, errMissingRef):
+		writeKVErrors(w, http.StatusNotFound, "no data found")
+	case errors.Is(err, errKVDeleted):
+		writeKVErrors(w, http.StatusNotFound, "no data for version")
+	case errors.Is(err, errLocked):
+		writeAPIError(w, http.StatusServiceUnavailable, "locked", "Secrets Broker local store is locked.", "locked", "unlock_broker")
+	case errors.Is(err, errSourceAuthRequired):
+		writeAPIError(w, http.StatusFailedDependency, "source_auth_required", "Vault or OpenBao token is missing.", "source_auth_required", "reconnect_source")
+	default:
+		writeAPIError(w, http.StatusServiceUnavailable, "degraded", "KV backend is unavailable.", "degraded", "inspect_sources")
+	}
+}

--- a/cmd/secretsbroker/kv_v2_test.go
+++ b/cmd/secretsbroker/kv_v2_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const kvSentinel = "kv-sentinel-alpha"
+
+func TestKVFacadePutGetListSoftDeleteAndCAS(t *testing.T) {
+	backend := testBackend(t)
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	putBody := []byte(`{"data":{"username":"demo-user","password":"` + kvSentinel + `"}}`)
+	put := kvDo(t, server, http.MethodPost, "/v1/kv/data/apps/db", putBody)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("put status=%d body=%s", put.StatusCode, kvRead(t, put))
+	}
+	var written kvWriteResponse
+	if err := json.Unmarshal(kvRead(t, put), &written); err != nil || written.Data.Version != 1 {
+		t.Fatalf("put version=%d err=%v", written.Data.Version, err)
+	}
+
+	listed := kvDo(t, server, http.MethodGet, "/v1/kv/metadata/?list=true", nil)
+	listPayload := kvRead(t, listed)
+	if listed.StatusCode != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listed.StatusCode, listPayload)
+	}
+	assertNoSecretMaterial(t, listPayload, kvSentinel)
+	var keys kvListResponse
+	if err := json.Unmarshal(listPayload, &keys); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(keys.Data.Keys, ",") != "apps/" {
+		t.Fatalf("root keys=%v", keys.Data.Keys)
+	}
+
+	nested := kvDo(t, server, http.MethodGet, "/v1/kv/metadata/apps?list=true", nil)
+	nestedPayload := kvRead(t, nested)
+	assertNoSecretMaterial(t, nestedPayload, kvSentinel)
+	var nestedKeys kvListResponse
+	if err := json.Unmarshal(nestedPayload, &nestedKeys); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(nestedKeys.Data.Keys, ",") != "db" {
+		t.Fatalf("apps keys=%v", nestedKeys.Data.Keys)
+	}
+
+	got := kvDo(t, server, http.MethodGet, "/v1/kv/data/apps/db", nil)
+	gotPayload := kvRead(t, got)
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", got.StatusCode, gotPayload)
+	}
+	var current kvDataResponse
+	if err := json.Unmarshal(gotPayload, &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Data.Data["password"] != kvSentinel || current.Data.Metadata.Version != 1 {
+		t.Fatalf("get payload=%s", gotPayload)
+	}
+
+	conflict := kvDo(t, server, http.MethodPost, "/v1/kv/data/apps/db", []byte(`{"data":{"password":"kv-sentinel-beta"},"options":{"cas":0}}`))
+	if conflict.StatusCode != http.StatusBadRequest {
+		t.Fatalf("cas status=%d body=%s", conflict.StatusCode, kvRead(t, conflict))
+	}
+
+	patched := kvDo(t, server, http.MethodPatch, "/v1/kv/data/apps/db", []byte(`{"data":{"role":"reader"},"options":{"cas":1}}`))
+	if patched.StatusCode != http.StatusOK {
+		t.Fatalf("patch status=%d body=%s", patched.StatusCode, kvRead(t, patched))
+	}
+
+	afterPatch := kvDo(t, server, http.MethodGet, "/v1/kv/data/apps/db", nil)
+	var merged kvDataResponse
+	if err := json.Unmarshal(kvRead(t, afterPatch), &merged); err != nil {
+		t.Fatal(err)
+	}
+	if merged.Data.Data["password"] != kvSentinel || merged.Data.Data["role"] != "reader" || merged.Data.Metadata.Version != 2 {
+		t.Fatalf("patched payload=%v version=%d", merged.Data.Data, merged.Data.Metadata.Version)
+	}
+
+	deleted := kvDo(t, server, http.MethodPost, "/v1/kv/delete/apps/db", nil)
+	if deleted.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status=%d body=%s", deleted.StatusCode, kvRead(t, deleted))
+	}
+	missing := kvDo(t, server, http.MethodGet, "/v1/kv/data/apps/db", nil)
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("deleted get status=%d body=%s", missing.StatusCode, kvRead(t, missing))
+	}
+	meta := kvDo(t, server, http.MethodGet, "/v1/kv/metadata/apps/db", nil)
+	metaPayload := kvRead(t, meta)
+	assertNoSecretMaterial(t, metaPayload, kvSentinel)
+	var metadata kvMetadataResponse
+	if err := json.Unmarshal(metaPayload, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Data.CurrentVersion != 2 || strings.TrimSpace(metadata.Data.Versions["2"].DeletionTime) == "" {
+		t.Fatalf("metadata after delete=%s", metaPayload)
+	}
+
+	undeleted := kvDo(t, server, http.MethodPost, "/v1/kv/undelete/apps/db", []byte(`{"versions":[2]}`))
+	if undeleted.StatusCode != http.StatusNoContent {
+		t.Fatalf("undelete status=%d body=%s", undeleted.StatusCode, kvRead(t, undeleted))
+	}
+	restored := kvDo(t, server, http.MethodGet, "/v1/kv/data/apps/db", nil)
+	var restoredBody kvDataResponse
+	if err := json.Unmarshal(kvRead(t, restored), &restoredBody); err != nil {
+		t.Fatal(err)
+	}
+	if restoredBody.Data.Data["password"] != kvSentinel {
+		t.Fatalf("restored payload=%v", restoredBody.Data.Data)
+	}
+
+	unauth := kvDoUnauth(t, server, http.MethodGet, "/v1/kv/data/apps/db")
+	if unauth.StatusCode == http.StatusOK {
+		t.Fatalf("unauthenticated read succeeded")
+	}
+}
+
+func TestKVFacadeLegacySecretReadsAsValueField(t *testing.T) {
+	backend := testBackend(t)
+	if _, err := backend.writeSecret(writeSecretRequest{Ref: "legacy/token", Value: kvSentinel}); err != nil {
+		t.Fatal(err)
+	}
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	got := kvDo(t, server, http.MethodGet, "/v1/kv/data/legacy/token", nil)
+	payload := kvRead(t, got)
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", got.StatusCode, payload)
+	}
+	var current kvDataResponse
+	if err := json.Unmarshal(payload, &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Data.Data["value"] != kvSentinel {
+		t.Fatalf("legacy payload=%s", payload)
+	}
+
+	resolved := backend.resolve(resolveRequest{Refs: []string{"legacy/token"}})
+	if len(resolved.Results) != 1 || resolved.Results[0].Value != kvSentinel {
+		t.Fatalf("resolve=%v", resolved.Results)
+	}
+}
+
+func TestKVFacadeOpenBaoProxyForwardsKVShape(t *testing.T) {
+	const remoteToken = "bao-operator-token"
+	var seenPath string
+	var seenToken string
+	var seenMethod string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenToken = r.Header.Get("X-Vault-Token")
+		seenMethod = r.Method
+		if r.URL.Query().Get("list") == "true" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"keys":["apps/"]}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"data":{"password":"` + kvSentinel + `"},"metadata":{"version":4,"created_time":"2026-08-18T00:00:00Z","deletion_time":"","destroyed":false}}}`))
+	}))
+	defer upstream.Close()
+
+	backend := testBackend(t)
+	backend.sources = sourceConfigFile{Sources: []sourceConfig{{
+		SourceID: "openbao-dev",
+		Kind:     "openbao",
+		Enabled:  true,
+		Address:  upstream.URL,
+		Token:    remoteToken,
+		Mount:    "secret",
+	}}}
+	state := "ready"
+	server := httptest.NewServer(newHandler(runtimeState{state: &state}, backend, localAPISecurity{token: "test-token"}))
+	defer server.Close()
+
+	listed := kvDo(t, server, http.MethodGet, "/v1/kv/metadata/?list=true&source=openbao-dev", nil)
+	listPayload := kvRead(t, listed)
+	if listed.StatusCode != http.StatusOK {
+		t.Fatalf("proxy list status=%d body=%s", listed.StatusCode, listPayload)
+	}
+	assertNoSecretMaterial(t, listPayload, kvSentinel, remoteToken)
+	if seenPath != "/v1/secret/metadata" || seenMethod != http.MethodGet {
+		t.Fatalf("proxy list path=%s method=%s", seenPath, seenMethod)
+	}
+
+	got := kvDo(t, server, http.MethodGet, "/v1/kv/data/apps/db?source=openbao-dev", nil)
+	payload := kvRead(t, got)
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("proxy get status=%d body=%s", got.StatusCode, payload)
+	}
+	if seenPath != "/v1/secret/data/apps/db" || seenToken != remoteToken {
+		t.Fatalf("proxy get path=%s token=%s", seenPath, seenToken)
+	}
+	if !strings.Contains(string(payload), kvSentinel) {
+		t.Fatalf("proxy get missing value: %s", payload)
+	}
+}
+
+func TestKVChildKeysAreImmediateOnly(t *testing.T) {
+	keys := kvChildKeys([]string{"apps/db", "apps/cache", "apps/nested/key", "other"}, "")
+	if strings.Join(keys, ",") != "apps/,other" {
+		t.Fatalf("root=%v", keys)
+	}
+	nested := kvChildKeys([]string{"apps/db", "apps/cache", "apps/nested/key", "other"}, "apps")
+	if strings.Join(nested, ",") != "cache,db,nested/" {
+		t.Fatalf("apps=%v", nested)
+	}
+}
+
+func kvDo(t *testing.T, server *httptest.Server, method, path string, body []byte) *http.Response {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, server.URL+path, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-token")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+func kvDoUnauth(t *testing.T, server *httptest.Server, method, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, server.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+func kvRead(t *testing.T, res *http.Response) []byte {
+	t.Helper()
+	defer res.Body.Close()
+	payload, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}

--- a/cmd/secretsbroker/local_store.go
+++ b/cmd/secretsbroker/local_store.go
@@ -109,6 +109,7 @@ type secretEntry struct {
 	Ref      string         `json:"ref"`
 	Metadata SecretMetadata `json:"metadata"`
 	Payload  secretPayload  `json:"payload"`
+	KV       *kvSecretState `json:"kv,omitempty"`
 }
 
 type SecretMetadata struct {

--- a/cmd/secretsbroker/main.go
+++ b/cmd/secretsbroker/main.go
@@ -248,6 +248,10 @@ func defaultCapabilities() CapabilitiesResponse {
 			"POST /v1/secrets",
 			"POST /v1/writeback",
 			"POST /v1/resolve",
+			"GET|POST|PATCH /v1/kv/data/{path}",
+			"GET /v1/kv/metadata/{path}",
+			"POST /v1/kv/delete/{path}",
+			"POST /v1/kv/undelete/{path}",
 			"GET /v1/provisioning/status",
 			"POST /v1/provisioning/operations/plan",
 			"POST /v1/provisioning/operations/apply",
@@ -294,6 +298,7 @@ func defaultCapabilities() CapabilitiesResponse {
 			"versioned-operation-capability-manifest",
 			"local-encrypted-store",
 			"batched-resolve",
+			"openbao-compatible-kv-v2",
 			"typed-errors",
 			"audit-redaction",
 			"source-status",
@@ -498,6 +503,7 @@ func newHandler(state runtimeState, backend *localBackend, security localAPISecu
 			security.audit = backend.audit
 		}
 		registerLocalStoreHandlers(mux, backend, security)
+		registerKVHandlers(mux, backend, security)
 		registerSourceRegistryHandlers(mux, backend)
 		registerSecretsManagementHandlers(mux, backend, security)
 		registerDecommissionHandlers(mux, backend, security)

--- a/cmd/secretsbroker/operation_manifest.go
+++ b/cmd/secretsbroker/operation_manifest.go
@@ -121,6 +121,7 @@ func defaultOperationManifest() []OperationCapability {
 	providers := supportedProviderKinds()
 	local := []string{"local-encrypted-store"}
 	localAndAWS := []string{"local-encrypted-store", "aws-secrets-manager"}
+	localAndVault := []string{"local-encrypted-store", "vault", "openbao"}
 
 	return []OperationCapability{
 		manifestOperation(http.MethodGet, "/health", OperationMaturityReadOnly, OperationClassificationRead, false, false, false, OperationScopeBrokerLocal, nil, "liveness_only"),
@@ -131,6 +132,12 @@ func defaultOperationManifest() []OperationCapability {
 		manifestOperation(http.MethodPost, "/v1/secrets", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "local_store_only"),
 		manifestOperation(http.MethodPost, "/v1/writeback", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "local_store_only"),
 		manifestOperation(http.MethodPost, "/v1/resolve", OperationMaturityValidated, OperationClassificationRead, true, true, true, OperationScopeMixed, providers, "runtime_controls_revalidated"),
+		manifestOperation(http.MethodGet, "/v1/kv/data/{path}", OperationMaturityValidated, OperationClassificationRead, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
+		manifestOperation(http.MethodPost, "/v1/kv/data/{path}", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
+		manifestOperation(http.MethodPatch, "/v1/kv/data/{path}", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
+		manifestOperation(http.MethodGet, "/v1/kv/metadata/{path}", OperationMaturityValidated, OperationClassificationRead, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
+		manifestOperation(http.MethodPost, "/v1/kv/delete/{path}", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
+		manifestOperation(http.MethodPost, "/v1/kv/undelete/{path}", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeMixed, localAndVault, "openbao_kv_v2"),
 		manifestOperation(http.MethodGet, "/v1/provisioning/status", OperationMaturityReadOnly, OperationClassificationRead, true, false, false, OperationScopeMixed, providers, "metadata_only"),
 		manifestOperation(http.MethodPost, "/v1/provisioning/operations/plan", OperationMaturityDryRun, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "no_secret_mutation"),
 		manifestOperation(http.MethodPost, "/v1/provisioning/operations/apply", OperationMaturityValidated, OperationClassificationMutation, true, true, true, OperationScopeBrokerLocal, local, "broker_generated_local_values_only"),
@@ -203,6 +210,12 @@ func providerOperationCapabilities(kind string, lifecycle SourceLifecycle, audit
 	kind = strings.ToLower(strings.TrimSpace(kind))
 	routes := [][2]string{
 		{http.MethodPost, "/v1/resolve"},
+		{http.MethodGet, "/v1/kv/data/{path}"},
+		{http.MethodPost, "/v1/kv/data/{path}"},
+		{http.MethodPatch, "/v1/kv/data/{path}"},
+		{http.MethodGet, "/v1/kv/metadata/{path}"},
+		{http.MethodPost, "/v1/kv/delete/{path}"},
+		{http.MethodPost, "/v1/kv/undelete/{path}"},
 		{http.MethodGet, "/v1/management/secrets/value-search"},
 		{http.MethodPost, "/v1/management/secrets/reveal"},
 		{http.MethodPost, "/v1/secrets"},
@@ -269,6 +282,14 @@ func providerOperationMaturity(kind, path string) OperationMaturity {
 	switch path {
 	case "/v1/resolve":
 		if has(AdapterCapabilityRead) {
+			return OperationMaturityValidated
+		}
+	case "/v1/kv/data/{path}", "/v1/kv/metadata/{path}":
+		if local || kind == "vault" || kind == "openbao" {
+			return OperationMaturityValidated
+		}
+	case "/v1/kv/delete/{path}", "/v1/kv/undelete/{path}":
+		if local || kind == "vault" || kind == "openbao" {
 			return OperationMaturityValidated
 		}
 	case "/v1/management/secrets/reveal":

--- a/cmd/secretsbroker/source_adapters.go
+++ b/cmd/secretsbroker/source_adapters.go
@@ -43,6 +43,7 @@ type sourceConfig struct {
 	Token                 string                     `json:"token,omitempty"`
 	TokenEnv              string                     `json:"tokenEnv,omitempty"`
 	CredentialRef         string                     `json:"credentialRef,omitempty"`
+	Mount                 string                     `json:"mount,omitempty"`
 	Refs                  map[string]sourceRefConfig `json:"refs"`
 }
 

--- a/cmd/secretsbroker/telemetry.go
+++ b/cmd/secretsbroker/telemetry.go
@@ -960,7 +960,18 @@ func telemetryRouteTemplate(path string) string {
 	case "/v1/management/secrets/policy/apply":
 		return "/v1/management/secrets/policy/apply"
 	default:
-		return "/unmatched"
+		switch {
+		case strings.HasPrefix(path, "/v1/kv/data/"):
+			return "/v1/kv/data/{path}"
+		case strings.HasPrefix(path, "/v1/kv/metadata"):
+			return "/v1/kv/metadata/{path}"
+		case strings.HasPrefix(path, "/v1/kv/delete/"):
+			return "/v1/kv/delete/{path}"
+		case strings.HasPrefix(path, "/v1/kv/undelete/"):
+			return "/v1/kv/undelete/{path}"
+		default:
+			return "/unmatched"
+		}
 	}
 }
 

--- a/conformance/fixtures/contract-states.json
+++ b/conformance/fixtures/contract-states.json
@@ -34,6 +34,10 @@
           "POST /v1/secrets",
           "POST /v1/writeback",
           "POST /v1/resolve",
+          "GET|POST|PATCH /v1/kv/data/{path}",
+          "GET /v1/kv/metadata/{path}",
+          "POST /v1/kv/delete/{path}",
+          "POST /v1/kv/undelete/{path}",
           "GET /v1/provisioning/status",
           "POST /v1/provisioning/operations/plan",
           "POST /v1/provisioning/operations/apply",
@@ -210,6 +214,126 @@
             ],
             "completionMode": "synchronous",
             "limitationCode": "runtime_controls_revalidated",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "getv1_kv_data_path",
+            "method": "GET",
+            "path": "/v1/kv/data/{path}",
+            "maturity": "validated",
+            "classification": "read",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "postv1_kv_data_path",
+            "method": "POST",
+            "path": "/v1/kv/data/{path}",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "patchv1_kv_data_path",
+            "method": "PATCH",
+            "path": "/v1/kv/data/{path}",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "getv1_kv_metadata_path",
+            "method": "GET",
+            "path": "/v1/kv/metadata/{path}",
+            "maturity": "validated",
+            "classification": "read",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "postv1_kv_delete_path",
+            "method": "POST",
+            "path": "/v1/kv/delete/{path}",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
+            "reasonCode": "implemented_and_validated",
+            "nextAction": "invoke_with_required_controls"
+          },
+          {
+            "operationId": "postv1_kv_undelete_path",
+            "method": "POST",
+            "path": "/v1/kv/undelete/{path}",
+            "maturity": "validated",
+            "classification": "mutation",
+            "authenticationRequired": true,
+            "policyRequired": true,
+            "auditRequired": true,
+            "scope": "mixed",
+            "providerKinds": [
+              "local-encrypted-store",
+              "vault",
+              "openbao"
+            ],
+            "completionMode": "synchronous",
+            "limitationCode": "openbao_kv_v2",
             "reasonCode": "implemented_and_validated",
             "nextAction": "invoke_with_required_controls"
           },
@@ -1223,6 +1347,7 @@
           "versioned-operation-capability-manifest",
           "local-encrypted-store",
           "batched-resolve",
+          "openbao-compatible-kv-v2",
           "typed-errors",
           "audit-redaction",
           "source-status",
@@ -1470,6 +1595,114 @@
                 "path": "/v1/resolve",
                 "maturity": "validated",
                 "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "getv1_kv_data_path",
+                "method": "GET",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "validated",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_kv_data_path",
+                "method": "POST",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "validated",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "patchv1_kv_data_path",
+                "method": "PATCH",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "validated",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "getv1_kv_metadata_path",
+                "method": "GET",
+                "path": "/v1/kv/metadata/{path}",
+                "maturity": "validated",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_kv_delete_path",
+                "method": "POST",
+                "path": "/v1/kv/delete/{path}",
+                "maturity": "validated",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "broker-local",
+                "providerKinds": [
+                  "local-encrypted-store"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "runtime_auth_policy_audit_revalidated",
+                "reasonCode": "source_operation_available",
+                "nextAction": "invoke_with_required_controls"
+              },
+              {
+                "operationId": "postv1_kv_undelete_path",
+                "method": "POST",
+                "path": "/v1/kv/undelete/{path}",
+                "maturity": "validated",
+                "classification": "mutation",
                 "authenticationRequired": true,
                 "policyRequired": true,
                 "auditRequired": true,
@@ -1967,6 +2200,114 @@
                 "path": "/v1/resolve",
                 "maturity": "unavailable",
                 "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "getv1_kv_data_path",
+                "method": "GET",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "postv1_kv_data_path",
+                "method": "POST",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "patchv1_kv_data_path",
+                "method": "PATCH",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "getv1_kv_metadata_path",
+                "method": "GET",
+                "path": "/v1/kv/metadata/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "postv1_kv_delete_path",
+                "method": "POST",
+                "path": "/v1/kv/delete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "openbao"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "source_auth_required",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "reconnect_source"
+              },
+              {
+                "operationId": "postv1_kv_undelete_path",
+                "method": "POST",
+                "path": "/v1/kv/undelete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
                 "authenticationRequired": true,
                 "policyRequired": true,
                 "auditRequired": true,
@@ -2480,6 +2821,114 @@
                 "nextAction": "reconnect_source"
               },
               {
+                "operationId": "getv1_kv_data_path",
+                "method": "GET",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_kv_data_path",
+                "method": "POST",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "patchv1_kv_data_path",
+                "method": "PATCH",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "getv1_kv_metadata_path",
+                "method": "GET",
+                "path": "/v1/kv/metadata/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_kv_delete_path",
+                "method": "POST",
+                "path": "/v1/kv/delete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
+                "operationId": "postv1_kv_undelete_path",
+                "method": "POST",
+                "path": "/v1/kv/undelete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "aws-secrets-manager"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "provider_operation_not_implemented",
+                "reasonCode": "operation_not_implemented",
+                "nextAction": "do_not_enable_operation"
+              },
+              {
                 "operationId": "getv1_management_secrets_value_search",
                 "method": "GET",
                 "path": "/v1/management/secrets/value-search",
@@ -2979,6 +3428,114 @@
                 "nextAction": "review_policy"
               },
               {
+                "operationId": "getv1_kv_data_path",
+                "method": "GET",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "postv1_kv_data_path",
+                "method": "POST",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "patchv1_kv_data_path",
+                "method": "PATCH",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "getv1_kv_metadata_path",
+                "method": "GET",
+                "path": "/v1/kv/metadata/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "postv1_kv_delete_path",
+                "method": "POST",
+                "path": "/v1/kv/delete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
+                "operationId": "postv1_kv_undelete_path",
+                "method": "POST",
+                "path": "/v1/kv/undelete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "policy_denied",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "review_policy"
+              },
+              {
                 "operationId": "getv1_management_secrets_value_search",
                 "method": "GET",
                 "path": "/v1/management/secrets/value-search",
@@ -3465,6 +4022,114 @@
                 "path": "/v1/resolve",
                 "maturity": "unavailable",
                 "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "getv1_kv_data_path",
+                "method": "GET",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "postv1_kv_data_path",
+                "method": "POST",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "patchv1_kv_data_path",
+                "method": "PATCH",
+                "path": "/v1/kv/data/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "getv1_kv_metadata_path",
+                "method": "GET",
+                "path": "/v1/kv/metadata/{path}",
+                "maturity": "unavailable",
+                "classification": "read",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "postv1_kv_delete_path",
+                "method": "POST",
+                "path": "/v1/kv/delete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
+                "authenticationRequired": true,
+                "policyRequired": true,
+                "auditRequired": true,
+                "scope": "provider-remote",
+                "providerKinds": [
+                  "vault"
+                ],
+                "completionMode": "synchronous",
+                "limitationCode": "audit_unavailable",
+                "reasonCode": "source_operation_blocked",
+                "nextAction": "restore_audit"
+              },
+              {
+                "operationId": "postv1_kv_undelete_path",
+                "method": "POST",
+                "path": "/v1/kv/undelete/{path}",
+                "maturity": "unavailable",
+                "classification": "mutation",
                 "authenticationRequired": true,
                 "policyRequired": true,
                 "auditRequired": true,
@@ -3982,6 +4647,114 @@
               "path": "/v1/resolve",
               "maturity": "unavailable",
               "classification": "read",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "getv1_kv_data_path",
+              "method": "GET",
+              "path": "/v1/kv/data/{path}",
+              "maturity": "unavailable",
+              "classification": "read",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_kv_data_path",
+              "method": "POST",
+              "path": "/v1/kv/data/{path}",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "patchv1_kv_data_path",
+              "method": "PATCH",
+              "path": "/v1/kv/data/{path}",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "getv1_kv_metadata_path",
+              "method": "GET",
+              "path": "/v1/kv/metadata/{path}",
+              "maturity": "unavailable",
+              "classification": "read",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_kv_delete_path",
+              "method": "POST",
+              "path": "/v1/kv/delete/{path}",
+              "maturity": "unavailable",
+              "classification": "mutation",
+              "authenticationRequired": true,
+              "policyRequired": true,
+              "auditRequired": true,
+              "scope": "provider-remote",
+              "providerKinds": [
+                "future-provider"
+              ],
+              "completionMode": "synchronous",
+              "limitationCode": "provider_operation_not_implemented",
+              "reasonCode": "operation_not_implemented",
+              "nextAction": "do_not_enable_operation"
+            },
+            {
+              "operationId": "postv1_kv_undelete_path",
+              "method": "POST",
+              "path": "/v1/kv/undelete/{path}",
+              "maturity": "unavailable",
+              "classification": "mutation",
               "authenticationRequired": true,
               "policyRequired": true,
               "auditRequired": true,

--- a/contract/v1/openapi.json
+++ b/contract/v1/openapi.json
@@ -1251,6 +1251,201 @@
         ],
         "type": "object"
       },
+      "kvDataBody": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/kvVersionMetadata"
+          }
+        },
+        "required": [
+          "data",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "kvDataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/kvDataBody"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "kvListedVersion": {
+        "additionalProperties": true,
+        "properties": {
+          "created_time": {
+            "type": "string"
+          },
+          "deletion_time": {
+            "type": "string"
+          },
+          "destroyed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "created_time",
+          "deletion_time",
+          "destroyed"
+        ],
+        "type": "object"
+      },
+      "kvMetadataBody": {
+        "additionalProperties": true,
+        "properties": {
+          "cas_required": {
+            "type": "boolean"
+          },
+          "created_time": {
+            "type": "string"
+          },
+          "current_version": {
+            "type": "integer"
+          },
+          "custom_metadata": {},
+          "delete_version_after": {
+            "type": "string"
+          },
+          "max_versions": {
+            "type": "integer"
+          },
+          "oldest_version": {
+            "type": "integer"
+          },
+          "updated_time": {
+            "type": "string"
+          },
+          "versions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/kvListedVersion"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "cas_required",
+          "created_time",
+          "current_version",
+          "custom_metadata",
+          "delete_version_after",
+          "max_versions",
+          "oldest_version",
+          "updated_time",
+          "versions"
+        ],
+        "type": "object"
+      },
+      "kvMetadataResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/kvMetadataBody"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "kvNoContentResponse": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "kvVersionMetadata": {
+        "additionalProperties": true,
+        "properties": {
+          "created_time": {
+            "type": "string"
+          },
+          "custom_metadata": {},
+          "deletion_time": {
+            "type": "string"
+          },
+          "destroyed": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created_time",
+          "custom_metadata",
+          "deletion_time",
+          "destroyed",
+          "version"
+        ],
+        "type": "object"
+      },
+      "kvVersionSelectRequest": {
+        "additionalProperties": true,
+        "properties": {
+          "versions": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "versions"
+        ],
+        "type": "object"
+      },
+      "kvWriteEnvelope": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "options": {
+            "$ref": "#/components/schemas/kvWriteOptions"
+          }
+        },
+        "required": [
+          "data",
+          "options"
+        ],
+        "type": "object"
+      },
+      "kvWriteOptions": {
+        "additionalProperties": true,
+        "properties": {
+          "cas": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cas"
+        ],
+        "type": "object"
+      },
+      "kvWriteResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/kvVersionMetadata"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "launchIdentityLease": {
         "additionalProperties": true,
         "properties": {
@@ -5119,6 +5314,544 @@
           "limitationCode": "metadata_only",
           "reasonCode": "implemented_read_only",
           "nextAction": "read_when_authorized"
+        }
+      }
+    },
+    "/v1/kv/data/{path}": {
+      "get": {
+        "operationId": "getv1_kv_data_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvDataResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvDataResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Read OpenBao-compatible KV v2 secret data",
+        "x-capability": {
+          "operationId": "getv1_kv_data_path",
+          "method": "GET",
+          "path": "/v1/kv/data/{path}",
+          "maturity": "validated",
+          "classification": "read",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      },
+      "patch": {
+        "operationId": "patchv1_kv_data_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/kvWriteEnvelope"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvWriteResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvWriteResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Patch OpenBao-compatible KV v2 secret data",
+        "x-capability": {
+          "operationId": "patchv1_kv_data_path",
+          "method": "PATCH",
+          "path": "/v1/kv/data/{path}",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      },
+      "post": {
+        "operationId": "postv1_kv_data_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/kvWriteEnvelope"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvWriteResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvWriteResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Write OpenBao-compatible KV v2 secret data",
+        "x-capability": {
+          "operationId": "postv1_kv_data_path",
+          "method": "POST",
+          "path": "/v1/kv/data/{path}",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      }
+    },
+    "/v1/kv/delete/{path}": {
+      "post": {
+        "operationId": "postv1_kv_delete_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/kvVersionSelectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvNoContentResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvNoContentResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Soft-delete OpenBao-compatible KV v2 versions",
+        "x-capability": {
+          "operationId": "postv1_kv_delete_path",
+          "method": "POST",
+          "path": "/v1/kv/delete/{path}",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      }
+    },
+    "/v1/kv/metadata/{path}": {
+      "get": {
+        "operationId": "getv1_kv_metadata_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvMetadataResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvMetadataResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Read or list OpenBao-compatible KV v2 metadata",
+        "x-capability": {
+          "operationId": "getv1_kv_metadata_path",
+          "method": "GET",
+          "path": "/v1/kv/metadata/{path}",
+          "maturity": "validated",
+          "classification": "read",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
+        }
+      }
+    },
+    "/v1/kv/undelete/{path}": {
+      "post": {
+        "operationId": "postv1_kv_undelete_path",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mount",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/kvVersionSelectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kvNoContentResponse"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/kvNoContentResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Typed failure response"
+          }
+        },
+        "security": [
+          {
+            "localBearerToken": []
+          },
+          {
+            "localHeaderToken": []
+          }
+        ],
+        "summary": "Undelete OpenBao-compatible KV v2 versions",
+        "x-capability": {
+          "operationId": "postv1_kv_undelete_path",
+          "method": "POST",
+          "path": "/v1/kv/undelete/{path}",
+          "maturity": "validated",
+          "classification": "mutation",
+          "authenticationRequired": true,
+          "policyRequired": true,
+          "auditRequired": true,
+          "scope": "mixed",
+          "providerKinds": [
+            "local-encrypted-store",
+            "vault",
+            "openbao"
+          ],
+          "completionMode": "synchronous",
+          "limitationCode": "openbao_kv_v2",
+          "reasonCode": "implemented_and_validated",
+          "nextAction": "invoke_with_required_controls"
         }
       }
     },

--- a/docs/kv-v2.md
+++ b/docs/kv-v2.md
@@ -1,0 +1,96 @@
+# OpenBao-compatible KV v2 facade
+
+Status: executable
+Issues: #164
+
+Secrets Broker is the out-of-the-box encrypted store. Operators can point a
+configured `vault` or `openbao` source at a real OpenBao/Vault cluster instead.
+Service Admin talks only to Broker. Both backends speak the same KV v2 JSON.
+
+```text
+Service Admin / Service Lasso
+        |
+        v
+  @secretsbroker /v1/kv/*
+        |
+        +-- local encrypted store (default, ?source=local)
+        |
+        +-- OpenBao or Vault KV v2 (?source=<sourceId>&mount=secret)
+```
+
+This is not an ACL/policy engine and it does not auto-onboard env vars.
+
+## Routes
+
+All routes require the local API token when configured.
+
+| Method | Path | OpenBao equivalent |
+| --- | --- | --- |
+| GET | `/v1/kv/data/{path}` | GET `/v1/{mount}/data/{path}` |
+| POST | `/v1/kv/data/{path}` | POST `/v1/{mount}/data/{path}` |
+| PATCH | `/v1/kv/data/{path}` | PATCH `/v1/{mount}/data/{path}` |
+| GET | `/v1/kv/metadata/{path}?list=true` | GET `/v1/{mount}/metadata/{path}?list=true` |
+| GET | `/v1/kv/metadata/{path}` | GET `/v1/{mount}/metadata/{path}` |
+| POST | `/v1/kv/delete/{path}` | POST `/v1/{mount}/delete/{path}` |
+| POST | `/v1/kv/undelete/{path}` | POST `/v1/{mount}/undelete/{path}` |
+
+Query parameters:
+
+- `source` defaults to `local`. A configured Vault/OpenBao `sourceId` proxies
+  the request to `{address}/v1/{mount}/...` with `X-Vault-Token`.
+- `mount` defaults to `secret`, or the source `mount` field when set.
+- `version` selects a historic version on GET data.
+- `list=true` lists immediate child keys only.
+
+## JSON shapes
+
+Write:
+
+```json
+{
+  "data": { "username": "demo-user", "password": "value" },
+  "options": { "cas": 1 }
+}
+```
+
+Read:
+
+```json
+{
+  "data": {
+    "data": { "username": "demo-user", "password": "value" },
+    "metadata": {
+      "created_time": "2026-08-18T00:00:00Z",
+      "deletion_time": "",
+      "destroyed": false,
+      "version": 2,
+      "custom_metadata": null
+    }
+  }
+}
+```
+
+List (keys only, never values):
+
+```json
+{ "data": { "keys": ["apps/", "other"] } }
+```
+
+Empty lists and missing/deleted data versions return OpenBao-style
+`{"errors":["..."]}` with HTTP 404. CAS mismatches return HTTP 400.
+
+## Local store mapping
+
+- The KV path is the local secret ref (`apps/db`).
+- A legacy single-string secret reads as `{ "value": "<plaintext>" }`.
+- A write with a single `value` field keeps `/v1/resolve` returning that string.
+- Multi-field writes store the JSON object; resolve returns that JSON string.
+- Soft delete keeps the encrypted payload and sets `deletion_time`. Undelete
+  clears it. Destroy is out of scope for this slice.
+- Version history is capped at 10.
+
+## Remote OpenBao/Vault
+
+The proxy does not follow redirects, requires HTTPS outside loopback, bounds
+response size, and never logs bodies. Broker still authenticates the operator
+token; OpenBao authenticates with the source token/token env.

--- a/docs/vault-openbao-source.md
+++ b/docs/vault-openbao-source.md
@@ -59,14 +59,18 @@ Vault/OpenBao capability/status output follows the shared adapter contract in `d
 - A disabled or incomplete connection remains planned/unsupported. The
   provider-family capability is also still planning metadata and never enables
   apply by itself.
-- General write/update, rotate/reset and policy apply remain unavailable or
-  planned; the executable mutation is limited to verified KV v2 migration.
+- General write/update, rotate/reset and policy apply on the management
+  dry-run/apply routes remain local-store-only or planned.
+- Operator create/read/update/delete of secret *data* uses the OpenBao-compatible
+  KV v2 facade (`/v1/kv/*`). That facade writes the local encrypted store by
+  default and proxies the same JSON to a configured `vault` or `openbao` source
+  when `?source=<sourceId>` is set. See `docs/kv-v2.md`.
 - `value-search` is intentionally not advertised for Vault/OpenBao.
 
 Service Admin must use the connection-scoped operation manifest. Vault/OpenBao
-read/reveal are validated. Migration apply is validated only on an explicitly
-enabled and fully configured connection; all other remote apply operations are
-unavailable or planned.
+read/reveal are validated. KV v2 data/metadata/delete/undelete are validated for
+the local store and for configured Vault/OpenBao sources. Migration apply is
+validated only on an explicitly enabled and fully configured connection.
 
 ## Auth and backend state mapping
 


### PR DESCRIPTION
## Summary
- Adds Broker /v1/kv/* with OpenBao KV v2 JSON for the local encrypted store.
- Proxies the same routes to a configured Vault or OpenBao source (?source=).
- List returns keys only; create/read/update, CAS, soft-delete, and undelete match OpenBao.

Closes #164

## Test plan
- [x] go test ./cmd/secretsbroker -run TestKV
- [ ] Review OpenAPI/contract artefact diff
- [ ] After merge, pin the Broker release on Core develop and recycle the canonical demo

Made with [Cursor](https://cursor.com)