### PR TITLE
fix: align released Broker manifest with Core actions

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -17,6 +17,7 @@ try {
   $manifestPaths = @('service.json') + (Get-ChildItem -Path (Join-Path $root 'services') -Recurse -Filter 'service.json' | ForEach-Object {
     $_.FullName.Substring($root.Length + 1)
   })
+  $supportedActionModes = @('built-in', 'command', 'workflow', 'handler')
   foreach ($manifestPath in $manifestPaths) {
     $manifest = Get-Content (Join-Path $root $manifestPath) -Raw | ConvertFrom-Json
     foreach ($legacyField in @('ports', 'urls', 'portmapping')) {
@@ -26,6 +27,12 @@ try {
     }
     if ($manifestPath -in @('service.json', 'services\@nginx\service.json', 'services\@serviceadmin\service.json', 'services\@traefik\service.json', 'services\echo-service\service.json') -and -not $manifest.endpoints) {
       throw "$manifestPath is missing endpoints[]"
+    }
+    foreach ($action in @($manifest.actions.PSObject.Properties)) {
+      $mode = $action.Value.mode
+      if ($mode -and $mode -notin $supportedActionModes) {
+        throw "$manifestPath action $($action.Name) uses unsupported mode $mode"
+      }
     }
   }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,6 +22,20 @@ if [[ "$SERVICE_ID" != "@secretsbroker" ]]; then
   exit 1
 fi
 
+python3 - <<'PY'
+import json
+import pathlib
+
+supported_action_modes = {'built-in', 'command', 'workflow', 'handler'}
+manifest_paths = [pathlib.Path('service.json'), *pathlib.Path('services').glob('**/service.json')]
+for manifest_path in manifest_paths:
+    manifest = json.loads(manifest_path.read_text())
+    for action_name, action in manifest.get('actions', {}).items():
+        mode = action.get('mode')
+        if mode and mode not in supported_action_modes:
+            raise SystemExit(f'{manifest_path} action {action_name} uses unsupported mode {mode}')
+PY
+
 CONTRACT_ID=$(python3 - <<'PY'
 import json, pathlib
 print(json.loads(pathlib.Path('verify/service-harness.json').read_text())['serviceId'])

--- a/service.json
+++ b/service.json
@@ -107,43 +107,6 @@
       }
     }
   },
-  "actions": {
-    "install": {
-      "description": "Acquire or unpack the packaged @secretsbroker runtime artifact.",
-      "mode": "converge-install",
-      "idempotent": true
-    },
-    "config": {
-      "description": "Materialize deployment-local @secretsbroker config and env values.",
-      "mode": "converge-config",
-      "idempotent": true
-    },
-    "update": {
-      "description": "Apply a newer @secretsbroker release artifact and reconcile update-time changes before restart.",
-      "mode": "converge-update",
-      "idempotent": true
-    },
-    "start": {
-      "description": "Start the @secretsbroker daemon.",
-      "mode": "runtime-start",
-      "idempotent": true
-    },
-    "stop": {
-      "description": "Stop the @secretsbroker daemon gracefully.",
-      "mode": "runtime-stop",
-      "idempotent": true
-    },
-    "restart": {
-      "description": "Restart @secretsbroker after config or update changes.",
-      "mode": "runtime-restart",
-      "idempotent": false
-    },
-    "rollback": {
-      "description": "Restore the previously deployed @secretsbroker artifact if an update fails validation.",
-      "mode": "state-rollback",
-      "idempotent": false
-    }
-  },
   "execconfig": {
     "serviceorder": 5,
     "execcwd": ".",


### PR DESCRIPTION
## Summary

- remove the legacy Broker actions override so Core supplies its standard lifecycle behavior
- reject unsupported action modes in both Windows and POSIX manifest validation before packaging
- keep the existing per-platform checksum policy unchanged

## Root cause

Published-package qualification run https://github.com/service-lasso/service-lasso/actions/runs/33141037368 verified the Core release archive and npm consumer on all three operating systems, then failed before lifecycle mutation because the released Broker service.json declares semantic modes such as converge-install. Current Core accepts only built-in, command, workflow, or handler action execution modes.

## Verification

- scripts/test.ps1: pass, including full Go tests, builds, status, and health
- go vet ./...: pass
- bash -n scripts/test.sh: pass
- Windows package build: pass; packaged service.json has no actions override and retains SHA256SUMS.txt on every platform
- published Core 2026.8.28-ae6da19 local isolated acquisition: Admin and Broker installs both pass with expected/actual release-asset SHA-256 equality

The local shell did not expose Go inside Git Bash, so the full POSIX script remains for the PR matrix; its new manifest check is syntax-valid and mirrors the passing PowerShell check.

## Release boundary

This PR does not merge or publish. Issue #162 stays open until a corrected five-asset Broker release and the final three-OS published-package qualification are green.

Closes #162.
Refs service-lasso/service-lasso#1152.
