### PR TITLE
fix(windows): converge wrapper owner and protected ACL

### DIFF
--- a/cmd/secretsbroker/key_lifecycle.go
+++ b/cmd/secretsbroker/key_lifecycle.go
@@ -467,10 +467,21 @@ func wrapperStatusWithProvider(path string, ctx wrapperContext, provider keyWrap
 	if !ctx.Supported {
 		return wrapperStatusDetail{Available: false, Supported: false, WrapperKind: ctx.Kind, OS: ctx.OS, State: "degraded", NextAction: "use_portable_key_unlock", FailureReason: ctx.Unsupported}
 	}
-	wrapper, err := readLocalKeyWrapper(path)
-	if errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		return wrapperStatusDetail{Available: false, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "locked", NextAction: "import_portable_key"}
+	} else if err != nil {
+		return wrapperStatusDetail{Available: true, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "degraded", NextAction: "import_portable_key", FailureReason: "wrapper metadata could not be read"}
 	}
+	// Converge owner and DACL state before reading even safe wrapper metadata.
+	// This prevents status inspection from bypassing upgrade repair or exposing
+	// metadata from a path whose private-custody state cannot be proven.
+	if err := provider.SecurePath(filepath.Dir(path), true); err != nil {
+		return wrapperStatusDetail{Available: true, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "degraded", NextAction: "import_portable_key", FailureReason: wrapperFailureReason(errWrapperAccess)}
+	}
+	if err := provider.SecurePath(path, false); err != nil {
+		return wrapperStatusDetail{Available: true, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "degraded", NextAction: "import_portable_key", FailureReason: wrapperFailureReason(errWrapperAccess)}
+	}
+	wrapper, err := readLocalKeyWrapper(path)
 	if err != nil {
 		return wrapperStatusDetail{Available: true, Supported: true, WrapperKind: ctx.Kind, OS: ctx.OS, User: ctx.User, Machine: ctx.Machine, State: "degraded", NextAction: "import_portable_key", FailureReason: "wrapper metadata could not be read"}
 	}
@@ -529,7 +540,11 @@ func wrapMasterKeyWithProvider(path, masterKey string, ctx wrapperContext, now t
 	defer zeroBytes(protected)
 	createdAt := now
 	if _, statErr := os.Stat(path); statErr == nil {
-		if err := provider.ValidatePath(path, false); err != nil {
+		// Existing wrappers can retain an inherited DACL or a different default
+		// owner after an OS/toolchain upgrade. Converge the metadata before
+		// reading the wrapper, then fail closed if the resulting state is not
+		// exactly private.
+		if err := provider.SecurePath(path, false); err != nil {
 			return localKeyWrapper{}, errWrapperAccess
 		}
 		if existing, readErr := readLocalKeyWrapper(path); readErr == nil && !existing.CreatedAt.IsZero() {
@@ -560,10 +575,12 @@ func unwrapMasterKeyWithProvider(path string, ctx wrapperContext, provider keyWr
 	if _, err := os.Stat(path); err != nil {
 		return nil, err
 	}
-	if err := provider.ValidatePath(filepath.Dir(path), true); err != nil {
+	// SecurePath is idempotent and repairs legacy/default ownership and ACL
+	// metadata without reading or rewriting wrapper ciphertext.
+	if err := provider.SecurePath(filepath.Dir(path), true); err != nil {
 		return nil, errWrapperAccess
 	}
-	if err := provider.ValidatePath(path, false); err != nil {
+	if err := provider.SecurePath(path, false); err != nil {
 		return nil, errWrapperAccess
 	}
 	wrapper, err := readLocalKeyWrapper(path)

--- a/cmd/secretsbroker/key_lifecycle_test.go
+++ b/cmd/secretsbroker/key_lifecycle_test.go
@@ -27,6 +27,41 @@ func (testKeyWrapperProvider) Unprotect(value []byte) ([]byte, error) {
 func (testKeyWrapperProvider) SecurePath(string, bool) error   { return nil }
 func (testKeyWrapperProvider) ValidatePath(string, bool) error { return nil }
 
+type orderedKeyWrapperProvider struct {
+	calls        []string
+	secureCalls  int
+	failSecureAt int
+}
+
+func (p *orderedKeyWrapperProvider) Algorithm() string { return testKeyWrapperProvider{}.Algorithm() }
+func (p *orderedKeyWrapperProvider) Protect(value []byte) ([]byte, error) {
+	return testKeyWrapperProvider{}.Protect(value)
+}
+func (p *orderedKeyWrapperProvider) Unprotect(value []byte) ([]byte, error) {
+	p.calls = append(p.calls, "unprotect")
+	return testKeyWrapperProvider{}.Unprotect(value)
+}
+func (p *orderedKeyWrapperProvider) SecurePath(_ string, directory bool) error {
+	p.secureCalls++
+	kind := "file"
+	if directory {
+		kind = "directory"
+	}
+	p.calls = append(p.calls, "secure:"+kind)
+	if p.failSecureAt > 0 && p.secureCalls == p.failSecureAt {
+		return errWrapperAccess
+	}
+	return nil
+}
+func (p *orderedKeyWrapperProvider) ValidatePath(_ string, directory bool) error {
+	kind := "file"
+	if directory {
+		kind = "directory"
+	}
+	p.calls = append(p.calls, "validate:"+kind)
+	return nil
+}
+
 func testWrapperContext() wrapperContext {
 	return wrapperContext{OS: "test", User: "test-user", Machine: "test-machine", Kind: "test-user-scope", Supported: true}
 }
@@ -278,5 +313,42 @@ func TestWrapperStatusReportsRecoveryGuidanceWithoutKeyMaterial(t *testing.T) {
 	unsupported := wrapperStatusResponse(missingPath, wrapperContextFor("plan9"))
 	if unsupported.Outcome != "degraded" || unsupported.Wrapper == nil || unsupported.Wrapper.Supported || unsupported.Wrapper.NextAction != "use_portable_key_unlock" {
 		t.Fatalf("unsupported wrapper status = %#v", unsupported)
+	}
+}
+
+func TestWrapperStatusConvergesSecurityBeforeReadingMetadata(t *testing.T) {
+	key := lifecycleTestKey(44)
+	path := filepath.Join(t.TempDir(), "wrapper.json")
+	ctx := testWrapperContext()
+	if _, err := wrapMasterKeyWithProvider(path, key, ctx, time.Now(), testKeyWrapperProvider{}); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &orderedKeyWrapperProvider{}
+	detail := wrapperStatusWithProvider(path, ctx, provider)
+	if detail.State != "ready" {
+		t.Fatalf("wrapper status = %#v", detail)
+	}
+	if len(provider.calls) < 3 || provider.calls[0] != "secure:directory" || provider.calls[1] != "secure:file" {
+		t.Fatalf("wrapper status call order = %#v", provider.calls)
+	}
+	unprotectIndex := -1
+	for index, call := range provider.calls {
+		if call == "unprotect" {
+			unprotectIndex = index
+			break
+		}
+	}
+	if unprotectIndex < 2 {
+		t.Fatalf("wrapper was unprotected before security convergence: %#v", provider.calls)
+	}
+
+	failing := &orderedKeyWrapperProvider{failSecureAt: 1}
+	degraded := wrapperStatusWithProvider(path, ctx, failing)
+	if degraded.State != "degraded" || degraded.KeyID != "" || degraded.FailureReason != wrapperFailureReason(errWrapperAccess) {
+		t.Fatalf("failed security status = %#v", degraded)
+	}
+	if len(failing.calls) != 1 || failing.calls[0] != "secure:directory" {
+		t.Fatalf("failed security call order = %#v", failing.calls)
 	}
 }

--- a/cmd/secretsbroker/key_wrapper_provider_other_test.go
+++ b/cmd/secretsbroker/key_wrapper_provider_other_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnsupportedKeyWrapperProviderRemainsFailClosed(t *testing.T) {
+	provider := platformKeyWrapperProvider()
+	if _, err := provider.Protect([]byte("portable-key-placeholder")); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("protect error = %v", err)
+	}
+	if _, err := provider.Unprotect([]byte("protected-placeholder")); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("unprotect error = %v", err)
+	}
+	if err := provider.SecurePath("wrapper.json", false); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("secure path error = %v", err)
+	}
+	if err := provider.ValidatePath("wrapper.json", false); !errors.Is(err, errUnsupportedOSWrapper) {
+		t.Fatalf("validate path error = %v", err)
+	}
+}

--- a/cmd/secretsbroker/key_wrapper_provider_windows.go
+++ b/cmd/secretsbroker/key_wrapper_provider_windows.go
@@ -15,7 +15,14 @@ import (
 
 const windowsDPAPIAlgorithm = "windows-dpapi-current-user"
 
+const windowsFileAllAccess = windows.ACCESS_MASK(windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0x1ff)
+
 var windowsDPAPIEntropy = []byte("service-lasso:@secretsbroker:master-key-wrapper:v2")
+
+var (
+	getWindowsNamedSecurityInfo = windows.GetNamedSecurityInfo
+	setWindowsNamedSecurityInfo = windows.SetNamedSecurityInfo
+)
 
 type windowsDPAPIKeyWrapperProvider struct{}
 
@@ -84,12 +91,7 @@ func (windowsDPAPIKeyWrapperProvider) SecurePath(path string, directory bool) er
 	if err != nil {
 		return err
 	}
-	inheritance := ""
-	if directory {
-		inheritance = "OICI"
-	}
-	sddl := fmt.Sprintf("O:%sD:P(A;%s;FA;;;SY)(A;%s;FA;;;%s)", userSID.String(), inheritance, inheritance, userSID.String())
-	sd, err := windows.SecurityDescriptorFromString(sddl)
+	sd, err := windowsPrivateSecurityDescriptor(userSID, directory)
 	if err != nil {
 		return err
 	}
@@ -97,7 +99,29 @@ func (windowsDPAPIKeyWrapperProvider) SecurePath(path string, directory bool) er
 	if err != nil {
 		return err
 	}
-	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil); err != nil {
+	if err := setWindowsNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	); err != nil {
+		return err
+	}
+	// Tighten the DACL first. Besides minimizing the failure state, this gives
+	// the current user WRITE_OWNER before correcting an elevated/default group
+	// owner on existing wrapper paths.
+	if err := setWindowsNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION,
+		userSID,
+		nil,
+		nil,
+		nil,
+	); err != nil {
 		return err
 	}
 	return windowsDPAPIKeyWrapperProvider{}.ValidatePath(path, directory)
@@ -111,11 +135,37 @@ func (windowsDPAPIKeyWrapperProvider) ValidatePath(path string, directory bool) 
 	if err != nil {
 		return err
 	}
-	systemSID, err := windows.StringToSid("S-1-5-18")
+	sd, err := getWindowsNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION)
 	if err != nil {
 		return err
 	}
-	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION)
+	return validateWindowsPrivateSecurityDescriptor(sd, userSID, directory)
+}
+
+func windowsPrivateSecurityDescriptor(userSID *windows.SID, directory bool) (*windows.SECURITY_DESCRIPTOR, error) {
+	if userSID == nil {
+		return nil, errWrapperUnavailable
+	}
+	systemSID, err := windows.StringToSid("S-1-5-18")
+	if err != nil {
+		return nil, err
+	}
+	inheritance := ""
+	if directory {
+		inheritance = "OICI"
+	}
+	aces := []string{fmt.Sprintf("(A;%s;FA;;;SY)", inheritance)}
+	if !userSID.Equals(systemSID) {
+		aces = append(aces, fmt.Sprintf("(A;%s;FA;;;%s)", inheritance, userSID.String()))
+	}
+	return windows.SecurityDescriptorFromString(fmt.Sprintf("O:%sD:P%s", userSID.String(), strings.Join(aces, "")))
+}
+
+func validateWindowsPrivateSecurityDescriptor(sd *windows.SECURITY_DESCRIPTOR, userSID *windows.SID, directory bool) error {
+	if sd == nil || userSID == nil {
+		return errWrapperAccess
+	}
+	systemSID, err := windows.StringToSid("S-1-5-18")
 	if err != nil {
 		return err
 	}
@@ -128,17 +178,31 @@ func (windowsDPAPIKeyWrapperProvider) ValidatePath(path string, directory bool) 
 		return errWrapperAccess
 	}
 	dacl, _, err := sd.DACL()
-	if err != nil || dacl == nil || dacl.AceCount != 2 {
+	expectedACECount := uint16(2)
+	if userSID.Equals(systemSID) {
+		expectedACECount = 1
+	}
+	if err != nil || dacl == nil || dacl.AceCount != expectedACECount {
 		return errWrapperAccess
 	}
 	seen := map[string]bool{}
+	expectedFlags := uint8(0)
+	if directory {
+		expectedFlags = windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE
+	}
 	for index := uint32(0); index < uint32(dacl.AceCount); index++ {
 		var ace *windows.ACCESS_ALLOWED_ACE
 		if err := windows.GetAce(dacl, index, &ace); err != nil || ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
 			return errWrapperAccess
 		}
+		if ace.Mask != windowsFileAllAccess || ace.Header.AceFlags != expectedFlags || ace.Header.AceFlags&windows.INHERITED_ACE != 0 {
+			return errWrapperAccess
+		}
 		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
 		if !sid.Equals(userSID) && !sid.Equals(systemSID) {
+			return errWrapperAccess
+		}
+		if seen[sid.String()] {
 			return errWrapperAccess
 		}
 		seen[sid.String()] = true

--- a/cmd/secretsbroker/key_wrapper_provider_windows_test.go
+++ b/cmd/secretsbroker/key_wrapper_provider_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestWindowsDPAPIWrapperUsesPrivateCurrentUserCustody(t *testing.T) {
@@ -122,6 +125,229 @@ func TestWindowsDPAPIWrapperRejectsBroadACLAndReparseTraversal(t *testing.T) {
 	}
 	if err := provider.ValidatePath(filepath.Join(link, "wrapper.json"), false); !errors.Is(err, errWrapperAccess) {
 		t.Fatalf("reparse traversal validation error = %v", err)
+	}
+}
+
+func TestWindowsDPAPIWrapperConvergesOwnerACLAndIsIdempotent(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "converge")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "wrapper.json")
+	if err := os.WriteFile(path, []byte("ciphertext-only-placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	provider := windowsDPAPIKeyWrapperProvider{}
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := provider.SecurePath(directory, true); err != nil {
+			t.Fatalf("secure directory attempt %d: %v", attempt+1, err)
+		}
+		if err := provider.SecurePath(path, false); err != nil {
+			t.Fatalf("secure wrapper attempt %d: %v", attempt+1, err)
+		}
+	}
+	userSID, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []struct {
+		path      string
+		directory bool
+	}{{directory, true}, {path, false}} {
+		sd, err := windows.GetNamedSecurityInfo(target.path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+		if err != nil {
+			t.Fatal(err)
+		}
+		owner, _, err := sd.Owner()
+		if err != nil || owner == nil || !owner.Equals(userSID) {
+			t.Fatalf("owner did not converge for %s", filepath.Base(target.path))
+		}
+		if err := provider.ValidatePath(target.path, target.directory); err != nil {
+			t.Fatalf("validate %s: %v", filepath.Base(target.path), err)
+		}
+	}
+}
+
+func TestWindowsDPAPIWrapperRequestsWrongOwnerConvergence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapper.json")
+	if err := os.WriteFile(path, []byte("ciphertext-only-placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userSID, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongOwnerSD, err := windows.SecurityDescriptorFromString(fmt.Sprintf("O:SYD:P(A;;FA;;;SY)(A;;FA;;;%s)", userSID.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	convergedSD, err := windows.SecurityDescriptorFromString(fmt.Sprintf("O:%sD:P(A;;FA;;;SY)(A;;FA;;;%s)", userSID.String(), userSID.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldGet, oldSet := getWindowsNamedSecurityInfo, setWindowsNamedSecurityInfo
+	t.Cleanup(func() {
+		getWindowsNamedSecurityInfo = oldGet
+		setWindowsNamedSecurityInfo = oldSet
+	})
+	state := wrongOwnerSD
+	setCalls := 0
+	getWindowsNamedSecurityInfo = func(string, windows.SE_OBJECT_TYPE, windows.SECURITY_INFORMATION) (*windows.SECURITY_DESCRIPTOR, error) {
+		return state, nil
+	}
+	setWindowsNamedSecurityInfo = func(_ string, _ windows.SE_OBJECT_TYPE, information windows.SECURITY_INFORMATION, owner, _ *windows.SID, dacl, _ *windows.ACL) error {
+		setCalls++
+		switch setCalls {
+		case 1:
+			if information != windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION || owner != nil || dacl == nil {
+				t.Fatal("secure path did not request a protected private DACL first")
+			}
+		case 2:
+			if information != windows.OWNER_SECURITY_INFORMATION || owner == nil || !owner.Equals(userSID) || dacl != nil {
+				t.Fatal("secure path did not request current-user ownership after tightening the DACL")
+			}
+			state = convergedSD
+		default:
+			t.Fatalf("unexpected security convergence call %d", setCalls)
+		}
+		return nil
+	}
+	if err := (windowsDPAPIKeyWrapperProvider{}).SecurePath(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if setCalls != 2 {
+		t.Fatalf("security convergence calls = %d, want 2", setCalls)
+	}
+}
+
+func TestWindowsDPAPIWrapperRejectsPartialControlAndRepairsIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapper.json")
+	if err := os.WriteFile(path, []byte("ciphertext-only-placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userSID, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sd, err := windows.SecurityDescriptorFromString(fmt.Sprintf("O:%sD:P(A;;FA;;;SY)(A;;FR;;;%s)", userSID.String(), userSID.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil); err != nil {
+		t.Fatal(err)
+	}
+	provider := windowsDPAPIKeyWrapperProvider{}
+	if err := provider.ValidatePath(path, false); !errors.Is(err, errWrapperAccess) {
+		t.Fatalf("partial-control ACL validation error = %v", err)
+	}
+	if err := provider.SecurePath(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.ValidatePath(path, false); err != nil {
+		t.Fatalf("repaired ACL validation: %v", err)
+	}
+}
+
+func TestWindowsDPAPIWrapperSecurityFailurePreservesCiphertext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapper.json")
+	ciphertext := []byte("ciphertext-only-placeholder")
+	if err := os.WriteFile(path, ciphertext, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSet := setWindowsNamedSecurityInfo
+	t.Cleanup(func() { setWindowsNamedSecurityInfo = oldSet })
+	setWindowsNamedSecurityInfo = func(string, windows.SE_OBJECT_TYPE, windows.SECURITY_INFORMATION, *windows.SID, *windows.SID, *windows.ACL, *windows.ACL) error {
+		return windows.ERROR_ACCESS_DENIED
+	}
+	if err := (windowsDPAPIKeyWrapperProvider{}).SecurePath(path, false); !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		t.Fatalf("security failure = %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, ciphertext) {
+		t.Fatal("security failure changed wrapper ciphertext")
+	}
+}
+
+func TestWindowsDPAPIWrapperOwnerFailureAfterDACLTighteningPreservesCiphertextAndRetryHeals(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapper.json")
+	ciphertext := []byte("ciphertext-only-placeholder")
+	if err := os.WriteFile(path, ciphertext, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldSet := setWindowsNamedSecurityInfo
+	t.Cleanup(func() { setWindowsNamedSecurityInfo = oldSet })
+	setCalls := 0
+	setWindowsNamedSecurityInfo = func(path string, objectType windows.SE_OBJECT_TYPE, information windows.SECURITY_INFORMATION, owner, group *windows.SID, dacl, sacl *windows.ACL) error {
+		setCalls++
+		if setCalls == 2 {
+			if information != windows.OWNER_SECURITY_INFORMATION {
+				t.Fatalf("second security update = %#x, want owner", information)
+			}
+			return windows.ERROR_ACCESS_DENIED
+		}
+		return oldSet(path, objectType, information, owner, group, dacl, sacl)
+	}
+	provider := windowsDPAPIKeyWrapperProvider{}
+	if err := provider.SecurePath(path, false); !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		t.Fatalf("owner convergence failure = %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, ciphertext) {
+		t.Fatal("partial security convergence changed wrapper ciphertext")
+	}
+
+	setWindowsNamedSecurityInfo = oldSet
+	if err := provider.SecurePath(path, false); err != nil {
+		t.Fatalf("security convergence retry: %v", err)
+	}
+	if err := provider.ValidatePath(path, false); err != nil {
+		t.Fatalf("validate after retry: %v", err)
+	}
+}
+
+func TestWindowsDPAPIWrapperDeduplicatesLocalSystemAndRejectsUnsafeACEs(t *testing.T) {
+	systemSID, err := windows.StringToSid("S-1-5-18")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sd, err := windowsPrivateSecurityDescriptor(systemSID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWindowsPrivateSecurityDescriptor(sd, systemSID, false); err != nil {
+		t.Fatalf("LocalSystem descriptor: %v", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		t.Fatalf("LocalSystem ACE count = %v, err = %v", dacl, err)
+	}
+
+	userSID, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsafeDescriptors := []string{
+		fmt.Sprintf("O:%sD:P(A;ID;FA;;;SY)(A;ID;FA;;;%s)", userSID.String(), userSID.String()),
+		fmt.Sprintf("O:%sD:P(A;;FA;;;SY)(A;;FA;;;%s)(A;;FA;;;BU)", userSID.String(), userSID.String()),
+	}
+	for _, sddl := range unsafeDescriptors {
+		unsafeSD, err := windows.SecurityDescriptorFromString(sddl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateWindowsPrivateSecurityDescriptor(unsafeSD, userSID, false); !errors.Is(err, errWrapperAccess) {
+			t.Fatalf("unsafe descriptor validation error = %v", err)
+		}
 	}
 }
 

--- a/docs/master-key-lifecycle.md
+++ b/docs/master-key-lifecycle.md
@@ -89,6 +89,8 @@ secretsbroker key rewrap `
 
 Re-wraps the same portable key for the current OS/user/machine context. Re-wrap is auditable and fail-closed: unsupported wrapper providers, unreadable wrappers, wrong keys, corrupted ciphertext, or store verification failures do not write a new wrapper.
 
+On Windows, wrapper directories and files converge to current-user ownership and a protected DACL containing exactly current-user and LocalSystem full-control entries. Directory entries are inheritable by child files and directories; wrapper-file entries are not. First enrollment, unlock after upgrade, and re-wrap repair safe owner/default-ACL drift before reading wrapper ciphertext. Reparse traversal, ownership changes that the OS refuses, inherited or extra entries, partial-control entries, and post-change validation failures remain fail-closed.
+
 ### OS wrapper status
 
 ```powershell


### PR DESCRIPTION
## Summary
- tighten Windows wrapper DACLs to exactly current-user and LocalSystem full control before converging ownership to the current user
- reject inherited, duplicate, extra, partial-control, and incorrectly inheritable ACEs while preserving reparse-point fail-closed checks
- repair safe owner/DACL drift before wrapper status metadata, unwrap, upgrade, and re-wrap reads
- preserve unsupported non-Windows wrapper behavior

## Local evidence
- focused Windows/status security suite: 13 tests passed
- go test -timeout 12m ./... -count=1: passed (Broker 497.388s)
- go vet ./...: passed
- scripts/test.ps1: passed, including native builds, CLI status, and owned health-process verification
- scripts/package.ps1: passed and produced the Windows package
- scripts/verify.ps1: passed with the SHA256-verified released harness v0.1.1
- git diff --check: passed

## Hosted gates still required
- Windows, Linux, and macOS validate-template jobs must pass and retain verify artifacts
- complete release checksums require all three hosted packages; the local Windows-only stage correctly refused verification when Linux/macOS assets were absent
- the release/tag/checksum workflow runs only after an authorized merge to main

## Residual
The existing by-name reparse check has a time-of-check/time-of-use window. This PR preserves and strengthens the current fail-closed checks; handle-based mutation is a separate, larger hardening change.

Closes #166